### PR TITLE
feat: wallet persistence, mobile nav, analytics page, pool access control tests

### DIFF
--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -1227,7 +1227,7 @@ mod test {
     use super::*;
     use soroban_sdk::{
         testutils::{Address as _, Ledger},
-        Env,
+        BytesN, Env,
     };
 
     #[contract]
@@ -1924,5 +1924,373 @@ mod test {
 
         // Trying to seize after repayment must panic
         client.seize_collateral(&admin, &1u64);
+    }
+
+    // ---- Issue #105: Comprehensive Access Control Tests ----
+
+    // --- Admin-gated function guards ---
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_pause_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        client.pause(&attacker);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_unpause_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _usdc_id, _share_token) = setup(&env);
+        client.pause(&admin);
+        let attacker = Address::generate(&env);
+        client.unpause(&attacker);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_add_token_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        let ta = Address::generate(&env);
+        let new_token = env.register_stellar_asset_contract_v2(ta).address();
+        let new_share = env.register(DummyShare, ());
+        client.add_token(&attacker, &new_token, &new_share);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_remove_token_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _usdc_id, _share_token) = setup(&env);
+        let ta2 = Address::generate(&env);
+        let new_token = env.register_stellar_asset_contract_v2(ta2).address();
+        let new_share = env.register(DummyShare, ());
+        client.add_token(&admin, &new_token, &new_share);
+        let attacker = Address::generate(&env);
+        client.remove_token(&attacker, &new_token);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_set_yield_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        client.set_yield(&attacker, &500u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_set_factoring_fee_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        client.set_factoring_fee(&attacker, &100u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_set_compound_interest_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        client.set_compound_interest(&attacker, &true);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_set_collateral_config_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        client.set_collateral_config(&attacker, &1_000i128, &2_000u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_set_exchange_rate_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        client.set_exchange_rate(&attacker, &usdc_id, &10_000u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_set_kyc_required_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        client.set_kyc_required(&attacker, &true);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_set_investor_kyc_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        let investor = Address::generate(&env);
+        client.set_investor_kyc(&attacker, &investor, &true);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_propose_upgrade_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _usdc_id, _share_token) = setup(&env);
+        let attacker = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[0u8; 32]);
+        client.propose_upgrade(&attacker, &hash);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_fund_multiple_invoices_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+        mint(&env, &usdc_id, &investor, 2_000);
+        client.deposit(&investor, &usdc_id, &2_000);
+
+        let mut requests = Vec::new(&env);
+        requests.push_back(FundingRequest {
+            invoice_id: 1u64,
+            principal: 500,
+            sme,
+            due_date: env.ledger().timestamp() + 10_000,
+            token: usdc_id,
+        });
+        let attacker = Address::generate(&env);
+        client.fund_multiple_invoices(&attacker, &requests);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_seize_collateral_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+
+        client.set_collateral_config(&admin, &1_000i128, &2_000u32);
+        let principal: i128 = 5_000;
+        let required = client.required_collateral_for(&principal);
+        mint(&env, &usdc_id, &investor, 10_000);
+        mint(&env, &usdc_id, &sme, required);
+        client.deposit(&investor, &usdc_id, &10_000);
+        client.deposit_collateral(&1u64, &sme, &usdc_id, &required);
+        client.fund_invoice(
+            &admin,
+            &1u64,
+            &principal,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+        let attacker = Address::generate(&env);
+        client.seize_collateral(&attacker, &1u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_cleanup_funded_invoice_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+
+        mint(&env, &usdc_id, &investor, 1_000);
+        mint(&env, &usdc_id, &sme, 2_000);
+        client.deposit(&investor, &usdc_id, &1_000);
+        client.fund_invoice(
+            &admin,
+            &1u64,
+            &1_000i128,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+        client.repay_invoice(&1u64, &sme);
+        let attacker = Address::generate(&env);
+        client.cleanup_funded_invoice(&attacker, &1u64);
+    }
+
+    // --- Pause mechanism tests ---
+
+    #[test]
+    #[should_panic(expected = "contract is paused")]
+    fn test_fund_invoice_when_paused_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+
+        mint(&env, &usdc_id, &investor, 2_000);
+        client.deposit(&investor, &usdc_id, &2_000);
+        client.pause(&admin);
+        client.fund_invoice(
+            &admin,
+            &1u64,
+            &1_000i128,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "contract is paused")]
+    fn test_repay_invoice_when_paused_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+
+        mint(&env, &usdc_id, &investor, 1_000);
+        mint(&env, &usdc_id, &sme, 2_000);
+        client.deposit(&investor, &usdc_id, &1_000);
+        client.fund_invoice(
+            &admin,
+            &1u64,
+            &1_000i128,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+        client.pause(&admin);
+        client.repay_invoice(&1u64, &sme);
+    }
+
+    #[test]
+    #[should_panic(expected = "contract is paused")]
+    fn test_deposit_collateral_when_paused_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let sme = Address::generate(&env);
+
+        client.set_collateral_config(&admin, &1_000i128, &2_000u32);
+        mint(&env, &usdc_id, &sme, 1_000);
+        client.pause(&admin);
+        client.deposit_collateral(&1u64, &sme, &usdc_id, &1_000);
+    }
+
+    #[test]
+    fn test_pause_and_unpause_restores_operations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+
+        mint(&env, &usdc_id, &investor, 2_000);
+        mint(&env, &usdc_id, &sme, 2_000);
+        client.deposit(&investor, &usdc_id, &2_000);
+
+        client.pause(&admin);
+        assert!(client.is_paused());
+
+        client.unpause(&admin);
+        assert!(!client.is_paused());
+
+        client.fund_invoice(
+            &admin,
+            &1u64,
+            &1_000i128,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+        client.repay_invoice(&1u64, &sme);
+        let fi = client.get_funded_invoice(&1u64).unwrap();
+        assert!(fi.repaid);
+    }
+
+    // --- KYC gate tests ---
+
+    #[test]
+    #[should_panic(expected = "investor not KYC approved")]
+    fn test_deposit_when_kyc_required_unapproved_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+
+        client.set_kyc_required(&admin, &true);
+        mint(&env, &usdc_id, &investor, 1_000);
+        client.deposit(&investor, &usdc_id, &1_000);
+    }
+
+    #[test]
+    fn test_deposit_when_kyc_required_and_approved_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+
+        client.set_kyc_required(&admin, &true);
+        client.set_investor_kyc(&admin, &investor, &true);
+        mint(&env, &usdc_id, &investor, 1_000);
+        client.deposit(&investor, &usdc_id, &1_000);
+
+        let tt = client.get_token_totals(&usdc_id);
+        assert_eq!(tt.pool_value, 1_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "investor not KYC approved")]
+    fn test_kyc_revocation_blocks_deposit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+
+        client.set_kyc_required(&admin, &true);
+        client.set_investor_kyc(&admin, &investor, &true);
+        mint(&env, &usdc_id, &investor, 2_000);
+        client.deposit(&investor, &usdc_id, &1_000);
+
+        // Revoke KYC — subsequent deposit must be blocked
+        client.set_investor_kyc(&admin, &investor, &false);
+        client.deposit(&investor, &usdc_id, &1_000);
+    }
+
+    #[test]
+    fn test_kyc_not_required_allows_any_investor() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+
+        // KYC disabled by default — any investor can deposit
+        assert!(!client.kyc_required());
+        mint(&env, &usdc_id, &investor, 500);
+        client.deposit(&investor, &usdc_id, &500);
+
+        let tt = client.get_token_totals(&usdc_id);
+        assert_eq!(tt.pool_value, 500);
     }
 }

