### PR TITLE
feat: yield distribution, role-based onboarding, health endpoint, error code namespaces

### DIFF
--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -43,7 +43,12 @@ pub struct PoolTokenTotals {
     pub total_deployed: i128,
     pub total_paid_out: i128,
     pub total_fee_revenue: i128,
+    /// Cumulative interest earned per share unit, scaled by REWARD_PRECISION.
+    pub reward_per_share: i128,
 }
+
+/// Scaling factor for reward_per_share to maintain precision with integer arithmetic.
+const REWARD_PRECISION: i128 = 1_000_000_000_000;
 
 #[contracttype]
 #[derive(Clone)]
@@ -146,6 +151,8 @@ pub enum DataKey {
     CollateralDeposit(u64),
 
     ReentrancyGuard,
+    /// Stores each investor's reward_per_share snapshot at last claim: (investor, token) -> i128
+    InvestorRewardSnapshot(Address, Address),
 }
 
 const EVT: Symbol = symbol_short!("POOL");
@@ -617,6 +624,68 @@ impl FundingPool {
             .publish((EVT, symbol_short!("withdraw")), (investor, amount, shares));
     }
 
+    /// Claim accrued yield for `investor` on `token`.
+    ///
+    /// Uses a reward-per-share accumulator pattern: each fully-repaid invoice
+    /// increments `reward_per_share`; investors claim the delta since their last
+    /// snapshot proportional to their share balance.
+    pub fn claim_yield(env: Env, investor: Address, token: Address) {
+        investor.require_auth();
+        bump_instance(&env);
+        Self::require_not_paused(&env);
+
+        let token_totals_key = DataKey::TokenTotals(token.clone());
+        let tt: PoolTokenTotals = env
+            .storage()
+            .instance()
+            .get(&token_totals_key)
+            .unwrap_or_default();
+
+        let snapshot_key = DataKey::InvestorRewardSnapshot(investor.clone(), token.clone());
+        let last_rps: i128 = env
+            .storage()
+            .persistent()
+            .get(&snapshot_key)
+            .unwrap_or(0);
+
+        let share_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::ShareToken(token.clone()))
+            .unwrap();
+
+        let investor_shares: i128 = env.invoke_contract(
+            &share_token,
+            &Symbol::new(&env, "balance"),
+            {
+                let mut args = Vec::new(&env);
+                args.push_back(investor.clone().into_val(&env));
+                args
+            },
+        );
+
+        let claimable = if investor_shares > 0 && tt.reward_per_share > last_rps {
+            ((tt.reward_per_share - last_rps) * investor_shares) / REWARD_PRECISION
+        } else {
+            0
+        };
+
+        // Update snapshot before transfer (checks-effects-interactions).
+        env.storage()
+            .persistent()
+            .set(&snapshot_key, &tt.reward_per_share);
+
+        if claimable > 0 {
+            let token_client = token::Client::new(&env, &token);
+            token_client.transfer(&env.current_contract_address(), &investor, &claimable);
+        }
+
+        env.events().publish(
+            (EVT, symbol_short!("yld_claim")),
+            (investor, token, claimable),
+        );
+    }
+
     pub fn fund_invoice(
         env: Env,
         admin: Address,
@@ -776,6 +845,21 @@ impl FundingPool {
             tt.total_fee_revenue += record.factoring_fee;
             tt.total_paid_out += total_due;
             stats.active_funded_invoices = stats.active_funded_invoices.saturating_sub(1);
+
+            // Distribute interest proportionally to share holders via reward_per_share accumulator.
+            let share_token: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::ShareToken(record.token.clone()))
+                .unwrap();
+            let total_shares: i128 = env.invoke_contract(
+                &share_token,
+                &Symbol::new(&env, "total_supply"),
+                Vec::new(&env),
+            );
+            if total_shares > 0 {
+                tt.reward_per_share += (total_interest as i128 * REWARD_PRECISION) / total_shares;
+            }
         }
 
         // Write all state BEFORE external call

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1875,47 +1875,61 @@ None — read-only operation.
 
 ## Error Reference
 
-This section consolidates every error variant that can be returned by any public contract method. Errors are grouped by contract.
+This section consolidates every error that can be returned by any public contract method.
+Errors are grouped by contract with assigned numeric code ranges for stable frontend mapping.
 
-### Invoice Contract Errors
+### Error Code Namespace
 
