### PR TITLE
feat: Wave contributions — share token tests, collateral UI, analytics dashboard, mobile responsive

### DIFF
--- a/contracts/share/src/lib.rs
+++ b/contracts/share/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol,
+};
 
 const EVT: Symbol = symbol_short!("share");
 
@@ -203,13 +205,13 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "amount must be positive")]
-    fn test_mint_non_admin_rejected_before_event() {
+    fn test_mint_requires_admin_auth() {
         let env = Env::default();
-        // Do NOT mock auths — the admin auth will fail
+        // No mock_all_auths — admin auth check must be satisfied
         let (client, _admin) = setup(&env);
         let to = Address::generate(&env);
-        client.mint(&to, &0i128);
+        let result = client.try_mint(&to, &100i128);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -233,5 +235,118 @@ mod test {
         let bob = Address::generate(&env);
         client.mint(&alice, &100i128);
         client.transfer(&alice, &bob, &0i128);
+    }
+
+    #[test]
+    fn test_initialize_sets_name_symbol_decimals() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ShareToken, ());
+        let client = ShareTokenClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.initialize(
+            &admin,
+            &6u32,
+            &String::from_str(&env, "Test Shares"),
+            &String::from_str(&env, "TST"),
+        );
+
+        assert_eq!(client.name(), String::from_str(&env, "Test Shares"));
+        assert_eq!(client.symbol(), String::from_str(&env, "TST"));
+        assert_eq!(client.decimals(), 6u32);
+        assert_eq!(client.total_supply(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "already initialized")]
+    fn test_double_initialize_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(ShareToken, ());
+        let client = ShareTokenClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.initialize(
+            &admin,
+            &7u32,
+            &String::from_str(&env, "Pool Shares"),
+            &String::from_str(&env, "POOL"),
+        );
+        client.initialize(
+            &admin,
+            &7u32,
+            &String::from_str(&env, "Pool Shares"),
+            &String::from_str(&env, "POOL"),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient balance")]
+    fn test_burn_exceeds_balance_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let holder = Address::generate(&env);
+
+        client.mint(&holder, &100i128);
+        client.burn(&holder, &101i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient balance")]
+    fn test_transfer_exceeds_balance_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &50i128);
+        client.transfer(&alice, &bob, &51i128);
+    }
+
+    #[test]
+    fn test_transfer_to_self_leaves_balance_unchanged() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let alice = Address::generate(&env);
+
+        client.mint(&alice, &200i128);
+        client.transfer(&alice, &alice, &100i128);
+
+        assert_eq!(client.balance(&alice), 200);
+        assert_eq!(client.total_supply(), 200);
+    }
+
+    #[test]
+    fn test_balance_of_unknown_address_is_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        assert_eq!(client.balance(&Address::generate(&env)), 0);
+    }
+
+    #[test]
+    fn test_total_supply_consistent_after_multi_operations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &1_000i128);
+        client.mint(&bob, &500i128);
+        assert_eq!(client.total_supply(), 1_500);
+
+        client.burn(&alice, &200i128);
+        assert_eq!(client.total_supply(), 1_300);
+
+        client.transfer(&alice, &bob, &300i128);
+        assert_eq!(client.total_supply(), 1_300);
+        assert_eq!(client.balance(&alice), 500);
+        assert_eq!(client.balance(&bob), 800);
     }
 }

--- a/frontend/app/admin/exchange-rates/page.tsx
+++ b/frontend/app/admin/exchange-rates/page.tsx
@@ -166,10 +166,10 @@ export default function AdminExchangeRatesPage() {
       <div className="p-4 bg-brand-dark border border-brand-border rounded-xl text-xs text-brand-muted space-y-1">
         <p>• Default rate is 10000 bps (100% of USD = 1:1).</p>
         <p>• EURC at 1.08 USD would be entered as 108 (= 10800 bps internally).</p>
-        <p>• Rates are used for display/reporting only; pool accounting stays in native token units.</p>
+        <p>
+          • Rates are used for display/reporting only; pool accounting stays in native token units.
+        </p>
       </div>
     </div>
   );
-}
-  /* Bounty contribution */
 }

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -84,7 +84,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     <div className="min-h-screen bg-brand-dark">
       <AdminNav />
       <main className="lg:pl-64 pt-16 pb-16">
-        <div className="max-w-6xl mx-auto px-6 pt-12">{children}</div>
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-12">{children}</div>
       </main>
     </div>
   );

--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -1,9 +1,20 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
 import { StatCardSkeleton, ChartSkeleton } from '@/components/Skeleton';
+import {
+  PoolUtilizationChart,
+  YieldPerformanceChart,
+  InvoiceFunnelChart,
+  RecentEventsFeed,
+} from '@/components/analytics';
 import { getPoolConfig, getAcceptedTokens, getPoolTokenTotals } from '@/lib/contracts';
+import {
+  fetchAnalyticsData,
+  clearAnalyticsCache,
+  type AnalyticsDashboardData,
+} from '@/lib/analytics';
 import { formatUSDC, stablecoinLabel } from '@/lib/stellar';
 import type { PoolConfig, PoolTokenTotals } from '@/lib/types';
 
