### PR TITLE
feat: explorer links, mock service, grace period override, GitHub templates (#228 #229 #230 #231)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+name: Bug Report
+description: Report a bug to help us improve Astera
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in as much detail as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug…
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the problem.
+      placeholder: |
+        1. Go to '…'
+        2. Click on '…'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      options:
+        - Smart Contract (invoice)
+        - Smart Contract (pool)
+        - Frontend
+        - SDK
+        - Mock Service
+        - Docs / DevOps
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g. macOS 14, Ubuntu 22.04, Windows 11
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser & Version
+      placeholder: e.g. Chrome 124, Firefox 126, Safari 17
+
+  - type: input
+    id: wallet
+    attributes:
+      label: Wallet & Version
+      placeholder: e.g. Freighter 5.0.0
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Stellar Network
+      options:
+        - Testnet
+        - Mainnet
+        - Local (Quickstart)
+
+  - type: input
+    id: contract_address
+    attributes:
+      label: Contract Address (if on-chain bug)
+      placeholder: C…
+
+  - type: input
+    id: tx_hash
+    attributes:
+      label: Transaction Hash (if on-chain bug)
+      placeholder: 64-char hex hash
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Error Messages
+      description: Paste any console errors, Soroban diagnostic events, or stack traces.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
-blank_issues: false
+blank_issues_enabled: true
 contact_links:
+  - name: Ask a Question / Start a Discussion
+    url: https://github.com/astera-hq/Astera/discussions
+    about: For questions and open-ended discussion, use GitHub Discussions rather than issues.
   - name: Drips Wave Program
     url: https://docs.drips.network/wave
-    about: Learn more about the Drips Wave contribution program
+    about: Learn more about the Drips Wave contribution program.
+  - name: Security Vulnerabilities
+    url: https://github.com/astera-hq/Astera/blob/main/SECURITY.md
+    about: Please report security issues privately — do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature Request
+description: Propose a new feature or improvement for Astera
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please provide as much context as possible.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to Solve
+      description: What problem does this feature address? Who is affected?
+      placeholder: As a … I want … so that …
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the change you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you consider? Why is your proposed solution better?
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      multiple: true
+      options:
+        - Smart Contract (invoice)
+        - Smart Contract (pool)
+        - Frontend
+        - SDK
+        - Mock Service
+        - Docs / DevOps
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Low — nice to have
+        - Medium — important but not blocking
+        - High — blocking a use-case
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, mockups, related issues, or external references.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,43 @@
 ## Summary
 
-<!-- Brief description of the changes -->
+<!-- Brief description of what changed and why. -->
 
 ## Related Issue
 
-<!-- Link the issue this PR addresses -->
+<!-- Every PR should close or reference at least one issue. -->
 Closes #
+
+## Type of Change
+
+<!-- Check all that apply. -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / internal improvement
+- [ ] Documentation update
+- [ ] Test-only change
+- [ ] DevOps / CI change
 
 ## Changes
 
-<!-- List the changes made -->
+<!-- List the key changes: new files, modified functions, removed code. -->
 -
 -
 
-## Testing
+## Testing Performed
 
-<!-- Describe how you tested your changes -->
-- [ ] `cargo test` passes (if contracts changed)
-- [ ] `npm run lint` passes (if frontend changed)
-- [ ] `npm run build` succeeds (if frontend changed)
+<!-- Describe how you verified the changes work. -->
+-
 
-## Screenshots (if applicable)
+## Checklist
 
-<!-- Add screenshots for UI changes -->
+- [ ] Tests added or updated (`cargo test` / `npm test` passes)
+- [ ] Documentation updated (README, inline docs, API reference)
+- [ ] `cargo fmt` and `cargo clippy -- -D warnings` pass (if contracts changed)
+- [ ] `npm run lint` and `npm run build` pass (if frontend changed)
+- [ ] No secrets, private keys, or production contract IDs in code
+- [ ] API reference updated if contract interface changed
+- [ ] PR title is descriptive and follows `type(scope): description` convention
+
+## Screenshots (UI changes only)
+
+<!-- Add before/after screenshots for any frontend changes. -->

--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -21,6 +21,7 @@ const MAX_INVOICES_PER_DAY: u32 = 10;
 const MAX_DAILY_INVOICE_LIMIT: u32 = 1_000;
 const SECS_PER_DAY: u64 = 86400;
 const DEFAULT_GRACE_PERIOD_DAYS: u32 = 7; // 7 days default grace period
+const MAX_GRACE_PERIOD_OVERRIDE_DAYS: u32 = 30; // per-invoice cap (#230)
 const DEFAULT_EXPIRATION_DURATION_SECS: u64 = SECS_PER_DAY * 30; // 30 days
 
 #[contracttype]
@@ -54,6 +55,10 @@ pub struct Invoice {
     pub verification_hash: String,
     pub oracle_verified: bool,
     pub dispute_reason: String,
+    /// Per-invoice grace-period override set by admin (#230).
+    /// `None` means use the global `GracePeriodDays` setting.
+    /// When set, the value must be ≤ `MAX_GRACE_PERIOD_OVERRIDE_DAYS`.
+    pub grace_period_override: Option<u32>,
 }
 
 /// Wallet / explorer–oriented view derived from [`Invoice`] (no extra storage).
@@ -407,6 +412,7 @@ impl InvoiceContract {
             verification_hash,
             oracle_verified: false,
             dispute_reason: empty_str,
+            grace_period_override: None,
         };
 
         env.storage()
@@ -671,11 +677,13 @@ impl InvoiceContract {
             panic!("invoice is not funded");
         }
 
-        let grace_period_days: u32 = env
+        // Use the invoice's per-invoice override if set; fall back to global (#230).
+        let global_grace: u32 = env
             .storage()
             .instance()
             .get(&DataKey::GracePeriodDays)
             .unwrap_or(DEFAULT_GRACE_PERIOD_DAYS);
+        let grace_period_days = invoice.grace_period_override.unwrap_or(global_grace);
         let grace_period_secs = grace_period_days as u64 * SECS_PER_DAY;
         let now = env.ledger().timestamp();
         let default_at = invoice.due_date + grace_period_secs;
@@ -925,6 +933,77 @@ impl InvoiceContract {
             .instance()
             .get(&DataKey::GracePeriodDays)
             .unwrap_or(DEFAULT_GRACE_PERIOD_DAYS)
+    }
+
+    /// Set a per-invoice grace-period override (#230).
+    ///
+    /// Only callable by admin on a `Funded` invoice.
+    /// `days` must be ≤ `MAX_GRACE_PERIOD_OVERRIDE_DAYS` (30).
+    /// Emits `(INVOICE, "grace_period_updated")` with `(id, old_days, new_days)`.
+    pub fn set_invoice_grace_period(env: Env, admin: Address, id: u64, days: u32) {
+        admin.require_auth();
+        require_not_paused(&env);
+        bump_instance(&env);
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic!("unauthorized: caller is not admin");
+        }
+
+        if days > MAX_GRACE_PERIOD_OVERRIDE_DAYS {
+            panic!(
+                "grace period override {} days exceeds maximum of {} days",
+                days, MAX_GRACE_PERIOD_OVERRIDE_DAYS
+            );
+        }
+
+        let mut invoice: Invoice = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Invoice(id))
+            .expect("invoice not found");
+
+        if invoice.status != InvoiceStatus::Funded {
+            panic!("grace period override only allowed on Funded invoices");
+        }
+
+        let global_grace: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::GracePeriodDays)
+            .unwrap_or(DEFAULT_GRACE_PERIOD_DAYS);
+        let old_days = invoice.grace_period_override.unwrap_or(global_grace);
+
+        invoice.grace_period_override = Some(days);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Invoice(id), &invoice);
+
+        env.events().publish(
+            (EVT, symbol_short!("gp_upd")),
+            (id, old_days, days),
+        );
+    }
+
+    /// Get the effective grace period for a specific invoice (#230).
+    /// Returns the per-invoice override if set, otherwise the global default.
+    pub fn get_invoice_grace_period(env: Env, id: u64) -> u32 {
+        bump_instance(&env);
+        let invoice: Invoice = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Invoice(id))
+            .expect("invoice not found");
+        let global_grace: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::GracePeriodDays)
+            .unwrap_or(DEFAULT_GRACE_PERIOD_DAYS);
+        invoice.grace_period_override.unwrap_or(global_grace)
     }
 
     pub fn set_pool(env: Env, admin: Address, pool: Address) {
@@ -2278,5 +2357,90 @@ mod test {
         );
         client.pause(&admin);
         assert!(client.is_paused());
+    }
+
+    // ── #230: per-invoice grace period tests ────────────────────────────────
+
+    #[test]
+    fn test_invoice_without_override_uses_global_grace_period() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, pool, _owner) = setup_funded_invoice(&env);
+
+        // No override set — effective grace period should be global (7 days by default).
+        let id = 1u64;
+        let effective = client.get_invoice_grace_period(&id);
+        assert_eq!(effective, DEFAULT_GRACE_PERIOD_DAYS);
+        let _ = admin;
+        let _ = pool;
+    }
+
+    #[test]
+    fn test_invoice_with_override_uses_override_grace_period() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _pool, _owner) = setup_funded_invoice(&env);
+
+        let id = 1u64;
+        client.set_invoice_grace_period(&admin, &id, &14u32);
+        let effective = client.get_invoice_grace_period(&id);
+        assert_eq!(effective, 14);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds maximum")]
+    fn test_override_exceeds_max_days_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _pool, _owner) = setup_funded_invoice(&env);
+
+        // 31 days > MAX_GRACE_PERIOD_OVERRIDE_DAYS (30) — must panic.
+        client.set_invoice_grace_period(&admin, &1u64, &31u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_non_admin_cannot_set_override() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _pool, owner) = setup_funded_invoice(&env);
+
+        // owner is not admin — must panic.
+        client.set_invoice_grace_period(&owner, &1u64, &10u32);
+    }
+
+    /// Helper: initialise a contract and produce a single funded invoice (id=1).
+    fn setup_funded_invoice(
+        env: &Env,
+    ) -> (
+        InvoiceContractClient<'_>,
+        Address,
+        Address,
+        Address,
+    ) {
+        let contract_id = env.register(InvoiceContract, ());
+        let client = InvoiceContractClient::new(env, &contract_id);
+
+        let admin = Address::generate(env);
+        let pool = Address::generate(env);
+        let oracle = Address::generate(env);
+        let owner = Address::generate(env);
+
+        client.initialize(&admin, &pool, &oracle);
+
+        let id = client.create_invoice(
+            &owner,
+            &String::from_str(env, "ACME Corp"),
+            &1_000_0000000i128,
+            &(env.ledger().timestamp() + SECS_PER_DAY * 30),
+            &String::from_str(env, "Test invoice"),
+            &String::from_str(env, "hash"),
+        );
+
+        // Verify and fund so the invoice reaches Funded status.
+        client.verify_invoice(&id, &oracle, &true, &String::from_str(env, ""));
+        client.mark_funded(&id, &pool);
+
+        (client, admin, pool, owner)
     }
 }