-| Error Message | Meaning | Affected Methods |
-|------|---------|---------|
-| `"already initialized"` | Contract has been initialized before. Each contract can only be initialized once. | `initialize` |
-| `"not initialized"` | Contract has not been initialized yet. All methods (except `initialize`) require the contract to be initialized first. | `mark_funded`, `mark_paid`, `mark_defaulted`, `get_invoice`, `get_metadata`, `set_pool` |
-| `"amount must be positive"` | Amount parameter is <= 0. Invoices must have a positive face value. | `create_invoice` |
-| `"due date must be in the future"` | Due date is not strictly in the future. Due date must be after the current ledger timestamp. | `create_invoice` |
-| `"invoice not found"` | Invoice ID does not exist in the contract state. | `get_invoice`, `mark_funded`, `mark_paid`, `mark_defaulted` |
-| `"unauthorized"` | Caller is not authorized to perform the action. For `mark_paid`: caller must be owner, pool, or admin. For `set_pool`: caller must be the admin. | `mark_paid`, `set_pool` |
-| `"unauthorized pool"` | The pool address is not the currently authorized pool. Usually indicates the pool contract has been replaced. | `mark_funded`, `mark_defaulted` |
-| `"invoice is not pending"` | Invoice is not in `Pending` state. `mark_funded` requires the invoice to be `Pending`. | `mark_funded` |
-| `"invoice is not funded"` | Invoice is not in `Funded` state. `mark_paid` requires the invoice to be `Funded`. | `mark_paid` |
+Each contract owns a distinct numeric range so codes never collide across contracts:
 
-### Pool Contract Errors
+| Range | Contract |
+|---|---|
+| `1xx` (100–199) | Invoice contract |
+| `2xx` (200–299) | Pool contract |
+| `3xx` (300–399) | Credit Score contract |
+| `4xx` (400–499) | Share Token contract |
 