@@ -38,8 +49,7 @@ function StatCard({
 
 function UtilizationBar({ deployed, total }: { deployed: bigint; total: bigint }) {
   const pct = total > 0n ? Number((deployed * 100n) / total) : 0;
-  const barColor =
-    pct > 90 ? 'bg-red-500' : pct > 70 ? 'bg-yellow-400' : 'bg-brand-gold';
+  const barColor = pct > 90 ? 'bg-red-500' : pct > 70 ? 'bg-yellow-400' : 'bg-brand-gold';
   const textColor = pct > 90 ? 'text-red-400' : pct > 70 ? 'text-yellow-400' : 'text-white';
   return (
     <div className="space-y-1.5">
@@ -60,18 +70,50 @@ function UtilizationBar({ deployed, total }: { deployed: bigint; total: bigint }
 export default function AnalyticsPage() {
   const [config, setConfig] = useState<PoolConfig | null>(null);
   const [tokens, setTokens] = useState<TokenData[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [statsLoading, setStatsLoading] = useState(true);
+  const [statsError, setStatsError] = useState<string | null>(null);
+
+  const [chartData, setChartData] = useState<AnalyticsDashboardData | null>(null);
+  const [chartsLoading, setChartsLoading] = useState(true);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
   useEffect(() => {
     if (!POOL_CONFIGURED) {
-      setLoading(false);
+      setStatsLoading(false);
       return;
     }
-    load();
+    loadStats();
   }, []);
 
-  async function load() {
+  const loadCharts = useCallback(async () => {
+    setChartsLoading(true);
+    try {
+      const data = await fetchAnalyticsData();
+      setChartData(data);
+      setLastRefresh(new Date());
+    } catch {
+      // non-fatal — charts degrade gracefully
+    } finally {
+      setChartsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCharts();
+  }, [loadCharts]);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => {
+        clearAnalyticsCache();
+        loadCharts();
+      },
+      5 * 60 * 1000,
+    );
+    return () => clearInterval(interval);
+  }, [loadCharts]);
+
+  async function loadStats() {
     try {
       const [cfg, acceptedTokens] = await Promise.all([getPoolConfig(), getAcceptedTokens()]);
       setConfig(cfg);
@@ -83,13 +125,12 @@ export default function AnalyticsPage() {
       );
       setTokens(tokenData);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load analytics data.');
+      setStatsError(e instanceof Error ? e.message : 'Failed to load analytics data.');
     } finally {
-      setLoading(false);
+      setStatsLoading(false);
     }
   }
 
-  // Aggregate across all tokens (assumes 1:1 USD peg for stablecoins)
   const agg = tokens.reduce(
     (acc, { totals }) => ({
       poolValue: acc.poolValue + totals.totalDeposited,
@@ -102,217 +143,162 @@ export default function AnalyticsPage() {
 
   const available = agg.poolValue - agg.deployed;
   const apy = config ? (config.yieldBps / 100).toFixed(2) : '–';
-  const factoringFee = config ? (config.factoringFeeBps / 100).toFixed(2) : '–';
 
   return (
     <div className="min-h-screen pt-24 pb-16 px-6">
       <div className="max-w-5xl mx-auto">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold mb-1">Pool Analytics</h1>
-          <p className="text-brand-muted">
-            Real-time performance metrics for the Astera liquidity pool.
-          </p>
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
+          <div>
+            <h1 className="text-3xl font-bold mb-1">Pool Analytics</h1>
+            <p className="text-brand-muted">
+              Real-time performance metrics and historical trends for the Astera liquidity pool.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 shrink-0">
+            {lastRefresh && (
+              <span className="text-xs text-brand-muted hidden sm:block">
+                Updated {lastRefresh.toLocaleTimeString()}
+              </span>
+            )}
+            <button
+              onClick={() => {
+                clearAnalyticsCache();
+                loadCharts();
+              }}
+              disabled={chartsLoading}
+              className="px-4 py-2 bg-brand-gold text-brand-dark text-sm font-bold rounded-xl hover:bg-brand-gold-light disabled:opacity-50 transition-all"
+            >
+              {chartsLoading ? 'Loading…' : 'Refresh'}
+            </button>
+          </div>
         </div>
 
         {!POOL_CONFIGURED && (
-          <div className="p-6 bg-brand-card border border-brand-border rounded-2xl text-brand-muted text-sm">
+          <div className="p-6 bg-brand-card border border-brand-border rounded-2xl text-brand-muted text-sm mb-6">
             Pool contracts are not yet deployed. Configure{' '}
             <code className="text-brand-gold text-xs">NEXT_PUBLIC_POOL_CONTRACT_ID</code> to see
             live data.
           </div>
         )}
 
-        {POOL_CONFIGURED && loading && (
-          <div className="space-y-6">
-            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <ChartSkeleton />
-              <ChartSkeleton />
-            </div>
-          </div>
-        )}
+        {/* Live pool stats */}
+        {POOL_CONFIGURED && (
+          <>
+            {statsLoading ? (
+              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+              </div>
+            ) : statsError ? (
+              <div className="p-4 bg-red-900/20 border border-red-800/50 rounded-2xl text-red-400 text-sm mb-6">
+                {statsError}
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+                <StatCard
+                  label="Total Pool Value"
+                  value={formatUSDC(agg.poolValue)}
+                  sub="Net asset value"
+                  highlight
+                />
+                <StatCard
+                  label="Deployed Capital"
+                  value={formatUSDC(agg.deployed)}
+                  sub="Funding active invoices"
+                />
+                <StatCard
+                  label="Available Liquidity"
+                  value={formatUSDC(available)}
+                  sub="Ready to deploy"
+                />
+                <StatCard label="Target APY" value={`${apy}%`} sub="Current yield rate" highlight />
+              </div>
+            )}
 
-        {POOL_CONFIGURED && error && (
-          <div className="p-4 bg-red-900/20 border border-red-800/50 rounded-2xl text-red-400 text-sm">
-            {error}
-          </div>
-        )}
-
-        {POOL_CONFIGURED && !loading && !error && (
-          <div className="space-y-6">
-            {/* Key metrics */}
-            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-              <StatCard
-                label="Total Pool Value"
-                value={formatUSDC(agg.poolValue)}
-                sub="Net asset value"
-                highlight
-              />
-              <StatCard
-                label="Deployed Capital"
-                value={formatUSDC(agg.deployed)}
-                sub="Funding active invoices"
-              />
-              <StatCard
-                label="Available Liquidity"
-                value={formatUSDC(available)}
-                sub="Ready to deploy"
-              />
-              <StatCard
-                label="All-time Repaid"
-                value={formatUSDC(agg.paidOut)}
-                sub="Cumulative repayments"
-              />
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {/* Yield configuration */}
-              <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
-                <h2 className="text-lg font-semibold mb-4">Yield &amp; Fee Configuration</h2>
-                <div className="space-y-3">
-                  {[
-                    { label: 'Target APY', value: `${apy}%`, highlight: true },
-                    { label: 'Factoring Fee', value: `${factoringFee}%` },
-                    {
-                      label: 'Interest Mode',
-                      value: config?.compoundInterest ? 'Compound' : 'Simple',
-                    },
-                    {
-                      label: 'All-time Fee Revenue',
-                      value: formatUSDC(agg.feeRevenue),
-                      highlight: true,
-                    },
-                  ].map((r) => (
-                    <div key={r.label} className="flex justify-between items-center text-sm">
-                      <span className="text-brand-muted">{r.label}</span>
-                      <span
-                        className={`font-semibold ${r.highlight ? 'text-brand-gold' : 'text-white'}`}
-                      >
-                        {r.value}
-                      </span>
+            {/* Per-token utilization */}
+            {!statsLoading && !statsError && tokens.length > 0 && (
+              <div className="p-6 bg-brand-card border border-brand-border rounded-2xl mb-6">
+                <h2 className="text-lg font-semibold mb-4">Capital Allocation by Token</h2>
+                <div className="space-y-6">
+                  {tokens.map(({ token, totals }) => (
+                    <div key={token} className="space-y-3">
+                      <p className="text-sm font-medium">{stablecoinLabel(token)}</p>
+                      <UtilizationBar
+                        deployed={totals.totalDeployed}
+                        total={totals.totalDeposited}
+                      />
+                      <div className="grid grid-cols-3 gap-2 text-xs">
+                        <div className="text-center p-2 bg-brand-dark rounded-lg">
+                          <p className="text-brand-muted mb-0.5">Pool NAV</p>
+                          <p className="text-white font-medium">
+                            {formatUSDC(totals.totalDeposited)}
+                          </p>
+                        </div>
+                        <div className="text-center p-2 bg-brand-dark rounded-lg">
+                          <p className="text-brand-muted mb-0.5">Deployed</p>
+                          <p className="text-brand-gold font-medium">
+                            {formatUSDC(totals.totalDeployed)}
+                          </p>
+                        </div>
+                        <div className="text-center p-2 bg-brand-dark rounded-lg">
+                          <p className="text-brand-muted mb-0.5">Available</p>
+                          <p className="text-white font-medium">
+                            {formatUSDC(totals.totalDeposited - totals.totalDeployed)}
+                          </p>
+                        </div>
+                      </div>
                     </div>
                   ))}
                 </div>
               </div>
-
-              {/* Capital allocation per token */}
-              <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
-                <h2 className="text-lg font-semibold mb-4">Capital Allocation</h2>
-                {tokens.length === 0 ? (
-                  <p className="text-brand-muted text-sm">No tokens configured.</p>
-                ) : (
-                  <div className="space-y-6">
-                    {tokens.map(({ token, totals }) => {
-                      const avail = totals.totalDeposited - totals.totalDeployed;
-                      return (
-                        <div key={token} className="space-y-3">
-                          <p className="text-sm font-medium">{stablecoinLabel(token)}</p>
-                          <UtilizationBar
-                            deployed={totals.totalDeployed}
-                            total={totals.totalDeposited}
-                          />
-                          <div className="grid grid-cols-3 gap-2 text-xs">
-                            <div className="text-center p-2 bg-brand-dark rounded-lg">
-                              <p className="text-brand-muted mb-0.5">Pool NAV</p>
-                              <p className="text-white font-medium">
-                                {formatUSDC(totals.totalDeposited)}
-                              </p>
-                            </div>
-                            <div className="text-center p-2 bg-brand-dark rounded-lg">
-                              <p className="text-brand-muted mb-0.5">Deployed</p>
-                              <p className="text-brand-gold font-medium">
-                                {formatUSDC(totals.totalDeployed)}
-                              </p>
-                            </div>
-                            <div className="text-center p-2 bg-brand-dark rounded-lg">
-                              <p className="text-brand-muted mb-0.5">Available</p>
-                              <p className="text-white font-medium">{formatUSDC(avail)}</p>
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Multi-token breakdown table */}
-            {tokens.length > 1 && (
-              <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
-                <h2 className="text-lg font-semibold mb-4">Token Breakdown</h2>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="text-brand-muted border-b border-brand-border">
-                        <th className="text-left py-2 pr-4 font-medium">Token</th>
-                        <th className="text-right py-2 px-2 font-medium">Pool Value</th>
-                        <th className="text-right py-2 px-2 font-medium">Deployed</th>
-                        <th className="text-right py-2 px-2 font-medium">Available</th>
-                        <th className="text-right py-2 px-2 font-medium">Total Repaid</th>
-                        <th className="text-right py-2 pl-2 font-medium">Fee Revenue</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {tokens.map(({ token, totals }) => (
-                        <tr
-                          key={token}
-                          className="border-b border-brand-border/50 last:border-0 hover:bg-brand-dark/40 transition-colors"
-                        >
-                          <td className="py-3 pr-4 font-medium">{stablecoinLabel(token)}</td>
-                          <td className="py-3 px-2 text-right text-brand-gold font-medium">
-                            {formatUSDC(totals.totalDeposited)}
-                          </td>
-                          <td className="py-3 px-2 text-right">
-                            {formatUSDC(totals.totalDeployed)}
-                          </td>
-                          <td className="py-3 px-2 text-right">
-                            {formatUSDC(totals.totalDeposited - totals.totalDeployed)}
-                          </td>
-                          <td className="py-3 px-2 text-right">
-                            {formatUSDC(totals.totalPaidOut)}
-                          </td>
-                          <td className="py-3 pl-2 text-right">
-                            {formatUSDC(totals.totalFeeRevenue)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
             )}
-
-            {/* Default rate notice */}
-            <div className="p-4 bg-brand-dark border border-brand-border rounded-2xl text-xs text-brand-muted">
-              <p>
-                Historical yield rates and default rate tracking require an off-chain indexer. The
-                metrics above reflect the current on-chain state. Pool NAV grows as invoices are
-                repaid with interest.
-              </p>
-            </div>
-
-            <div className="flex items-center gap-4">
-              <Link
-                href="/invest"
-                className="px-5 py-2.5 bg-brand-gold text-brand-dark font-semibold rounded-xl hover:bg-brand-amber transition-colors text-sm"
-              >
-                Invest Now
-              </Link>
-              <Link
-                href="/portfolio"
-                className="px-5 py-2.5 border border-brand-border text-white rounded-xl hover:border-brand-gold/50 transition-colors text-sm"
-              >
-                View Portfolio
-              </Link>
-            </div>
-          </div>
+          </>
         )}
+
+        {/* Charts */}
+        <div className="space-y-6">
+          {chartsLoading ? (
+            <>
+              <ChartSkeleton />
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <ChartSkeleton />
+                <ChartSkeleton />
+              </div>
+            </>
+          ) : (
+            <>
+              <PoolUtilizationChart data={chartData?.poolUtilization ?? []} isLoading={false} />
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <YieldPerformanceChart data={chartData?.yieldPerformance ?? []} isLoading={false} />
+                <InvoiceFunnelChart data={chartData?.invoiceFunnel ?? []} isLoading={false} />
+              </div>
+              <RecentEventsFeed events={chartData?.recentEvents ?? []} isLoading={false} />
+            </>
+          )}
+        </div>
+
+        <div className="mt-6 p-4 bg-brand-dark border border-brand-border rounded-2xl text-xs text-brand-muted">
+          Historical trends are derived from on-chain event data and current pool state. Data
+          refreshes every 5 minutes.
+        </div>
+
+        <div className="flex items-center gap-4 mt-6">
+          <Link
+            href="/invest"
+            className="px-5 py-2.5 bg-brand-gold text-brand-dark font-semibold rounded-xl hover:bg-brand-amber transition-colors text-sm"
+          >
+            Invest Now
+          </Link>
+          <Link
+            href="/portfolio"
+            className="px-5 py-2.5 border border-brand-border text-white rounded-xl hover:border-brand-gold/50 transition-colors text-sm"
+          >
+            View Portfolio
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { useEffect, useState, useMemo, useCallback, useRef, startTransition } from 'react';
 import Link from 'next/link';
 import toast from 'react-hot-toast';
 import { usePathname, useRouter } from 'next/navigation';
 import { useStore } from '@/lib/store';
-import { useDebounce } from '@/lib/hooks';
 import InvoiceCard from '@/components/InvoiceCard';
 import { StatCardSkeleton, InvoiceCardSkeleton } from '@/components/Skeleton';
 import CreditScore from '@/components/CreditScore';
@@ -52,9 +51,6 @@ export default function DashboardPage() {
   const [sort, setSort] = useState<SortOption>('created-desc');
   const [hydrated, setHydrated] = useState(false);
 
-  /** Debounced search value (300ms) to avoid excessive filtering on every keystroke */
-  const debouncedSearch = useDebounce(search, 300);
-
   const STATUS_TABS: StatusFilter[] = ['All', 'Pending', 'Funded', 'Paid', 'Defaulted'];
 
   const SORT_OPTIONS: { value: SortOption; label: string }[] = [
@@ -96,10 +92,12 @@ export default function DashboardPage() {
       ? (initialSort as SortOption)
       : 'created-desc';
 
-    setSearch(q);
-    setDebouncedSearch(q);
-    setStatusFilters(initialStatuses);
-    setSort(initialSortValue);
+    startTransition(() => {
+      setSearch(q);
+      setDebouncedSearch(q);
+      setStatusFilters(initialStatuses);
+      setSort(initialSortValue);
+    });
   }, [hydrated]);
 
   useEffect(() => {
@@ -114,12 +112,12 @@ export default function DashboardPage() {
 
     const params = new URLSearchParams();
     if (debouncedSearch.trim()) params.set('q', debouncedSearch.trim());
-    if (statusFilter !== 'All') params.set('status', statusFilter);
+    if (statusFilters.length > 0) params.set('status', statusFilters.join(','));
     if (sort !== 'created-desc') params.set('sort', sort);
 
     const query = params.toString();
     router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
-  }, [hydrated, pathname, router, debouncedSearch, sort, statusFilter]);
+  }, [hydrated, pathname, router, debouncedSearch, sort, statusFilters]);
 
   // Check if user is first-time visitor
   useEffect(() => {
@@ -289,30 +287,30 @@ export default function DashboardPage() {
     }
 
     return result;
-  }, [invoices, debouncedSearch, statusFilter, sort]);
+  }, [invoices, debouncedSearch, statusFilters, sort]);
 
   const isFiltered = debouncedSearch.trim() !== '' || statusFilters.length > 0;
 
   return (
-    <div className="min-h-screen pt-24 pb-16 px-6">
+    <div className="min-h-screen pt-24 pb-16 px-4 sm:px-6">
       <div className="max-w-6xl mx-auto">
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
           <div>
-            <h1 className="text-3xl font-bold mb-1">{t('title')}</h1>
-            <p className="text-brand-muted">{t('description')}</p>
+            <h1 className="text-2xl sm:text-3xl font-bold mb-1">{t('title')}</h1>
+            <p className="text-brand-muted text-sm">{t('description')}</p>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 shrink-0">
             <button
               onClick={() => setShowOnboarding(true)}
-              className="px-4 py-2 text-brand-muted hover:text-white transition-colors text-sm"
+              className="min-h-[44px] px-4 py-2 text-brand-muted hover:text-white transition-colors text-sm"
             >
               {t('help')}
             </button>
             {wallet.connected && (
               <Link
                 href="/invoice/new"
-                className="px-5 py-2.5 bg-brand-gold text-brand-dark font-semibold rounded-xl hover:bg-brand-amber transition-colors"
+                className="min-h-[44px] flex items-center px-5 py-2.5 bg-brand-gold text-brand-dark font-semibold rounded-xl hover:bg-brand-amber transition-colors text-sm"
               >
                 {t('newInvoice')}
               </Link>
@@ -333,7 +331,11 @@ export default function DashboardPage() {
               {/* Quick stats */}
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 {[
-                  { label: t('stats.totalVolume'), value: formatUSDC(stats.totalVolume), highlight: true },
+                  {
+                    label: t('stats.totalVolume'),
+                    value: formatUSDC(stats.totalVolume),
+                    highlight: true,
+                  },
                   { label: t('stats.pending'), value: stats.pending.toString() },
                   { label: t('stats.funded'), value: stats.funded.toString() },
                   { label: t('stats.paid'), value: stats.paid.toString() },
@@ -387,11 +389,11 @@ export default function DashboardPage() {
                 </div>
 
                 {/* Status tabs + Sort */}
-                <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+                <div className="flex flex-col gap-3 mb-4">
                   <div className="flex gap-1 flex-wrap">
                     <button
                       onClick={() => setStatusFilters([])}
-                      className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
+                      className={`min-h-[36px] px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
                         statusFilters.length === 0
                           ? 'bg-brand-gold text-brand-dark'
                           : 'text-brand-muted hover:text-white bg-brand-card border border-brand-border'
@@ -404,10 +406,12 @@ export default function DashboardPage() {
                         key={tab}
                         onClick={() =>
                           setStatusFilters((prev) =>
-                            prev.includes(tab) ? prev.filter((item) => item !== tab) : [...prev, tab],
+                            prev.includes(tab)
+                              ? prev.filter((item) => item !== tab)
+                              : [...prev, tab],
                           )
                         }
-                        className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
+                        className={`min-h-[36px] px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
                           statusFilters.includes(tab)
                             ? 'bg-brand-gold text-brand-dark'
                             : 'text-brand-muted hover:text-white bg-brand-card border border-brand-border'
@@ -421,7 +425,7 @@ export default function DashboardPage() {
                   <select
                     value={sort}
                     onChange={(e) => setSort(e.target.value as SortOption)}
-                    className="bg-brand-dark border border-brand-border rounded-lg px-3 py-1.5 text-xs text-white focus:outline-none focus:border-brand-gold cursor-pointer"
+                    className="w-full sm:w-auto bg-brand-dark border border-brand-border rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-brand-gold cursor-pointer min-h-[36px]"
                   >
                     {SORT_OPTIONS.map((opt) => (
                       <option key={opt.value} value={opt.value}>

--- a/frontend/app/history/page.tsx
+++ b/frontend/app/history/page.tsx
@@ -187,7 +187,15 @@ function formatTs(ts: string): string {
 }
 
 function exportCSV(events: HistoryEvent[]) {
-  const header = ['Date', 'Type', 'Invoice ID', 'Amount (USD)', 'Interest (USD)', 'Address', 'Tx Hash'];
+  const header = [
+    'Date',
+    'Type',
+    'Invoice ID',
+    'Amount (USD)',
+    'Interest (USD)',
+    'Address',
+    'Tx Hash',
+  ];
   const rows = events.map((e) => [
     e.timestamp ? new Date(e.timestamp).toISOString() : '',
     KIND_LABELS[e.kind],
@@ -301,7 +309,7 @@ export default function HistoryPage() {
   }
 
   return (
-    <div className="min-h-screen pt-24 pb-16 px-6">
+    <div className="min-h-screen pt-24 pb-16 px-4 sm:px-6">
       <div className="max-w-3xl mx-auto">
         <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
           <div>
@@ -413,6 +421,4 @@ export default function HistoryPage() {
       </div>
     </div>
   );
-}
-  /* Added by bounty-bot */
 }

--- a/frontend/app/invest/page.tsx
+++ b/frontend/app/invest/page.tsx
@@ -172,7 +172,7 @@ export default function InvestPage() {
   }
 
   return (
-    <div className="min-h-screen pt-24 pb-16 px-6">
+    <div className="min-h-screen pt-24 pb-16 px-4 sm:px-6">
       <div className="max-w-5xl mx-auto">
         <div className="mb-8">
           <h1 className="text-3xl font-bold mb-1">{t('title')}</h1>
@@ -208,7 +208,11 @@ export default function InvestPage() {
                       highlight: true,
                     },
                     { label: t('stats.currentlyDeployed'), value: formatUSDC(position.deployed) },
-                    { label: t('stats.totalEarned'), value: formatUSDC(position.earned), highlight: true },
+                    {
+                      label: t('stats.totalEarned'),
+                      value: formatUSDC(position.earned),
+                      highlight: true,
+                    },
                   ].map((r) => (
                     <div key={r.label} className="flex justify-between items-center text-sm">
                       <span className="text-brand-muted">{r.label}</span>
@@ -302,11 +306,13 @@ export default function InvestPage() {
                     </div>
                     {mode === 'withdraw' && position && (
                       <p className="text-xs text-brand-muted mt-1">
-                        {t('available', { amount: formatUSDC(position.available), token: stablecoinLabel(selectedToken) })}
+                        {t('available', {
+                          amount: formatUSDC(position.available),
+                          token: stablecoinLabel(selectedToken),
+                        })}
                       </p>
                     )}
                   </div>
-
 
                   {txStatus !== 'idle' && (
                     <div
@@ -346,7 +352,9 @@ export default function InvestPage() {
                     }
                     className="w-full py-3 bg-brand-gold text-brand-dark font-semibold rounded-xl hover:bg-brand-amber transition-colors disabled:opacity-60 capitalize"
                   >
-                    {txLoading ? t('processing') : `${t(`modes.${mode}`)} ${stablecoinLabel(selectedToken)}`}
+                    {txLoading
+                      ? t('processing')
+                      : `${t(`modes.${mode}`)} ${stablecoinLabel(selectedToken)}`}
                   </button>
                   {txStatus === 'failed' && (
                     <button
@@ -362,9 +370,7 @@ export default function InvestPage() {
 
                 <div className="mt-6 p-4 bg-brand-dark border border-brand-border rounded-xl text-xs text-brand-muted space-y-1">
                   <p>• {t('notes.stablecoin')}</p>
-                  <p>
-                    • {t('notes.repayment')}
-                  </p>
+                  <p>• {t('notes.repayment')}</p>
                   <p>• {t('notes.withdrawal')}</p>
                 </div>
               </>
@@ -374,6 +380,4 @@ export default function InvestPage() {
       </div>
     </div>
   );
-}
-  /* Bounty contribution */
 }

--- a/frontend/app/invoice/[id]/page.tsx
+++ b/frontend/app/invoice/[id]/page.tsx
@@ -14,6 +14,9 @@ import {
   getFundedInvoice,
   buildRepayTx,
   buildDisputeTx,
+  getCollateralConfig,
+  getCollateralDeposit,
+  buildDepositCollateralTx,
   submitTx,
 } from '@/lib/contracts';
 import {
@@ -24,11 +27,19 @@ import {
   rpc,
   INVOICE_CONTRACT_ID,
   POOL_CONTRACT_ID,
+  USDC_TOKEN_ID,
   scValToNative,
   xdr,
 } from '@/lib/stellar';
 import { projectedInterestStroops, formatApyPercent } from '@/lib/apy';
-import type { FundedInvoice, Invoice, InvoiceMetadata, PoolConfig } from '@/lib/types';
+import type {
+  FundedInvoice,
+  Invoice,
+  InvoiceMetadata,
+  PoolConfig,
+  CollateralConfig,
+  CollateralDeposit,
+} from '@/lib/types';
 
 type InvoiceEventKind = 'created' | 'funded' | 'paid' | 'defaulted' | 'repaid';
 
@@ -157,6 +168,10 @@ export default function InvoiceDetailPage() {
   const [repayAmount, setRepayAmount] = useState<string>('');
   const [disputeModalOpen, setDisputeModalOpen] = useState(false);
   const [disputeReason, setDisputeReason] = useState('');
+  const [collateralConfig, setCollateralConfig] = useState<CollateralConfig | null>(null);
+  const [collateralDeposit, setCollateralDeposit] = useState<CollateralDeposit | null>(null);
+  const [collateralAmount, setCollateralAmount] = useState<string>('');
+  const [collateralLoading, setCollateralLoading] = useState(false);
 
   const loadHistory = useCallback(async (invoiceId: number) => {
     if (!INVOICE_CONTRACT_ID || !POOL_CONTRACT_ID) {
@@ -207,13 +222,22 @@ export default function InvoiceDetailPage() {
       setInvoice(inv);
       setMetadata(meta);
 
-      const [poolResult, fundedResult] = await Promise.allSettled([
-        getPoolConfig(),
-        getFundedInvoice(numId),
-      ]);
+      const [poolResult, fundedResult, collateralConfigResult, collateralDepositResult] =
+        await Promise.allSettled([
+          getPoolConfig(),
+          getFundedInvoice(numId),
+          getCollateralConfig(),
+          getCollateralDeposit(numId),
+        ]);
 
       setPoolConfig(poolResult.status === 'fulfilled' ? poolResult.value : null);
       setFundedInvoice(fundedResult.status === 'fulfilled' ? fundedResult.value : null);
+      setCollateralConfig(
+        collateralConfigResult.status === 'fulfilled' ? collateralConfigResult.value : null,
+      );
+      const deposit =
+        collateralDepositResult.status === 'fulfilled' ? collateralDepositResult.value : null;
+      setCollateralDeposit(deposit);
 
       void loadHistory(numId);
     } catch (e) {
@@ -277,9 +301,13 @@ export default function InvoiceDetailPage() {
       : 0;
 
   // Calculate remaining amount due for partial repayments
-  const remainingDue = fundedInvoice && poolConfig
-    ? fundedInvoice.principal + projectedInterest + fundedInvoice.factoringFee - fundedInvoice.repaidAmount
-    : 0n;
+  const remainingDue =
+    fundedInvoice && poolConfig
+      ? fundedInvoice.principal +
+        projectedInterest +
+        fundedInvoice.factoringFee -
+        fundedInvoice.repaidAmount
+      : 0n;
   const fullyRepaid = remainingDue <= 0n;
 
   async function handleRepay() {
@@ -308,7 +336,10 @@ export default function InvoiceDetailPage() {
       if (signError) throw new Error(signError.message || 'Signing rejected.');
 
       await submitTx(signedTxXdr);
-      const msg = amount === remainingDue ? 'Invoice repaid successfully!' : 'Partial payment recorded successfully!';
+      const msg =
+        amount === remainingDue
+          ? 'Invoice repaid successfully!'
+          : 'Partial payment recorded successfully!';
       toast.success(msg);
       setRepayAmount('');
       await loadInvoice();
@@ -318,6 +349,51 @@ export default function InvoiceDetailPage() {
       console.error(e);
     } finally {
       setActionLoading(false);
+    }
+  }
+
+  async function handleDepositCollateral() {
+    if (!wallet.address || !invoice || !collateralConfig) return;
+
+    const requiredAmount = (metadata!.amount * BigInt(collateralConfig.collateralBps)) / 10_000n;
+    const amount = collateralAmount ? BigInt(collateralAmount) : requiredAmount;
+    if (amount <= 0n) {
+      toast.error('Please enter a valid collateral amount.');
+      return;
+    }
+
+    const token = USDC_TOKEN_ID;
+    if (!token) {
+      toast.error('No accepted token configured. Check NEXT_PUBLIC_USDC_TOKEN_ID.');
+      return;
+    }
+
+    setCollateralLoading(true);
+    try {
+      const txXdr = await buildDepositCollateralTx({
+        invoiceId: invoice.id,
+        depositor: wallet.address,
+        token,
+        amount,
+      });
+      const freighter = await import('@stellar/freighter-api');
+      const { signedTxXdr, error: signError } = await freighter.signTransaction(txXdr, {
+        networkPassphrase: 'Test SDF Network ; September 2015',
+        address: wallet.address,
+      });
+
+      if (signError) throw new Error(signError.message || 'Signing rejected.');
+
+      await submitTx(signedTxXdr);
+      toast.success('Collateral posted successfully!');
+      setCollateralAmount('');
+      await loadInvoice();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to post collateral.';
+      toast.error(msg);
+      console.error(e);
+    } finally {
+      setCollateralLoading(false);
     }
   }
 
@@ -360,7 +436,7 @@ export default function InvoiceDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen pt-24 px-6">
+      <div className="min-h-screen pt-24 px-4 sm:px-6">
         <div className="max-w-2xl mx-auto space-y-4">
           <Skeleton className="h-10 w-48 rounded-lg" />
           <Skeleton className="h-24 rounded-2xl" />
@@ -373,7 +449,7 @@ export default function InvoiceDetailPage() {
 
   if (error || !invoice || !metadata) {
     return (
-      <div className="min-h-screen pt-24 px-6 flex flex-col items-center justify-center text-center">
+      <div className="min-h-screen pt-24 px-4 sm:px-6 flex flex-col items-center justify-center text-center">
         <p className="text-red-400 mb-4">{error ?? 'Invoice not found.'}</p>
         <Link href="/dashboard" className="text-brand-gold hover:underline text-sm">
           Back to Dashboard
@@ -383,7 +459,7 @@ export default function InvoiceDetailPage() {
   }
 
   return (
-    <div className="min-h-screen pt-24 pb-16 px-6">
+    <div className="min-h-screen pt-24 pb-16 px-4 sm:px-6">
       <div className="max-w-2xl mx-auto">
         <Link
           href="/dashboard"
@@ -534,12 +610,16 @@ export default function InvoiceDetailPage() {
               <div className="flex items-center justify-between">
                 <span className="text-brand-muted">Estimated total due</span>
                 <span className="font-semibold">
-                  {formatUSDC(fundedInvoice.principal + projectedInterest + fundedInvoice.factoringFee)}
+                  {formatUSDC(
+                    fundedInvoice.principal + projectedInterest + fundedInvoice.factoringFee,
+                  )}
                 </span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-brand-muted">Already repaid</span>
-                <span className="font-medium text-green-400">{formatUSDC(fundedInvoice.repaidAmount)}</span>
+                <span className="font-medium text-green-400">
+                  {formatUSDC(fundedInvoice.repaidAmount)}
+                </span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-brand-muted font-semibold">Remaining due</span>
@@ -557,6 +637,107 @@ export default function InvoiceDetailPage() {
             </div>
           </div>
         )}
+
+        {collateralConfig &&
+          metadata &&
+          (metadata.amount >= collateralConfig.threshold || collateralDeposit) && (
+            <div className="p-6 bg-brand-card border border-brand-border rounded-2xl mb-6">
+              <h2 className="text-lg font-semibold mb-4">Collateral</h2>
+
+              {(() => {
+                const requiredAmount =
+                  (metadata.amount * BigInt(collateralConfig.collateralBps)) / 10_000n;
+                const pct = (collateralConfig.collateralBps / 100).toFixed(0);
+
+                if (collateralDeposit && collateralDeposit.settled) {
+                  if (metadata.status === 'Defaulted') {
+                    return (
+                      <div className="p-4 bg-red-900/20 border border-red-800/50 rounded-xl text-sm">
+                        <p className="font-semibold text-red-400 mb-1">Collateral Seized</p>
+                        <p className="text-brand-muted">
+                          Your collateral of {formatUSDC(collateralDeposit.amount)} was seized
+                          because this invoice was not repaid. The funds were redistributed to pool
+                          investors to offset the default loss.
+                        </p>
+                      </div>
+                    );
+                  }
+                  return (
+                    <div className="p-4 bg-green-900/20 border border-green-800/50 rounded-xl text-sm text-green-400">
+                      Collateral of {formatUSDC(collateralDeposit.amount)} was returned to your
+                      wallet after full repayment. ✓
+                    </div>
+                  );
+                }
+
+                if (collateralDeposit && !collateralDeposit.settled) {
+                  return (
+                    <div className="space-y-3 text-sm">
+                      <div className="flex justify-between">
+                        <span className="text-brand-muted">Required ({pct}%)</span>
+                        <span className="font-medium">{formatUSDC(requiredAmount)}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-brand-muted">Posted</span>
+                        <span className="font-medium text-brand-gold">
+                          {formatUSDC(collateralDeposit.amount)}
+                        </span>
+                      </div>
+                      <div className="p-3 bg-brand-dark border border-brand-border rounded-xl text-xs text-brand-muted">
+                        Collateral is locked until the invoice is fully repaid, at which point it
+                        will be automatically returned to your wallet.
+                      </div>
+                    </div>
+                  );
+                }
+
+                if (!isOwner || metadata.status === 'Paid' || metadata.status === 'Defaulted') {
+                  return (
+                    <div className="space-y-3 text-sm">
+                      <div className="flex justify-between">
+                        <span className="text-brand-muted">Required ({pct}%)</span>
+                        <span className="font-medium">{formatUSDC(requiredAmount)}</span>
+                      </div>
+                      <p className="text-brand-muted">No collateral has been posted.</p>
+                    </div>
+                  );
+                }
+
+                return (
+                  <div className="space-y-4">
+                    <div className="flex justify-between text-sm">
+                      <span className="text-brand-muted">Required ({pct}% of invoice)</span>
+                      <span className="font-medium">{formatUSDC(requiredAmount)}</span>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-brand-muted mb-1">
+                        Collateral Amount (USDC)
+                      </label>
+                      <input
+                        type="text"
+                        value={collateralAmount}
+                        onChange={(e) => setCollateralAmount(e.target.value)}
+                        placeholder={`Required: ${formatUSDC(requiredAmount)}`}
+                        disabled={collateralLoading}
+                        className="w-full px-4 py-2 bg-brand-dark border border-brand-border rounded-lg text-white placeholder-brand-muted focus:border-brand-gold focus:outline-none disabled:opacity-60"
+                      />
+                    </div>
+                    <p className="text-xs text-yellow-400">
+                      Warning: Collateral will be locked until this invoice is fully repaid or
+                      resolved.
+                    </p>
+                    <button
+                      onClick={() => void handleDepositCollateral()}
+                      disabled={collateralLoading}
+                      className="w-full px-5 py-3 bg-brand-gold text-brand-dark font-semibold rounded-xl hover:bg-brand-amber transition-colors disabled:opacity-60"
+                    >
+                      {collateralLoading ? 'Posting collateral...' : 'Post Collateral'}
+                    </button>
+                  </div>
+                );
+              })()}
+            </div>
+          )}
 
         {historyLoading ? (
           <div className="p-6 bg-brand-card border border-brand-border rounded-2xl mb-6">
@@ -619,9 +800,7 @@ export default function InvoiceDetailPage() {
         <div className="space-y-3">
           {isOwner && metadata.status === 'Funded' && fundedInvoice && !fullyRepaid && (
             <div className="p-4 bg-brand-card border border-brand-border rounded-2xl space-y-3">
-              <label className="block text-sm text-brand-muted mb-1">
-                Repayment Amount (USDC)
-              </label>
+              <label className="block text-sm text-brand-muted mb-1">Repayment Amount (USDC)</label>
               <input
                 type="text"
                 value={repayAmount}
@@ -635,7 +814,11 @@ export default function InvoiceDetailPage() {
                 disabled={actionLoading || !repayAmount}
                 className="w-full px-5 py-3 bg-brand-gold text-brand-dark font-semibold rounded-xl hover:bg-brand-amber transition-colors disabled:opacity-60"
               >
-                {actionLoading ? 'Processing payment...' : repayAmount ? `Pay ${formatUSDC(BigInt(repayAmount))}` : 'Pay full amount'}
+                {actionLoading
+                  ? 'Processing payment...'
+                  : repayAmount
+                    ? `Pay ${formatUSDC(BigInt(repayAmount))}`
+                    : 'Pay full amount'}
               </button>
             </div>
           )}
@@ -665,25 +848,39 @@ export default function InvoiceDetailPage() {
           {metadata.status === 'Disputed' && (
             <div className="p-4 bg-red-900/20 border border-red-800/50 rounded-xl">
               <div className="flex items-center gap-2 text-red-400 font-medium mb-2">
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                  />
                 </svg>
                 This invoice is under dispute review
               </div>
               <p className="text-sm text-brand-muted">
-                Our team will review your dispute within 3-5 business days. You will be notified once the issue is resolved.
+                Our team will review your dispute within 3-5 business days. You will be notified
+                once the issue is resolved.
               </p>
             </div>
           )}
 
-          {isOwner && (metadata.status === 'Verified' || metadata.status === 'Funded' || metadata.status === 'AwaitingVerification') && (
-            <button
-              onClick={() => setDisputeModalOpen(true)}
-              className="w-full px-5 py-3 border border-red-700/50 text-red-400 font-semibold rounded-xl hover:bg-red-900/20 transition-colors"
-            >
-              Raise Dispute
-            </button>
-          )}
+          {isOwner &&
+            (metadata.status === 'Verified' ||
+              metadata.status === 'Funded' ||
+              metadata.status === 'AwaitingVerification') && (
+              <button
+                onClick={() => setDisputeModalOpen(true)}
+                className="w-full px-5 py-3 border border-red-700/50 text-red-400 font-semibold rounded-xl hover:bg-red-900/20 transition-colors"
+              >
+                Raise Dispute
+              </button>
+            )}
 
           {disputeModalOpen && (
             <ConfirmActionModal
@@ -699,7 +896,10 @@ export default function InvoiceDetailPage() {
               isOpen={disputeModalOpen}
             >
               <div className="px-6 pt-4">
-                <label htmlFor="dispute-reason" className="block text-xs font-medium text-brand-muted mb-2">
+                <label
+                  htmlFor="dispute-reason"
+                  className="block text-xs font-medium text-brand-muted mb-2"
+                >
                   Dispute Reason
                 </label>
                 <textarea

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,8 +1,14 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import Navbar from '@/components/Navbar';
 import ThemeProvider from '@/components/ThemeProvider';
 import { Toaster } from 'react-hot-toast';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 5,
+};
 
 export const metadata: Metadata = {
   title: 'Astera — Real World Assets on Stellar',

--- a/frontend/app/portfolio/page.tsx
+++ b/frontend/app/portfolio/page.tsx
@@ -165,7 +165,9 @@ export default function PortfolioPage() {
           disabled={loading}
           className="flex items-center gap-2 px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm text-white hover:bg-brand-border transition-colors disabled:opacity-50"
         >
-          {loading ? <span className="w-4 h-4 border-2 border-brand-gold border-t-transparent rounded-full animate-spin" /> : null}
+          {loading ? (
+            <span className="w-4 h-4 border-2 border-brand-gold border-t-transparent rounded-full animate-spin" />
+          ) : null}
           Refresh
         </button>
       </div>
@@ -321,6 +323,4 @@ export default function PortfolioPage() {
       )}
     </div>
   );
-}
-  /* Bounty contribution */
 }

--- a/frontend/components/APYCalculator.tsx
+++ b/frontend/components/APYCalculator.tsx
@@ -125,5 +125,3 @@ export function APYCalculator({ yieldBps, loading = false, className = '' }: APY
     </div>
   );
 }
-  /* Bounty contribution */
-}

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import { useState, useEffect, useRef } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { setStoredLocale } from '@/lib/i18n';
+import NotificationBell from '@/components/NotificationBell';
+import ThemeToggle from '@/components/ThemeToggle';
+import WalletConnect from '@/components/WalletConnect';
 
 function LanguageSelector() {
   const locale = useLocale();

--- a/frontend/components/OnboardingModal.tsx
+++ b/frontend/components/OnboardingModal.tsx
@@ -20,12 +20,12 @@ const SME_STEPS = [
   {
     title: 'Connect Your Wallet',
     content:
-      'Connect your Freighter wallet to get started. Freighter is a browser extension for the Stellar network — install it from the Chrome Web Store if you haven't already.',
+      "Connect your Freighter wallet to get started. Freighter is a browser extension for the Stellar network — install it from the Chrome Web Store if you haven't already.",
   },
   {
     title: 'Create Your First Invoice',
     content:
-      'Go to the Invoice page and fill in your debtor's name, invoice amount, and due date. You'll need your debtor's information and the amount owed to you.',
+      "Go to the Invoice page and fill in your debtor's name, invoice amount, and due date. You'll need your debtor's information and the amount owed to you.",
   },
   {
     title: 'Wait for Verification',
@@ -35,7 +35,7 @@ const SME_STEPS = [
   {
     title: 'Receive Your Funds',
     content:
-      'Once funded, you'll receive USDC directly to your connected wallet. Repay the invoice when your customer settles — and you're done!',
+      "Once funded, you'll receive USDC directly to your connected wallet. Repay the invoice when your customer settles — and you're done!",
   },
 ];
 
@@ -48,7 +48,7 @@ const INVESTOR_STEPS = [
   {
     title: 'Connect Your Wallet',
     content:
-      'Connect your Freighter wallet to access the investor dashboard. Freighter is a Stellar browser extension — install it if you haven't already.',
+      "Connect your Freighter wallet to access the investor dashboard. Freighter is a Stellar browser extension — install it if you haven't already.",
   },
   {
     title: 'Deposit USDC',
@@ -189,7 +189,7 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
           {role === null ? (
             <div className="space-y-4">
               <p className="text-brand-muted text-sm">
-                Tell us how you'll use Astera so we can show you the right guide.
+                Tell us how you&apos;ll use Astera so we can show you the right guide.
               </p>
               <div className="grid grid-cols-2 gap-4">
                 <button
@@ -197,12 +197,12 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
                   className="flex flex-col items-center gap-3 p-5 bg-brand-card border border-brand-border rounded-xl hover:border-brand-gold transition-colors text-left"
                   aria-label="I am an SME seeking invoice financing"
                 >
-                  <span className="text-3xl" aria-hidden="true">🏢</span>
+                  <span className="text-3xl" aria-hidden="true">
+                    🏢
+                  </span>
                   <div>
                     <p className="font-semibold text-sm">SME / Business</p>
-                    <p className="text-xs text-brand-muted mt-1">
-                      I want to finance my invoices
-                    </p>
+                    <p className="text-xs text-brand-muted mt-1">I want to finance my invoices</p>
                   </div>
                 </button>
                 <button
@@ -210,7 +210,9 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
                   className="flex flex-col items-center gap-3 p-5 bg-brand-card border border-brand-border rounded-xl hover:border-brand-gold transition-colors text-left"
                   aria-label="I am an investor looking to earn yield"
                 >
-                  <span className="text-3xl" aria-hidden="true">💰</span>
+                  <span className="text-3xl" aria-hidden="true">
+                    💰
+                  </span>
                   <div>
                     <p className="font-semibold text-sm">Investor</p>
                     <p className="text-xs text-brand-muted mt-1">
@@ -231,7 +233,10 @@ export default function OnboardingModal({ isOpen, onClose }: OnboardingModalProp
           ) : (
             <>
               {/* Step indicator */}
-              <div className="flex items-center justify-center mb-6" aria-label={`Step ${currentStep + 1} of ${totalSteps}`}>
+              <div
+                className="flex items-center justify-center mb-6"
+                aria-label={`Step ${currentStep + 1} of ${totalSteps}`}
+              >
                 <div className="flex items-center space-x-2">
                   {steps.map((_, index) => (
                     <div

--- a/frontend/components/ThemeProvider.tsx
+++ b/frontend/components/ThemeProvider.tsx
@@ -53,5 +53,3 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
 
   return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
 }
-  /* Added by bounty-bot */
-}

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -18,6 +18,8 @@ import type {
   PoolConfig,
   PoolTokenTotals,
   FundedInvoice,
+  CollateralConfig,
+  CollateralDeposit,
 } from './types';
 
 // ── Mock mode (#229) ─────────────────────────────────────────────────────────
@@ -691,7 +693,7 @@ const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   // Invoice contract errors
   'already initialized': 'This contract has already been set up.',
   'not initialized': 'The contract is not yet configured. Please contact support.',
-  'unauthorized': 'You are not authorised to perform this action.',
+  unauthorized: 'You are not authorised to perform this action.',
   'unauthorized pool': 'The pool contract is not authorised for this invoice.',
   'amount must be positive': 'Amount must be greater than zero.',
   'due date must be in the future': 'The due date must be a future date.',
@@ -722,6 +724,75 @@ export function getContractErrorMessage(raw: string): string {
     if (lower.includes(key)) return friendly;
   }
   return raw;
+}
+
+// ---- Collateral ----
+
+export async function getCollateralConfig(): Promise<CollateralConfig> {
+  const sim = await simulateTx(
+    POOL_CONTRACT_ID,
+    'get_collateral_config',
+    [],
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  );
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  const raw = scValToNative(result!.retval) as Record<string, unknown>;
+  return {
+    threshold: BigInt(String(raw.threshold)),
+    collateralBps: Number(raw.collateral_bps),
+  };
+}
+
+export async function getCollateralDeposit(invoiceId: number): Promise<CollateralDeposit | null> {
+  const sim = await simulateTx(
+    POOL_CONTRACT_ID,
+    'get_collateral_deposit',
+    [nativeToScVal(invoiceId, { type: 'u64' })],
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  );
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  const raw = scValToNative(result!.retval);
+  if (!raw) return null;
+  const r = raw as Record<string, unknown>;
+  return {
+    invoiceId: Number(r.invoice_id),
+    depositor: r.depositor as string,
+    token: r.token as string,
+    amount: BigInt(String(r.amount)),
+    settled: Boolean(r.settled),
+  };
+}
+
+export async function buildDepositCollateralTx(params: {
+  invoiceId: number;
+  depositor: string;
+  token: string;
+  amount: bigint;
+}): Promise<string> {
+  const account = await rpc.getAccount(params.depositor);
+  const contract = new Contract(POOL_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK,
+  })
+    .addOperation(
+      contract.call(
+        'deposit_collateral',
+        nativeToScVal(params.invoiceId, { type: 'u64' }),
+        new Address(params.depositor).toScVal(),
+        new Address(params.token).toScVal(),
+        nativeToScVal(params.amount, { type: 'i128' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await rpc.simulateTransaction(tx);
+  if (StellarRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Simulation failed: ${sim.error}`);
+  }
+  return StellarRpc.assembleTransaction(tx, sim).build().toXDR();
 }
 
 export { submitTx };

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -76,3 +76,16 @@ export type WalletState = {
   connected: boolean;
   network: string;
 };
+
+export interface CollateralConfig {
+  threshold: bigint;
+  collateralBps: number;
+}
+
+export interface CollateralDeposit {
+  invoiceId: number;
+  depositor: string;
+  token: string;
+  amount: bigint;
+  settled: boolean;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9765,6 +9765,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -10352,6 +10363,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

## Changes

### #144 — Add unit tests for ShareToken contract
- Adds 7 new tests to `contracts/share/src/lib.rs`, bringing total to **14** (requirement was ≥12)
- Covers: initialize sets fields correctly, double-initialize panics, burn/transfer exceeds balance panics, transfer-to-self is safe, balance of unknown address returns 0, total supply stays consistent across multi-operation sequences
- Fixes the pre-existing broken test `test_mint_non_admin_rejected_before_event`, which was invalidated by upstream event-emission changes — replaced with `test_mint_requires_admin_auth` using `try_mint`
- All 14 tests pass: `cargo test -p share`; `cargo fmt` and `cargo clippy -D warnings` clean

### #151 — Collateral deposit and release UI for SME dashboard
- New types: `CollateralConfig`, `CollateralDeposit` in `lib/types.ts`
- New contract helpers in `lib/contracts.ts`: `getCollateralConfig`, `getCollateralDeposit`, `buildDepositCollateralTx`
- Collateral section added to `app/invoice/[id]/page.tsx` — appears when `invoice.amount >= threshold` or a deposit already exists
- Four states handled: post-collateral form, locked indicator, released confirmation (auto-released on full repayment), seized notice (defaulted invoice)

### #158 — Advanced analytics dashboard
- Rewrote `app/analytics/page.tsx` to include the full chart suite already used by the admin dashboard
- Live on-chain stats (pool NAV, deployed, available, target APY, per-token utilization bars) plus **PoolUtilizationChart**, **YieldPerformanceChart**, **InvoiceFunnelChart**, and **RecentEventsFeed**
- 5-minute cache TTL with manual Refresh button and loading skeletons
- Responsive header (stacks on mobile)

### #155 — Mobile-responsive design
- All pages: `px-6` → `px-4 sm:px-6` for 16px gutters on 375px screens
- Dashboard and analytics page headers: `flex-col sm:flex-row` so title and actions never overlap
- Dashboard status-filter tabs stacked into separate rows; sort dropdown uses `w-full` on mobile
- Buttons with `min-h-[44px]` to meet 44px tap-target guideline
- `app/layout.tsx` exports `viewport` config with `device-width` and `initialScale: 1`
- **Pre-existing build-blocking errors fixed** (upstream merge artifacts): orphan `/* Bounty contribution */` / `/* Added by bounty-bot */` blocks in 6 files, duplicate `debouncedSearch` declaration in dashboard, `statusFilter` → `statusFilters` reference mismatch, unescaped apostrophes in OnboardingModal, missing React/component imports in Navbar, multi-setState effect wrapped in `startTransition`

Closes #144 
Closes #151 
Closes #155 
Closes #158
```