--- a/frontend/components/ExplorerLink.tsx
+++ b/frontend/components/ExplorerLink.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+/**
+ * ExplorerLink — Stellar deep-link component (#228).
+ *
+ * Renders a truncated identifier with a tooltip showing the full value,
+ * and an external-link icon. Opens in a new tab with rel="noopener noreferrer".
+ *
+ * Usage:
+ *   <ExplorerLink type="transaction" id={txHash} />
+ *   <ExplorerLink type="account" id={address}>View wallet ↗</ExplorerLink>
+ *   <ExplorerLink type="contract" id={contractId} network="mainnet" />
+ */
+
+import { explorerUrl, truncateAddress } from '@/lib/stellar';
+import type { ExplorerEntity, StellarNetwork } from '@/lib/stellar';
+
+interface ExplorerLinkProps {
+  /** Entity type passed to explorerUrl(). */
+  type: ExplorerEntity;
+  /** Full on-chain identifier — address, tx hash, contract ID, or ledger number. */
+  id: string;
+  /** Override network; defaults to NEXT_PUBLIC_STELLAR_NETWORK. */
+  network?: StellarNetwork;
+  /** Custom link label. Defaults to a truncated version of `id`. */
+  children?: React.ReactNode;
+  /** Extra CSS classes applied to the <a> element. */
+  className?: string;
+}
+
+export function ExplorerLink({
+  type,
+  id,
+  network,
+  children,
+  className = '',
+}: ExplorerLinkProps) {
+  if (!id) return null;
+
+  const url = explorerUrl(type, id, network);
+  const label = children ?? truncateAddress(id);
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={id}
+      className={`inline-flex items-center gap-1 font-mono text-xs text-blue-400 hover:text-blue-300 hover:underline transition-colors ${className}`}
+    >
+      {label}
+      {/* External link icon */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        className="h-3 w-3 shrink-0"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M4.75 3.5A.75.75 0 0 0 4 4.25v7.5c0 .414.336.75.75.75h7.5a.75.75 0 0 0 .75-.75V9a.75.75 0 0 1 1.5 0v2.75A2.25 2.25 0 0 1 12.25 14h-7.5A2.25 2.25 0 0 1 2.5 11.75v-7.5A2.25 2.25 0 0 1 4.75 2H7.5a.75.75 0 0 1 0 1.5H4.75Z"
+          clipRule="evenodd"
+        />
+        <path
+          fillRule="evenodd"
+          d="M9.25 2a.75.75 0 0 1 .75-.75h4a.75.75 0 0 1 .75.75v4a.75.75 0 0 1-1.5 0V3.56L8.03 8.78a.75.75 0 0 1-1.06-1.06l5.22-5.22H10a.75.75 0 0 1-.75-.75Z"
+          clipRule="evenodd"
+        />
+      </svg>
+    </a>
+  );
+}

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -20,9 +20,24 @@ import type {
   FundedInvoice,
 } from './types';
 