-| Error Message | Meaning | Affected Methods |
-|------|---------|---------|
-| `"already initialized"` | Contract has been initialized before. Each contract can only be initialized once. | `initialize` |
-| `"not initialized"` | Contract has not been initialized yet. All methods (except `initialize`) require initialization first. | `add_token`, `remove_token`, `deposit`, `init_co_funding`, `commit_to_invoice`, `repay_invoice`, `withdraw`, `set_yield`, `get_config`, `accepted_tokens`, `get_token_totals`, `available_liquidity`, `estimate_repayment` |
-| `"amount must be positive"` | Amount parameter is <= 0. Deposits, commitments, and withdrawals require positive amounts. | `deposit`, `commit_to_invoice`, `withdraw` |
-| `"unauthorized"` | Caller is not authorized. For admin-only methods: caller must match the stored admin address. | `add_token`, `remove_token`, `init_co_funding`, `set_yield` |
-| `"token not accepted"` | Token is not on the whitelist of accepted tokens. | `deposit`, `init_co_funding` |
-| `"token already accepted"` | Token is already on the whitelist. Cannot add a duplicate. | `add_token` |
-| `"token not in whitelist"` | Token is not on the whitelist. Cannot remove a token that was never added. | `remove_token` |
-| `"token has non-zero pool balances"` | Token has nonzero `total_deposited`, `total_deployed`, or `total_paid_out`. Cannot remove a token with active balances. | `remove_token` |
-| `"principal must be positive"` | Principal is <= 0. Invoice funding targets must be positive. | `init_co_funding` |
-| `"invoice already registered for funding"` | Invoice ID was already opened for co-funding. Cannot register the same invoice twice. | `init_co_funding` |
-| `"invoice not registered for co-funding"` | Invoice ID is not registered for co-funding. Often indicates the invoice does not exist in the pool's records. | `commit_to_invoice` |
-| `"invoice already fully funded"` | Invoice is already fully funded (`funded_at != 0`). Cannot commit to a funded invoice. | `commit_to_invoice` |
-| `"invoice already repaid"` | Invoice has been repaid (`repaid == true`). Cannot commit to a repaid invoice or repay twice. | `commit_to_invoice`, `repay_invoice` |
-| `"amount exceeds remaining funding gap"` | Commitment amount exceeds the remaining principal to be funded. Cannot over-commit. | `commit_to_invoice` |
-| `"investor has no position in this invoice token"` | Investor has never deposited in this token. Must deposit before committing. | `commit_to_invoice` |
-| `"insufficient available balance"` | Investor's available balance is less than the requested amount. | `commit_to_invoice`, `withdraw` |
-| `"invoice not found"` | Invoice ID not found in pool records. | `repay_invoice` |
-| `"invoice not fully funded yet"` | Invoice is not fully funded (`funded_at == 0`). Cannot repay before the invoice is fully funded. | `repay_invoice` |
-| `"no position found"` | Investor has no position in this token. Must deposit before withdrawing. | `withdraw` |
-| `"yield cannot exceed 50%"` | Yield in basis points exceeds 5000 (50% APY). | `set_yield` |
-| `"invoice not funded"` (in estimate_repayment) | Invoice is not registered for co-funding. | `estimate_repayment` |
+> **Note:** Contracts currently use `panic!` strings rather than structured error enums.
+> The codes in the tables below are the canonical identifiers to use in the frontend
+> error-message map (`frontend/lib/contracts.ts`) and in any external tooling.
+> They map 1-to-1 to the panic strings shown.
+
+### Invoice Contract Errors (codes 100–199)
+
+| Code | Error Message | Meaning | Affected Methods |
+|---|------|---------|---------|
+| 100 | `"already initialized"` | Contract has been initialized before. Each contract can only be initialized once. | `initialize` |
+| 101 | `"not initialized"` | Contract has not been initialized yet. All methods (except `initialize`) require initialization first. | `mark_funded`, `mark_paid`, `mark_defaulted`, `get_invoice`, `get_metadata`, `set_pool` |
+| 102 | `"unauthorized"` | Caller is not authorized. For `mark_paid`: must be owner, pool, or admin. For `set_pool`: must be admin. | `mark_paid`, `set_pool` |
+| 103 | `"unauthorized pool"` | Pool address is not the authorized pool contract. | `mark_funded`, `mark_defaulted` |
+| 104 | `"amount must be positive"` | Amount parameter is ≤ 0. | `create_invoice` |
+| 105 | `"due date must be in the future"` | Due date is not strictly after the current ledger timestamp. | `create_invoice` |
+| 106 | `"invoice not found"` | Invoice ID does not exist in contract state. | `get_invoice`, `mark_funded`, `mark_paid`, `mark_defaulted` |
+| 107 | `"invoice is not pending"` | Invoice is not in `Pending` state; `mark_funded` requires `Pending`. | `mark_funded` |
+| 108 | `"invoice is not funded"` | Invoice is not in `Funded` state; `mark_paid` requires `Funded`. | `mark_paid` |
+| 109 | `"contract is paused"` | Contract is administratively paused. | all state-mutating methods |
+
+### Pool Contract Errors (codes 200–299)
+
+| Code | Error Message | Meaning | Affected Methods |
+|---|------|---------|---------|
+| 200 | `"already initialized"` | Contract has been initialized before. | `initialize` |
+| 201 | `"unauthorized"` | Caller is not the stored admin address. | `add_token`, `remove_token`, `fund_invoice`, `set_yield` |
+| 202 | `"amount must be positive"` | Amount parameter is ≤ 0. | `deposit`, `withdraw`, `repay_invoice` |
+| 203 | `"token not accepted"` | Token is not on the accepted-tokens whitelist. | `deposit`, `fund_invoice` |
+| 204 | `"token already accepted"` | Token is already on the whitelist. | `add_token` |
+| 205 | `"token not in whitelist"` | Token was never added. | `remove_token` |
+| 206 | `"token has non-zero pool balances"` | Token has active balances; cannot be removed. | `remove_token` |
+| 207 | `"principal must be positive"` | Principal is ≤ 0. | `fund_invoice` |
+| 208 | `"insufficient available liquidity"` | Pool has less available liquidity than the requested principal. | `fund_invoice` |
+| 209 | `"invoice already funded"` | Invoice was already funded by the pool. | `fund_invoice` |
+| 210 | `"invoice not found"` | Invoice ID not found in pool records. | `repay_invoice` |
+| 211 | `"invoice already fully repaid"` | Invoice has already been fully repaid. | `repay_invoice` |
+| 212 | `"payment exceeds total due"` | Payment amount would exceed the total owed. | `repay_invoice` |
+| 213 | `"shares must be positive"` | Share amount for withdrawal is ≤ 0. | `withdraw` |
+| 214 | `"insufficient shares"` | Investor's share balance is less than requested. | `withdraw` |
+| 215 | `"yield cannot exceed 50%"` | Yield in basis points exceeds 5000. | `set_yield` |
+| 216 | `"contract is paused"` | Contract is administratively paused. | all state-mutating methods |
 
 ---
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,122 @@
+# Astera Monitoring Guide
+
+This document describes the health check endpoint, alert rules, and webhook
+integration for running Astera in production.
+
+---
+
+## Health Check Endpoint
+
+**`GET /api/health`**
+
+Returns a JSON object describing the current health of all critical dependencies.
+
+### Response schema
+
+```json
+{
+  "status": "ok" | "degraded" | "down",
+  "checks": {
+    "stellar_rpc": {
+      "name": "stellar_rpc",
+      "status": "ok" | "degraded" | "down",
+      "detail": "142ms"
+    }
+  },
+  "timestamp": "2024-01-15T12:00:00.000Z"
+}
+```
+
+| Field | Description |
+|---|---|
+| `status` | Worst status across all individual checks |
+| `checks` | Per-dependency result map |
+| `timestamp` | ISO-8601 time the check ran |
+
+### HTTP status codes
+
+| Response status | HTTP code |
+|---|---|
+| `ok` | 200 |
+| `degraded` | 200 |
+| `down` | 503 |
+
+### Checks performed
+
+| Check | Passes when |
+|---|---|
+| `stellar_rpc` | RPC responds within 5 seconds with HTTP 200 |
+
+---
+
+## Alert Rules
+
+Alert rules are defined in `frontend/lib/alert-rules.ts`.
+
+| Rule ID | Alert type | Priority | Trigger condition |
+|---|---|---|---|
+| `rule-large-tx` | `LARGE_TRANSACTION` | HIGH | Single transaction > 5,000 USDC |
+| `rule-unusual-activity` | `UNUSUAL_ACTIVITY` | MEDIUM | ≥ 3 events from one address within 10 minutes |
+| `rule-contract-default` | `CONTRACT_DEFAULT` | CRITICAL | Invoice marked `defaulted` |
+| `rule-invoice-funded` | `INVOICE_FUNDED` | MEDIUM | Invoice transitions to `funded` |
+| `rule-invoice-paid` | `INVOICE_PAID` | MEDIUM | Invoice fully repaid |
+| `rule-invoice-defaulted` | `INVOICE_DEFAULTED` | CRITICAL | Invoice defaulted via SME/investor flow |
+| `rule-low-liquidity` | `LOW_LIQUIDITY` | HIGH | Available pool liquidity < 10% of total deposits |
+| `rule-high-default-rate` | `HIGH_DEFAULT_RATE` | CRITICAL | Default rate > 5% in rolling 7-day window |
+| `rule-contract-paused` | `CONTRACT_PAUSED` | CRITICAL | Any core contract is paused |
+| `rule-rpc-slow` | `RPC_SLOW` | HIGH | Stellar RPC response time > 5 seconds |
+
+---
+
+## Webhook Integration
+
+When `ALERT_WEBHOOK_URL` is set (see `frontend/.env.example`), the `/api/health`
+endpoint POSTs the following payload whenever the overall status is `degraded` or
+`down`:
+
+```json
+{
+  "alert": "health_degraded",
+  "severity": "warning" | "critical",
+  "data": { ...full HealthResponse... },
+  "timestamp": "2024-01-15T12:00:00.000Z"
+}
+```
+
+`severity` is `"critical"` when `status === "down"`, otherwise `"warning"`.
+
+### Slack
+
+Set `ALERT_WEBHOOK_URL` to your Slack incoming webhook URL. The raw JSON payload
+will appear in the configured channel.
+
+### Discord
+
+Set `ALERT_WEBHOOK_URL` to your Discord webhook URL (append `?wait=true` if you
+want delivery confirmation).
+
+### PagerDuty
+
+Use your PagerDuty Events API v2 integration URL. Map `severity` to
+`payload.severity` in a PagerDuty routing rule, or use a middleware adapter.
+
+### Generic endpoint
+
+Any HTTPS endpoint that accepts `POST` with `Content-Type: application/json` is
+compatible.
+
+---
+
+## Uptime Monitoring
+
+Configure an external uptime monitor to ping `GET /api/health` at your chosen
+interval (60 seconds recommended).
+
+| Service | Free tier | Notes |
+|---|---|---|
+| UptimeRobot | 50 monitors, 5-min interval | Alerts on non-2xx or keyword mismatch |
+| Better Uptime | 10 monitors | Supports JSON keyword checks |
+| Freshping | 50 monitors, 1-min interval | — |
+
+Set the monitor to alert on HTTP 503, which the health endpoint returns when
+`status === "down"`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -17,3 +17,10 @@ NEXT_PUBLIC_EURC_TOKEN_ID=
 # Optional: Custom RPC URLs (defaults to public endpoints based on network)
 # NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 # NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Monitoring & Alerts