--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getPoolConfig, getAcceptedTokens, getPoolTokenTotals } from '@/lib/contracts';
+import { formatUSDC, stablecoinLabel } from '@/lib/stellar';
+import type { PoolConfig, PoolTokenTotals } from '@/lib/types';
+
+const POOL_CONFIGURED = Boolean(process.env.NEXT_PUBLIC_POOL_CONTRACT_ID);
+
+interface TokenData {
+  token: string;
+  totals: PoolTokenTotals;
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  highlight,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div className="p-5 bg-brand-card border border-brand-border rounded-2xl">
+      <p className="text-xs text-brand-muted mb-1">{label}</p>
+      <p className={`text-2xl font-bold truncate ${highlight ? 'text-brand-gold' : 'text-white'}`}>
+        {value}
+      </p>
+      {sub && <p className="text-xs text-brand-muted mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+function UtilizationBar({ deployed, total }: { deployed: bigint; total: bigint }) {
+  const pct = total > 0n ? Number((deployed * 100n) / total) : 0;
+  const barColor =
+    pct > 90 ? 'bg-red-500' : pct > 70 ? 'bg-yellow-400' : 'bg-brand-gold';
+  const textColor = pct > 90 ? 'text-red-400' : pct > 70 ? 'text-yellow-400' : 'text-white';
+  return (
+    <div className="space-y-1.5">
+      <div className="flex justify-between text-xs text-brand-muted">
+        <span>Utilization</span>
+        <span className={textColor}>{pct.toFixed(1)}%</span>
+      </div>
+      <div className="h-2.5 bg-brand-dark rounded-full overflow-hidden border border-brand-border">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+          style={{ width: `${Math.min(pct, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function AnalyticsPage() {
+  const [config, setConfig] = useState<PoolConfig | null>(null);
+  const [tokens, setTokens] = useState<TokenData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!POOL_CONFIGURED) {
+      setLoading(false);
+      return;
+    }
+    load();
+  }, []);
+
+  async function load() {
+    try {
+      const [cfg, acceptedTokens] = await Promise.all([getPoolConfig(), getAcceptedTokens()]);
+      setConfig(cfg);
+      const tokenData = await Promise.all(
+        acceptedTokens.map(async (token) => ({
+          token,
+          totals: await getPoolTokenTotals(token),
+        })),
+      );
+      setTokens(tokenData);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load analytics data.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Aggregate across all tokens (assumes 1:1 USD peg for stablecoins)
+  const agg = tokens.reduce(
+    (acc, { totals }) => ({
+      poolValue: acc.poolValue + totals.totalDeposited,
+      deployed: acc.deployed + totals.totalDeployed,
+      paidOut: acc.paidOut + totals.totalPaidOut,
+      feeRevenue: acc.feeRevenue + totals.totalFeeRevenue,
+    }),
+    { poolValue: 0n, deployed: 0n, paidOut: 0n, feeRevenue: 0n },
+  );
+
+  const available = agg.poolValue - agg.deployed;
+  const apy = config ? (config.yieldBps / 100).toFixed(2) : '–';
+  const factoringFee = config ? (config.factoringFeeBps / 100).toFixed(2) : '–';
+
+  return (
+    <div className="min-h-screen pt-24 pb-16 px-6">
+      <div className="max-w-5xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-1">Pool Analytics</h1>
+          <p className="text-brand-muted">
+            Real-time performance metrics for the Astera liquidity pool.
+          </p>
+        </div>
+
+        {!POOL_CONFIGURED && (
+          <div className="p-6 bg-brand-card border border-brand-border rounded-2xl text-brand-muted text-sm">
+            Pool contracts are not yet deployed. Configure{' '}
+            <code className="text-brand-gold text-xs">NEXT_PUBLIC_POOL_CONTRACT_ID</code> to see
+            live data.
+          </div>
+        )}
+
+        {POOL_CONFIGURED && loading && (
+          <div className="space-y-6">
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-24 bg-brand-card border border-brand-border rounded-2xl animate-pulse"
+                />
+              ))}
+            </div>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div className="h-56 bg-brand-card border border-brand-border rounded-2xl animate-pulse" />
+              <div className="h-56 bg-brand-card border border-brand-border rounded-2xl animate-pulse" />
+            </div>
+          </div>
+        )}
+
+        {POOL_CONFIGURED && error && (
+          <div className="p-4 bg-red-900/20 border border-red-800/50 rounded-2xl text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        {POOL_CONFIGURED && !loading && !error && (
+          <div className="space-y-6">
+            {/* Key metrics */}
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+              <StatCard
+                label="Total Pool Value"
+                value={formatUSDC(agg.poolValue)}
+                sub="Net asset value"
+                highlight
+              />
+              <StatCard
+                label="Deployed Capital"
+                value={formatUSDC(agg.deployed)}
+                sub="Funding active invoices"
+              />
+              <StatCard
+                label="Available Liquidity"
+                value={formatUSDC(available)}
+                sub="Ready to deploy"
+              />
+              <StatCard
+                label="All-time Repaid"
+                value={formatUSDC(agg.paidOut)}
+                sub="Cumulative repayments"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {/* Yield configuration */}
+              <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
+                <h2 className="text-lg font-semibold mb-4">Yield &amp; Fee Configuration</h2>
+                <div className="space-y-3">
+                  {[
+                    { label: 'Target APY', value: `${apy}%`, highlight: true },
+                    { label: 'Factoring Fee', value: `${factoringFee}%` },
+                    {
+                      label: 'Interest Mode',
+                      value: config?.compoundInterest ? 'Compound' : 'Simple',
+                    },
+                    {
+                      label: 'All-time Fee Revenue',
+                      value: formatUSDC(agg.feeRevenue),
+                      highlight: true,
+                    },
+                  ].map((r) => (
+                    <div key={r.label} className="flex justify-between items-center text-sm">
+                      <span className="text-brand-muted">{r.label}</span>
+                      <span
+                        className={`font-semibold ${r.highlight ? 'text-brand-gold' : 'text-white'}`}
+                      >
+                        {r.value}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Capital allocation per token */}
+              <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
+                <h2 className="text-lg font-semibold mb-4">Capital Allocation</h2>
+                {tokens.length === 0 ? (
+                  <p className="text-brand-muted text-sm">No tokens configured.</p>
+                ) : (
+                  <div className="space-y-6">
+                    {tokens.map(({ token, totals }) => {
+                      const avail = totals.totalDeposited - totals.totalDeployed;
+                      return (
+                        <div key={token} className="space-y-3">
+                          <p className="text-sm font-medium">{stablecoinLabel(token)}</p>
+                          <UtilizationBar
+                            deployed={totals.totalDeployed}
+                            total={totals.totalDeposited}
+                          />
+                          <div className="grid grid-cols-3 gap-2 text-xs">
+                            <div className="text-center p-2 bg-brand-dark rounded-lg">
+                              <p className="text-brand-muted mb-0.5">Pool NAV</p>
+                              <p className="text-white font-medium">
+                                {formatUSDC(totals.totalDeposited)}
+                              </p>
+                            </div>
+                            <div className="text-center p-2 bg-brand-dark rounded-lg">
+                              <p className="text-brand-muted mb-0.5">Deployed</p>
+                              <p className="text-brand-gold font-medium">
+                                {formatUSDC(totals.totalDeployed)}
+                              </p>
+                            </div>
+                            <div className="text-center p-2 bg-brand-dark rounded-lg">
+                              <p className="text-brand-muted mb-0.5">Available</p>
+                              <p className="text-white font-medium">{formatUSDC(avail)}</p>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Multi-token breakdown table */}
+            {tokens.length > 1 && (
+              <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
+                <h2 className="text-lg font-semibold mb-4">Token Breakdown</h2>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-brand-muted border-b border-brand-border">
+                        <th className="text-left py-2 pr-4 font-medium">Token</th>
+                        <th className="text-right py-2 px-2 font-medium">Pool Value</th>
+                        <th className="text-right py-2 px-2 font-medium">Deployed</th>
+                        <th className="text-right py-2 px-2 font-medium">Available</th>
+                        <th className="text-right py-2 px-2 font-medium">Total Repaid</th>
+                        <th className="text-right py-2 pl-2 font-medium">Fee Revenue</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {tokens.map(({ token, totals }) => (
+                        <tr
+                          key={token}
+                          className="border-b border-brand-border/50 last:border-0 hover:bg-brand-dark/40 transition-colors"
+                        >
+                          <td className="py-3 pr-4 font-medium">{stablecoinLabel(token)}</td>
+                          <td className="py-3 px-2 text-right text-brand-gold font-medium">
+                            {formatUSDC(totals.totalDeposited)}
+                          </td>
+                          <td className="py-3 px-2 text-right">
+                            {formatUSDC(totals.totalDeployed)}
+                          </td>
+                          <td className="py-3 px-2 text-right">
+                            {formatUSDC(totals.totalDeposited - totals.totalDeployed)}
+                          </td>
+                          <td className="py-3 px-2 text-right">
+                            {formatUSDC(totals.totalPaidOut)}
+                          </td>
+                          <td className="py-3 pl-2 text-right">
+                            {formatUSDC(totals.totalFeeRevenue)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {/* Default rate notice */}
+            <div className="p-4 bg-brand-dark border border-brand-border rounded-2xl text-xs text-brand-muted">
+              <p>
+                Historical yield rates and default rate tracking require an off-chain indexer. The
+                metrics above reflect the current on-chain state. Pool NAV grows as invoices are
+                repaid with interest.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <Link
+                href="/invest"
+                className="px-5 py-2.5 bg-brand-gold text-brand-dark font-semibold rounded-xl hover:bg-brand-amber transition-colors text-sm"
+              >
+                Invest Now
+              </Link>
+              <Link
+                href="/portfolio"
+                className="px-5 py-2.5 border border-brand-border text-white rounded-xl hover:border-brand-gold/50 transition-colors text-sm"
+              >
+                View Portfolio
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -10,6 +10,7 @@ import NotificationBell from './NotificationBell';
 const links = [
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/invest', label: 'Invest' },
+  { href: '/analytics', label: 'Analytics' },
   { href: '/portfolio', label: 'Portfolio' },
   { href: '/invoice/new', label: 'New Invoice' },
 ];
@@ -35,6 +36,15 @@ export default function Navbar() {
     };
   }, [drawerOpen]);
 
+  // Close drawer on Escape key
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && drawerOpen) setDrawerOpen(false);
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [drawerOpen]);
+
   return (
     <>
       <header className="fixed top-0 left-0 right-0 z-50 border-b border-brand-border bg-brand-dark/80 backdrop-blur-md">
@@ -43,7 +53,7 @@ export default function Navbar() {
             <span className="gradient-text">Astera</span>
           </Link>
 
-          {/* Desktop nav — unchanged */}
+          {/* Desktop nav */}
           <nav className="hidden md:flex items-center gap-1">
             {links.map((l) => (
               <Link
@@ -74,7 +84,8 @@ export default function Navbar() {
               onClick={() => setDrawerOpen(true)}
               aria-label="Open menu"
               aria-expanded={drawerOpen}
-              className="p-2 rounded-lg text-brand-muted hover:text-white hover:bg-brand-card transition-colors"
+              aria-controls="mobile-nav"
+              className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg text-brand-muted hover:text-white hover:bg-brand-card transition-colors"
             >
               <svg
                 width="20"
@@ -111,6 +122,7 @@ export default function Navbar() {
         Both the backdrop and drawer are hidden on md+ so desktop is unaffected.
       */}
       <aside
+        id="mobile-nav"
         role="dialog"
         aria-label="Navigation menu"
         aria-modal="true"
@@ -124,7 +136,7 @@ export default function Navbar() {
           <button
             onClick={() => setDrawerOpen(false)}
             aria-label="Close menu"
-            className="p-2 rounded-lg text-brand-muted hover:text-white hover:bg-brand-card transition-colors"
+            className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg text-brand-muted hover:text-white hover:bg-brand-card transition-colors"
           >
             <svg
               width="18"
@@ -147,7 +159,7 @@ export default function Navbar() {
             <Link
               key={l.href}
               href={l.href}
-              className={`px-4 py-3 rounded-xl text-sm font-medium transition-colors ${
+              className={`px-4 py-3 rounded-xl text-sm font-medium transition-colors min-h-[44px] flex items-center ${
                 path === l.href
                   ? 'bg-brand-gold/10 text-brand-gold'
                   : 'text-brand-muted hover:text-white hover:bg-brand-card'

--- a/frontend/components/WalletConnect.tsx
+++ b/frontend/components/WalletConnect.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { useStore } from '@/lib/store';
+import { useEffect, useState } from 'react';
+import { useStore, getStoredWalletAddress } from '@/lib/store';
 import { truncateAddress } from '@/lib/stellar';
 import LoadingSpinner from '@/components/LoadingSpinner';
 
@@ -23,6 +23,31 @@ export default function WalletConnect() {
   const [retryCount, setRetryCount] = useState(0);
 
   const loading = step !== 'idle';
+
+  // Auto-reconnect on mount if a wallet address was previously stored
+  useEffect(() => {
+    const stored = getStoredWalletAddress();
+    if (!stored || wallet.connected) return;
+
+    void (async () => {
+      try {
+        const freighter = await import('@stellar/freighter-api');
+        const { isConnected } = await freighter.isConnected();
+        if (!isConnected) return;
+
+        const { isAllowed } = await freighter.isAllowed();
+        if (!isAllowed) return;
+
+        const { address, error: addrError } = await freighter.getAddress();
+        if (addrError || !address) return;
+
+        setWallet({ address, connected: true, network: 'testnet' });
+      } catch {
+        // Silent failure — user can reconnect manually
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function connect(attempt = 0) {
     setStep('detecting');

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -1,6 +1,13 @@
 import { create } from 'zustand';
 import type { WalletState, PoolConfig, InvestorPosition } from './types';
 
+const WALLET_KEY = 'astera_wallet_address';
+
+export function getStoredWalletAddress(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(WALLET_KEY);
+}
+
 interface AsteraStore {
   wallet: WalletState;
   poolConfig: PoolConfig | null;
@@ -17,9 +24,22 @@ export const useStore = create<AsteraStore>((set) => ({
   poolConfig: null,
   position: null,
 
-  setWallet: (wallet) => set({ wallet }),
+  setWallet: (wallet) => {
+    if (typeof window !== 'undefined') {
+      if (wallet.connected && wallet.address) {
+        localStorage.setItem(WALLET_KEY, wallet.address);
+      } else {
+        localStorage.removeItem(WALLET_KEY);
+      }
+    }
+    set({ wallet });
+  },
   setPoolConfig: (poolConfig) => set({ poolConfig }),
   setPosition: (position) => set({ position }),
-  disconnect: () =>
-    set({ wallet: { address: null, connected: false, network: 'testnet' }, position: null }),
+  disconnect: () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(WALLET_KEY);
+    }
+    set({ wallet: { address: null, connected: false, network: 'testnet' }, position: null });
+  },
 }));


### PR DESCRIPTION
## Summary

- **#53 – Wallet Connection Persistence**: Wallet address is saved to `localStorage` on connect and cleared on disconnect. On page load, `WalletConnect` silently attempts to re-authorise via Freighter if a stored address is found — no prompt shown during auto-reconnect; errors are swallowed so the user can reconnect manually.

- **#51 – Mobile-Responsive Navigation**: Fixed hamburger and close-button touch targets to the WCAG 44×44 px minimum (`min-w-[44px] min-h-[44px]` + flex centering). Added Escape key handler to close the mobile drawer. Added `aria-controls` on the hamburger. All existing drawer behaviour (backdrop click, route-change close, scroll lock) preserved. Added Analytics link to nav.

- **#48 – Investor Pool Analytics Dashboard**: New `/analytics` page with live on-chain data — pool NAV, deployed capital, available liquidity, all-time repayments, yield & fee configuration, per-token utilization bars (colour-coded by utilization %), and a multi-token breakdown table. No external chart library needed. Graceful loading skeletons and error states included.

- **#105 – Pool Contract Access Control Tests**: Added 23 tests to the pool contract's `#[cfg(test)]` module:
  - Every admin-gated function (`pause`, `unpause`, `add_token`, `remove_token`, `fund_invoice`, `fund_multiple_invoices`, `set_yield`, `set_factoring_fee`, `set_compound_interest`, `set_collateral_config`, `set_exchange_rate`, `set_kyc_required`, `set_investor_kyc`, `propose_upgrade`, `seize_collateral`, `cleanup_funded_invoice`) panics with `"unauthorized"` when called by a non-admin address.
  - Pause-mechanism guards: `fund_invoice`, `repay_invoice`, and `deposit_collateral` panic with `"contract is paused"` while the pool is paused; `test_pause_and_unpause_restores_operations` verifies operations resume after unpause.
  - KYC gate: unapproved investor blocked, approved investor passes, revoked investor blocked. All 53 unit tests pass.

Closes #53
Closes #51
Closes #48 
Closes #105