+// ── Mock mode (#229) ─────────────────────────────────────────────────────────
+// Set NEXT_PUBLIC_USE_MOCK=true to read from the local json-server instead of
+// making live Soroban RPC calls. Useful for frontend-only development when no
+// Stellar node is available. See mock-service/README.md for setup instructions.
+
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
+const MOCK_API_URL = process.env.NEXT_PUBLIC_MOCK_API_URL ?? 'http://localhost:4000';
+
+async function mockFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${MOCK_API_URL}${path}`);
+  if (!res.ok) throw new Error(`Mock API error: ${res.status} ${path}`);
+  return res.json() as Promise<T>;
+}
+
 // ---- Invoice Contract ----
 
 export async function getInvoice(id: number): Promise<Invoice> {
+  if (USE_MOCK) return mockFetch<Invoice>(`/invoices/${id}`);
   const sim = await simulateTx(
     INVOICE_CONTRACT_ID,
     'get_invoice',

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -238,6 +238,32 @@ export function truncateAddress(addr: string): string {
   return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
 }
 
+// ---- Stellar Explorer Deep Links (#228) ----
+
+export type ExplorerEntity = 'account' | 'transaction' | 'contract' | 'ledger';
+export type StellarNetwork = 'testnet' | 'mainnet';
+
+const EXPLORER_BASES: Record<StellarNetwork, string> = {
+  testnet: 'https://stellar.expert/explorer/testnet',
+  mainnet: 'https://stellar.expert/explorer/public',
+};
+
+/**
+ * Build a deep link to stellar.expert for any on-chain entity.
+ *
+ * @param type    - 'account' | 'transaction' | 'contract' | 'ledger'
+ * @param id      - The entity identifier (address, hash, or ledger number)
+ * @param network - 'testnet' (default) or 'mainnet'
+ */
+export function explorerUrl(
+  type: ExplorerEntity,
+  id: string,
+  network: StellarNetwork = (process.env.NEXT_PUBLIC_STELLAR_NETWORK as StellarNetwork) ?? 'testnet',
+): string {
+  const base = EXPLORER_BASES[network] ?? EXPLORER_BASES.testnet;
+  return `${base}/${type}/${encodeURIComponent(id)}`;
+}
+
 // ---- BigInt handling ----
 //
 // Contract responses decoded via `scValToNative` may include `bigint` values

--- a/mock-service/README.md
+++ b/mock-service/README.md
@@ -1,0 +1,74 @@
+# Mock Service — Offline Frontend Development
+
+The mock service is a lightweight [json-server](https://github.com/typicode/json-server) instance that serves realistic fixture data for all invoice states, pool states, and user scenarios. It allows frontend contributors to develop and test without a running Stellar node.
+
+## Prerequisites
+
+```bash
+npm install -g json-server   # or: pnpm add -g json-server
+```
+
+## Starting the Mock Service
+
+```bash
+# From the repo root:
+cd mock-service
+json-server --watch db.json --port 4000
+```
+
+The API will be available at `http://localhost:4000`.
+
+## Switching the Frontend to Mock Mode
+
+Set the environment variable before starting the frontend dev server:
+
+```bash
+# .env.local (frontend/)
+NEXT_PUBLIC_USE_MOCK=true
+NEXT_PUBLIC_MOCK_API_URL=http://localhost:4000
+```
+
+When `NEXT_PUBLIC_USE_MOCK=true`, the frontend reads data from the mock service instead of making Soroban RPC calls. This lets you work on UI and component logic with no blockchain dependency.
+
+## Available Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /invoices` | All invoices (one per status) |
+| `GET /invoices/:id` | Single invoice by ID |
+| `GET /pool` | Pool configuration and totals |
+| `GET /pool_token_totals` | Share price and USDC totals |
+| `GET /investors` | All investor positions |
+| `GET /investors/:id` | Single investor |
+| `GET /credit_scores` | SME credit scores |
+
+### Filtering (json-server built-in)
+
+```bash
+# Invoices by status:
+GET /invoices?status=Funded
+
+# Invoices by owner:
+GET /invoices?owner=GDEV1…
+```
+
+## Mock Data Coverage
+
+`db.json` includes one invoice in each status:
+
+| ID | Status | Debtor |
+|----|--------|--------|
+| 1 | Pending | Acme Corp |
+| 2 | AwaitingVerification | Beta Industries |
+| 3 | Verified | Gamma Ltd |
+| 4 | Funded (14-day grace override) | Delta Manufacturing |
+| 5 | Paid | Epsilon Retail |
+| 6 | Defaulted | Zeta Logistics |
+| 7 | Disputed | Eta Services |
+| 8 | Expired | Theta Wholesale |
+
+Pool state shows partially deployed capital (42% deployed). Two investors are included — one with three commitments (2 active, 1 completed) and one with no commitments. Three SME credit-score profiles cover Excellent (750), Fair (520), and No History (500).
+
+## Adding New Mock Data
+
+Edit `db.json` directly. json-server watches the file and reloads automatically. Follow the shape of existing records. Amount fields use stroops (1 USDC = 10 000 000 stroops).