+# Webhook URL for health-degraded / health-down alerts fired by /api/health.
+# Compatible with Slack incoming webhooks, Discord webhooks, PagerDuty Events
+# API v2, Opsgenie, and any endpoint that accepts a POST with a JSON body.
+# Leave blank to disable webhook delivery.
+ALERT_WEBHOOK_URL=

--- a/frontend/app/api/health/route.ts
+++ b/frontend/app/api/health/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+interface HealthCheck {
+  name: string;
+  status: 'ok' | 'degraded' | 'down';
+  detail?: string;
+}
+
+interface HealthResponse {
+  status: 'ok' | 'degraded' | 'down';
+  checks: Record<string, HealthCheck>;
+  timestamp: string;
+}
+
+const RPC_URL = process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const RPC_TIMEOUT_MS = 5000;
+
+async function checkRpc(): Promise<HealthCheck> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RPC_TIMEOUT_MS);
+  try {
+    const start = Date.now();
+    const res = await fetch(RPC_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getHealth', params: [] }),
+      signal: controller.signal,
+    });
+    const elapsed = Date.now() - start;
+    if (!res.ok) {
+      return { name: 'stellar_rpc', status: 'down', detail: `HTTP ${res.status}` };
+    }
+    if (elapsed > RPC_TIMEOUT_MS) {
+      return { name: 'stellar_rpc', status: 'degraded', detail: `Response time ${elapsed}ms > ${RPC_TIMEOUT_MS}ms` };
+    }
+    return { name: 'stellar_rpc', status: 'ok', detail: `${elapsed}ms` };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'unreachable';
+    return { name: 'stellar_rpc', status: 'down', detail: message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function overallStatus(checks: Record<string, HealthCheck>): 'ok' | 'degraded' | 'down' {
+  const statuses = Object.values(checks).map((c) => c.status);
+  if (statuses.includes('down')) return 'down';
+  if (statuses.includes('degraded')) return 'degraded';
+  return 'ok';
+}
+
+async function fireWebhook(payload: HealthResponse): Promise<void> {
+  const webhookUrl = process.env.ALERT_WEBHOOK_URL;
+  if (!webhookUrl || payload.status === 'ok') return;
+  try {
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        alert: 'health_degraded',
+        severity: payload.status === 'down' ? 'critical' : 'warning',
+        data: payload,
+        timestamp: payload.timestamp,
+      }),
+    });
+  } catch {
+    // Best-effort — do not fail the health endpoint because of a webhook error.
+  }
+}
+
+export async function GET() {
+  const rpc = await checkRpc();
+
+  const checks: Record<string, HealthCheck> = {
+    stellar_rpc: rpc,
+  };
+
+  const response: HealthResponse = {
+    status: overallStatus(checks),
+    checks,
+    timestamp: new Date().toISOString(),
+  };
+
+  await fireWebhook(response);
+
+  const httpStatus = response.status === 'down' ? 503 : 200;
+  return NextResponse.json(response, { status: httpStatus });
+}

--- a/frontend/components/OnboardingModal.tsx
+++ b/frontend/components/OnboardingModal.tsx
@@ -9,84 +9,72 @@ interface OnboardingModalProps {
 
 const ONBOARDING_STORAGE_KEY = 'astera-onboarding-completed';
 
+type UserRole = 'sme' | 'investor' | null;
+
+const SME_STEPS = [
+  {
+    title: 'Welcome to Astera',
+    content:
+      'Astera lets you get paid early on your outstanding invoices. Tokenize your invoices on the Stellar blockchain and receive USDC directly to your wallet.',
+  },
+  {
+    title: 'Connect Your Wallet',
+    content:
+      'Connect your Freighter wallet to get started. Freighter is a browser extension for the Stellar network — install it from the Chrome Web Store if you haven't already.',
+  },
+  {
+    title: 'Create Your First Invoice',
+    content:
+      'Go to the Invoice page and fill in your debtor's name, invoice amount, and due date. You'll need your debtor's information and the amount owed to you.',
+  },
+  {
+    title: 'Wait for Verification',
+    content:
+      'Our oracle will verify your invoice details. Verified invoices become eligible for funding from the liquidity pool. This typically takes a short time.',
+  },
+  {
+    title: 'Receive Your Funds',
+    content:
+      'Once funded, you'll receive USDC directly to your connected wallet. Repay the invoice when your customer settles — and you're done!',
+  },
+];
+
+const INVESTOR_STEPS = [
+  {
+    title: 'Welcome to Astera',
+    content:
+      'Deposit stablecoins to earn yield from invoice financing. Your funds are deployed to verified SME invoices and you earn interest on repayment.',
+  },
+  {
+    title: 'Connect Your Wallet',
+    content:
+      'Connect your Freighter wallet to access the investor dashboard. Freighter is a Stellar browser extension — install it if you haven't already.',
+  },
+  {
+    title: 'Deposit USDC',
+    content:
+      'Go to the Invest page and deposit USDC into the liquidity pool. You will receive share tokens representing your proportional ownership of the pool.',
+  },
+  {
+    title: 'Your Funds Go to Work',
+    content:
+      'The pool deploys your funds to verified SME invoices. Your share of the pool grows as invoices are repaid with interest.',
+  },
+  {
+    title: 'Earn Yield Automatically',
+    content:
+      'Withdraw anytime your funds are available. Claim accrued yield at any time from the dashboard. Your earnings are proportional to your share of the pool.',
+  },
+];
+
 export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
+  const [role, setRole] = useState<UserRole>(null);
   const [currentStep, setCurrentStep] = useState(0);
   const modalRef = useRef<HTMLDivElement>(null);
   const firstFocusableRef = useRef<HTMLButtonElement>(null);
 
-  const steps = [
-    {
-      title: 'Welcome to Astera',
-      content: (
-        <div className="space-y-4">
-          <p className="text-brand-muted">
-            Astera is a decentralized invoice financing platform that helps SMEs access immediate
-            liquidity by tokenizing their invoices on the Stellar blockchain.
-          </p>
-          <div className="bg-brand-card border border-brand-border rounded-lg p-4">
-            <h4 className="font-semibold mb-2">How it works:</h4>
-            <ul className="space-y-2 text-sm text-brand-muted">
-              <li>• Create invoices with your debtor information</li>
-              <li>• Tokenize them on the Stellar blockchain</li>
-              <li>• Get funded by investors or use co-funding</li>
-              <li>• Repay when your customer pays the invoice</li>
-            </ul>
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: 'Getting Testnet USDC',
-      content: (
-        <div className="space-y-4">
-          <p className="text-brand-muted">
-            To test the platform, you&apos;ll need some testnet USDC in your wallet.
-          </p>
-          <div className="bg-brand-card border border-brand-border rounded-lg p-4">
-            <h4 className="font-semibold mb-2">Steps to get testnet USDC:</h4>
-            <ol className="space-y-2 text-sm text-brand-muted list-decimal list-inside">
-              <li>• Connect your Freighter wallet</li>
-              <li>• Visit the Stellar Testnet Faucet</li>
-              <li>• Enter your wallet address</li>
-              <li>• Request testnet USDC (10 USDC per request)</li>
-              <li>• Wait for the tokens to arrive in your wallet</li>
-            </ol>
-          </div>
-          <div className="bg-blue-900/20 border border-blue-800/50 rounded-lg p-3">
-            <p className="text-sm text-blue-400">
-              <strong>Note:</strong> Testnet USDC has no real value and is only for testing
-              purposes.
-            </p>
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: 'Creating Your First Invoice',
-      content: (
-        <div className="space-y-4">
-          <p className="text-brand-muted">
-            Ready to create your first invoice? Here&apos;s what you&apos;ll need:
-          </p>
-          <div className="bg-brand-card border border-brand-border rounded-lg p-4">
-            <h4 className="font-semibold mb-2">Required Information:</h4>
-            <ul className="space-y-2 text-sm text-brand-muted">
-              <li>• Debtor&apos;s wallet address (who owes you)</li>
-              <li>• Invoice amount in USDC</li>
-              <li>• Due date (when payment is expected)</li>
-              <li>• Description of goods/services</li>
-            </ul>
-          </div>
-          <div className="bg-green-900/20 border border-green-800/50 rounded-lg p-3">
-            <p className="text-sm text-green-400">
-              <strong>Pro tip:</strong> Start with a small amount to test the process before
-              creating larger invoices.
-            </p>
-          </div>
-        </div>
-      ),
-    },
-  ];
+  const steps = role === 'sme' ? SME_STEPS : role === 'investor' ? INVESTOR_STEPS : [];
+  const totalSteps = steps.length;
 
   useEffect(() => {
     if (isOpen && firstFocusableRef.current) {
@@ -137,7 +125,7 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
   if (!isOpen) return null;
 
   const handleNext = () => {
-    if (currentStep < steps.length - 1) {
+    if (currentStep < totalSteps - 1) {
       setCurrentStep(currentStep + 1);
     } else {
       handleComplete();
@@ -160,6 +148,11 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
     onClose();
   };
 
+  const handleRoleSelect = (selected: UserRole) => {
+    setRole(selected);
+    setCurrentStep(0);
+  };
+
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
       <div
@@ -173,7 +166,7 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
           {/* Header */}
           <div className="flex items-center justify-between mb-6">
             <h2 id="onboarding-title" className="text-xl font-bold">
-              {steps[currentStep].title}
+              {role === null ? 'Get Started' : steps[currentStep]?.title}
             </h2>
             <button
               ref={firstFocusableRef}
@@ -192,52 +185,112 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
             </button>
           </div>
 
-          {/* Progress indicator */}
-          <div className="flex items-center justify-center mb-6">
-            <div className="flex items-center space-x-2">
-              {steps.map((_, index) => (
-                <div
-                  key={index}
-                  className={`h-2 rounded-full transition-all duration-300 ${
-                    index === currentStep
-                      ? 'w-8 bg-brand-gold'
-                      : index < currentStep
-                        ? 'w-2 bg-brand-gold/60'
-                        : 'w-2 bg-brand-border'
-                  }`}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* Content */}
-          <div className="mb-8">{steps[currentStep].content}</div>
-
-          {/* Actions */}
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-3">
-              {currentStep > 0 && (
+          {/* Role selection */}
+          {role === null ? (
+            <div className="space-y-4">
+              <p className="text-brand-muted text-sm">
+                Tell us how you'll use Astera so we can show you the right guide.
+              </p>
+              <div className="grid grid-cols-2 gap-4">
                 <button
-                  onClick={handlePrevious}
-                  className="px-4 py-2 text-brand-muted hover:text-white transition-colors"
+                  onClick={() => handleRoleSelect('sme')}
+                  className="flex flex-col items-center gap-3 p-5 bg-brand-card border border-brand-border rounded-xl hover:border-brand-gold transition-colors text-left"
+                  aria-label="I am an SME seeking invoice financing"
                 >
-                  Previous
+                  <span className="text-3xl" aria-hidden="true">🏢</span>
+                  <div>
+                    <p className="font-semibold text-sm">SME / Business</p>
+                    <p className="text-xs text-brand-muted mt-1">
+                      I want to finance my invoices
+                    </p>
+                  </div>
                 </button>
-              )}
-              <button
-                onClick={handleSkip}
-                className="px-4 py-2 text-brand-muted hover:text-white transition-colors"
-              >
-                Skip
-              </button>
+                <button
+                  onClick={() => handleRoleSelect('investor')}
+                  className="flex flex-col items-center gap-3 p-5 bg-brand-card border border-brand-border rounded-xl hover:border-brand-gold transition-colors text-left"
+                  aria-label="I am an investor looking to earn yield"
+                >
+                  <span className="text-3xl" aria-hidden="true">💰</span>
+                  <div>
+                    <p className="font-semibold text-sm">Investor</p>
+                    <p className="text-xs text-brand-muted mt-1">
+                      I want to deposit and earn yield
+                    </p>
+                  </div>
+                </button>
+              </div>
+              <div className="flex justify-end pt-2">
+                <button
+                  onClick={handleSkip}
+                  className="px-4 py-2 text-sm text-brand-muted hover:text-white transition-colors"
+                >
+                  Skip tour
+                </button>
+              </div>
             </div>
-            <button
-              onClick={handleNext}
-              className="px-6 py-2 bg-brand-gold text-brand-dark font-semibold rounded-lg hover:bg-brand-amber transition-colors"
-            >
-              {currentStep === steps.length - 1 ? 'Get Started' : 'Next'}
-            </button>
-          </div>
+          ) : (
+            <>
+              {/* Step indicator */}
+              <div className="flex items-center justify-center mb-6" aria-label={`Step ${currentStep + 1} of ${totalSteps}`}>
+                <div className="flex items-center space-x-2">
+                  {steps.map((_, index) => (
+                    <div
+                      key={index}
+                      aria-hidden="true"
+                      className={`h-2 rounded-full transition-all duration-300 ${
+                        index === currentStep
+                          ? 'w-8 bg-brand-gold'
+                          : index < currentStep
+                            ? 'w-2 bg-brand-gold/60'
+                            : 'w-2 bg-brand-border'
+                      }`}
+                    />
+                  ))}
+                </div>
+                <span className="sr-only">{`Step ${currentStep + 1} of ${totalSteps}`}</span>
+              </div>
+
+              {/* Content */}
+              <div className="mb-8 bg-brand-card border border-brand-border rounded-lg p-4">
+                <p className="text-brand-muted text-sm leading-relaxed">
+                  {steps[currentStep]?.content}
+                </p>
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-3">
+                  {currentStep > 0 ? (
+                    <button
+                      onClick={handlePrevious}
+                      className="px-4 py-2 text-brand-muted hover:text-white transition-colors"
+                    >
+                      Previous
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => setRole(null)}
+                      className="px-4 py-2 text-brand-muted hover:text-white transition-colors"
+                    >
+                      Back
+                    </button>
+                  )}
+                  <button
+                    onClick={handleSkip}
+                    className="px-4 py-2 text-brand-muted hover:text-white transition-colors"
+                  >
+                    Skip
+                  </button>
+                </div>
+                <button
+                  onClick={handleNext}
+                  className="px-6 py-2 bg-brand-gold text-brand-dark font-semibold rounded-lg hover:bg-brand-amber transition-colors"
+                >
+                  {currentStep === totalSteps - 1 ? 'Get Started' : 'Next'}
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/lib/alert-rules.ts
+++ b/frontend/lib/alert-rules.ts
@@ -21,6 +21,21 @@ export const ACTIVITY_WINDOW_SECONDS = 600;
 /** Priority Levels for Alerts */
 export type AlertPriority = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
 
+/**
+ * Liquidity threshold: alert when available liquidity drops below this fraction
+ * of total pool deposits (0.10 = 10%).
+ */
+export const LOW_LIQUIDITY_THRESHOLD_RATIO = 0.10;
+
+/**
+ * Default rate threshold: alert when more than this fraction of invoices
+ * in a rolling 7-day window are defaulted (0.05 = 5%).
+ */
+export const DEFAULT_RATE_THRESHOLD_RATIO = 0.05;
+
+/** Rolling window for default-rate calculation (seconds). */
+export const DEFAULT_RATE_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+
 /** Alert Types */
 export type AlertType =
   | 'LARGE_TRANSACTION'
@@ -29,7 +44,11 @@ export type AlertType =
   | 'SYSTEM_ERROR'
   | 'INVOICE_FUNDED'
   | 'INVOICE_PAID'
-  | 'INVOICE_DEFAULTED';
+  | 'INVOICE_DEFAULTED'
+  | 'LOW_LIQUIDITY'
+  | 'HIGH_DEFAULT_RATE'
+  | 'CONTRACT_PAUSED'
+  | 'RPC_SLOW';
 
 /** Rule Definition */
 export interface AlertRule {
@@ -82,5 +101,33 @@ export const ALERT_RULES: AlertRule[] = [
     type: 'INVOICE_DEFAULTED',
     priority: 'CRITICAL',
     description: 'Triggered when an invoice is marked as defaulted via the SME/investor flow.',
+  },
+  {
+    id: 'rule-low-liquidity',
+    name: 'Low Pool Liquidity',
+    type: 'LOW_LIQUIDITY',
+    priority: 'HIGH',
+    description: `Triggered when available pool liquidity drops below ${LOW_LIQUIDITY_THRESHOLD_RATIO * 100}% of total deposits.`,
+  },
+  {
+    id: 'rule-high-default-rate',
+    name: 'High Invoice Default Rate',
+    type: 'HIGH_DEFAULT_RATE',
+    priority: 'CRITICAL',
+    description: `Triggered when more than ${DEFAULT_RATE_THRESHOLD_RATIO * 100}% of invoices in a 7-day rolling window are defaulted.`,
+  },
+  {
+    id: 'rule-contract-paused',
+    name: 'Contract Paused',
+    type: 'CONTRACT_PAUSED',
+    priority: 'CRITICAL',
+    description: 'Triggered when any core contract is paused unexpectedly.',
+  },
+  {
+    id: 'rule-rpc-slow',
+    name: 'Stellar RPC Slow',
+    type: 'RPC_SLOW',
+    priority: 'HIGH',
+    description: 'Triggered when the Stellar RPC endpoint response time exceeds 5 seconds.',
   },
 ];

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -635,4 +635,45 @@ export async function fetchInvestorPosition(investor: string): Promise<InvestorP
   return null;
 }
 
+// ---- Error message mapping (issue #163) ----
+// Maps contract panic strings to user-friendly messages.
+// Full error code reference: docs/API_REFERENCE.md
+
+const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
+  // Invoice contract errors
+  'already initialized': 'This contract has already been set up.',
+  'not initialized': 'The contract is not yet configured. Please contact support.',
+  'unauthorized': 'You are not authorised to perform this action.',
+  'unauthorized pool': 'The pool contract is not authorised for this invoice.',
+  'amount must be positive': 'Amount must be greater than zero.',
+  'due date must be in the future': 'The due date must be a future date.',
+  'invoice not found': 'Invoice not found. Please check the invoice ID.',
+  'invoice is not pending': 'This invoice is not in a pending state.',
+  'invoice is not funded': 'This invoice has not been funded yet.',
+  'contract is paused': 'The contract is currently paused. Please try again later.',
+  // Pool contract errors
+  'token not accepted': 'This token is not supported by the pool.',
+  'insufficient available liquidity': 'The pool does not have enough liquidity for this invoice.',
+  'invoice already funded': 'This invoice has already been funded.',
+  'invoice already fully repaid': 'This invoice has already been fully repaid.',
+  'payment exceeds total due': 'The payment amount exceeds the total amount owed.',
+  'shares must be positive': 'Share amount must be greater than zero.',
+  'insufficient shares': 'You do not have enough shares to withdraw that amount.',
+  'yield cannot exceed 50%': 'Yield rate cannot exceed 50% APY.',
+  // Credit score contract errors
+  'invoice already processed': 'This invoice has already been recorded in the credit score.',
+};
+
+/**
+ * Converts a raw contract panic string to a user-friendly message.
+ * Falls back to the original message if no mapping is found.
+ */
+export function getContractErrorMessage(raw: string): string {
+  const lower = raw.toLowerCase();
+  for (const [key, friendly] of Object.entries(CONTRACT_ERROR_MESSAGES)) {
+    if (lower.includes(key)) return friendly;
+  }
+  return raw;
+}
+
 export { submitTx };


### PR DESCRIPTION
## Summary

- Add reward-per-share yield accumulator and `claim_yield()` function to the pool contract so investors can claim accrued yield without withdrawing
- Replace the generic onboarding placeholder with role-based 5-step tours for SMEs and Investors, with role selection, step indicator, Skip persistence, and keyboard navigation
- Add a `/api/health` endpoint with Stellar RPC check, webhook delivery on degraded/down status, four new alert rules, and a monitoring guide in `docs/monitoring.md`
- Assign non-overlapping error code ranges per contract in `docs/API_REFERENCE.md` and add a `getContractErrorMessage()` helper in `frontend/lib/contracts.ts`

## Issues closed

Closes #177
Closes #178
Closes #171
Closes #163

## Test plan

- [ ] Call `claim_yield` after a repaid invoice and confirm tokens are transferred to investor proportional to share balance
- [ ] Verify onboarding modal shows role selection on first open, correct 5-step flow per role, and does not reappear after Skip
- [ ] Hit `GET /api/health` and confirm JSON response; set `ALERT_WEBHOOK_URL` and confirm POST fires when RPC is unreachable
- [ ] Confirm no error code appears in more than one contract's range in `API_REFERENCE.md`