--- a/mock-service/db.json
+++ b/mock-service/db.json
@@ -1,9 +1,179 @@
 {
   "invoices": [
-    { "id": 1, "amount": 1000, "status": "funded" },
-    { "id": 2, "amount": 5000, "status": "open" }
+    {
+      "id": 1,
+      "owner": "GDEV1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
+      "debtor": "Acme Corp",
+      "amount": 10000000000,
+      "due_date": 1800000000,
+      "description": "Web development services Q1 2026",
+      "status": "Pending",
+      "created_at": 1700000000,
+      "funded_at": 0,
+      "paid_at": 0,
+      "grace_period_override": null,
+      "verification_hash": "",
+      "oracle_verified": false
+    },
+    {
+      "id": 2,
+      "owner": "GDEV1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
+      "debtor": "Beta Industries",
+      "amount": 50000000000,
+      "due_date": 1800086400,
+      "description": "Equipment supply contract",
+      "status": "AwaitingVerification",
+      "created_at": 1700010000,
+      "funded_at": 0,
+      "paid_at": 0,
+      "grace_period_override": null,
+      "verification_hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      "oracle_verified": false
+    },
+    {
+      "id": 3,
+      "owner": "GDEV2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC",
+      "debtor": "Gamma Ltd",
+      "amount": 25000000000,
+      "due_date": 1800172800,
+      "description": "Consulting retainer March 2026",
+      "status": "Verified",
+      "created_at": 1700020000,
+      "funded_at": 0,
+      "paid_at": 0,
+      "grace_period_override": null,
+      "verification_hash": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+      "oracle_verified": true
+    },
+    {
+      "id": 4,
+      "owner": "GDEV1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
+      "debtor": "Delta Manufacturing",
+      "amount": 100000000000,
+      "due_date": 1800259200,
+      "description": "Raw materials purchase order #2026-04",
+      "status": "Funded",
+      "created_at": 1700030000,
+      "funded_at": 1700100000,
+      "paid_at": 0,
+      "grace_period_override": 14,
+      "verification_hash": "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+      "oracle_verified": true
+    },
+    {
+      "id": 5,
+      "owner": "GDEV2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC",
+      "debtor": "Epsilon Retail",
+      "amount": 15000000000,
+      "due_date": 1750000000,
+      "description": "Marketing campaign Q4 2025",
+      "status": "Paid",
+      "created_at": 1699000000,
+      "funded_at": 1699100000,
+      "paid_at": 1750100000,
+      "grace_period_override": null,
+      "verification_hash": "d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5",
+      "oracle_verified": true
+    },
+    {
+      "id": 6,
+      "owner": "GDEV3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD",
+      "debtor": "Zeta Logistics",
+      "amount": 80000000000,
+      "due_date": 1720000000,
+      "description": "Freight contract — defaulted",
+      "status": "Defaulted",
+      "created_at": 1698000000,
+      "funded_at": 1698100000,
+      "paid_at": 0,
+      "grace_period_override": null,
+      "verification_hash": "e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6",
+      "oracle_verified": true
+    },
+    {
+      "id": 7,
+      "owner": "GDEV1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
+      "debtor": "Eta Services",
+      "amount": 30000000000,
+      "due_date": 1800345600,
+      "description": "IT support contract — under dispute",
+      "status": "Disputed",
+      "created_at": 1700050000,
+      "funded_at": 1700200000,
+      "paid_at": 0,
+      "grace_period_override": null,
+      "dispute_reason": "Work not delivered as agreed in scope",
+      "verification_hash": "f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1",
+      "oracle_verified": true
+    },
+    {
+      "id": 8,
+      "owner": "GDEV2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC",
+      "debtor": "Theta Wholesale",
+      "amount": 5000000000,
+      "due_date": 1680000000,
+      "description": "Small trade invoice — expired",
+      "status": "Expired",
+      "created_at": 1679000000,
+      "funded_at": 0,
+      "paid_at": 0,
+      "grace_period_override": null,
+      "verification_hash": "",
+      "oracle_verified": false
+    }
   ],
-  "users": [
-    { "id": 1, "name": "Local Dev SME" }
+  "pool": {
+    "id": "CPOOLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "yield_bps": 800,
+    "total_deposited": 500000000000,
+    "total_deployed": 210000000000,
+    "total_repaid": 15000000000,
+    "investor_count": 2
+  },
+  "pool_token_totals": {
+    "total_shares": 500000000000,
+    "total_usdc": 500000000000,
+    "share_price_usdc": 1000000
+  },
+  "investors": [
+    {
+      "id": "GINV1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+      "shares": 300000000000,
+      "usdc_deposited": 300000000000,
+      "commitments": [
+        { "invoice_id": 4, "amount": 100000000000, "status": "active" },
+        { "invoice_id": 5, "amount": 15000000000, "status": "completed" },
+        { "invoice_id": 7, "amount": 30000000000, "status": "active" }
+      ]
+    },
+    {
+      "id": "GINV2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF",
+      "shares": 200000000000,
+      "usdc_deposited": 200000000000,
+      "commitments": []
+    }
+  ],
+  "credit_scores": [
+    {
+      "sme": "GDEV1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
+      "score": 750,
+      "grade": "Excellent",
+      "invoices_paid": 12,
+      "invoices_defaulted": 0
+    },
+    {
+      "sme": "GDEV2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC",
+      "score": 520,
+      "grade": "Fair",
+      "invoices_paid": 3,
+      "invoices_defaulted": 1
+    },
+    {
+      "sme": "GDEV3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD",
+      "score": 500,
+      "grade": "No History",
+      "invoices_paid": 0,
+      "invoices_defaulted": 0
+    }
   ]
 }


### PR DESCRIPTION
## Summary

**#228** — Stellar explorer deep links
- `explorerUrl(type, id, network?)` in `frontend/lib/stellar.ts` — builds `stellar.expert` deep links for account, transaction, contract, ledger.
- `frontend/components/ExplorerLink.tsx` — reusable component with truncated label, full-ID tooltip, external-link icon, `rel="noopener noreferrer"`.

**#229** — Mock service expansion for offline frontend development
- `mock-service/db.json` expanded from 2 stubs to all 8 invoice statuses, pool state with partial deployment, 2 investor positions, 3 SME credit-score profiles.
- `mock-service/README.md` added with startup guide, endpoint reference, and data-shape documentation.
- `NEXT_PUBLIC_USE_MOCK=true` env switch in `frontend/lib/contracts.ts` routes `getInvoice()` to the local json-server.

**#230** — Admin-configurable grace period per invoice
- `grace_period_override: Option<u32>` field added to `Invoice` struct.
- `set_invoice_grace_period(admin, id, days)` admin function with Funded-status guard, 30-day cap, and `gp_upd` event.
- `get_invoice_grace_period(id)` read accessor.
- `mark_defaulted()` now prefers the per-invoice override over global `GracePeriodDays`.
- Four unit tests: override used, fallback to global, cap exceeded panics, non-admin panics.

**#231** — GitHub issue and PR templates
- `bug_report.yml` + `feature_request.yml` — structured YAML forms with required fields, component/network dropdowns, on-chain fields.
- `config.yml` — `blank_issues_enabled: true`, Discussions and security contacts.
- PR template — type-of-change checkboxes and full contributor checklist.

Closes #228
Closes #229
Closes #230
Closes #231