### PR TITLE
ci: add changelog, release workflow, and PR title enforcement

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,49 @@
+name: PR Title Format
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pr:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            style
+            ci
+            build
+            perf
+            revert
+          scopes: |
+            invoice
+            pool
+            credit_score
+            share
+            frontend
+            contracts
+            sdk
+            mock-service
+            docs
+            ci
+            deps
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject must not start with an uppercase character.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    name: Generate Release Notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: CHANGES.md
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- PR title format enforcement via `amannn/action-semantic-pull-request@v5`.
+- Automated release notes generation on tag push via `git-cliff`.
+- `CHANGELOG.md` following Keep a Changelog format.
+
+## [0.5.0] - 2026-04-27
+
+### Added
+- Minimum deposit requirements for pool investors.
+- Revenue tracking and yield distribution improvements.
+- Withdrawal limits for investor positions.
+- Co-fund share transfer functionality.
+- Invoice dispute UI with CSV import and PDF export.
+- Real-time validation on invoice creation form.
+- Explorer links for on-chain transactions.
+- Mock service for local development and testing.
+- Grace period override for invoice default marking.
+- GitHub issue and pull request templates.
+- Local development setup guide.
+
+### Changed
+- Replaced `unwrap`/`panic` with structured `PoolError` across pool contract.
+- Improved event emission for pool operations and collateral updates.
+
+### Fixed
+- Multiple bounty contributions addressing issues #201, #203, #205, #238, #246.
+
+## [0.4.0] - 2026-04-26
+
+### Added
+- Analytics dashboard for SMEs and investors.
+- SSE Events polling service for real-time contract updates.
+- Emergency pause functionality for critical contract operations.
+- Grace period before marking invoices as defaulted.
+- Access control for invoice status transitions.
+- Reentrancy guard on pool contract.
+- ConfirmActionModal for destructive admin actions.
+- Invoice search and filter functionality on the dashboard.
+- Role-based 5-step onboarding tour for SMEs and investors.
+- `/api/health` monitoring endpoint with alert rules and webhook.
+- Reward-per-share yield distribution and `claim_yield`.
+- Error code namespaces for contracts and frontend error mapping.
+
+## [0.3.0] - 2026-04-23
+
+### Added
+- Theme toggle, improved wallet UX, portfolio dashboard, and invoice notifications.
+- Fuzz testing, integration tests, gas optimizations, and grace period logic.
+- Multi-currency support, KYC whitelist, transaction export, and property-based tests.
+- Collateral requirement enforcement for high-value invoices.
+- Batch operations and dashboard detail improvements.
+- Invoice expiration after configurable unfunded duration.
+- Configurable maximum invoice amount enforcement.
+- Yield change cooldown and maximum step controls.
+- Technical architecture documentation.
+- API reference documentation for contract methods.
+
+### Fixed
+- Resolved issues #56, #61, #64, and #114.
+
+## [0.2.0] - 2026-04-02
+
+### Added
+- Complete dispute resolution and reconciliation protocol.
+- Circuit breaker pattern for emergency protocol shutdown.
+- Invoice factoring fee structure.
+- Investor share token mechanics.
+- On-chain credit scoring mechanism calculated from repayment history.
+- Docker-based development environment.
+- Storage optimization ADR and oracle environment configuration.
+
+## [0.1.0] - 2026-03-25
+
+### Added
+- Initial Rust workspace with Soroban resolver and core smart contracts (invoice, pool, credit_score, share).
+- Frontend Next.js 14 scaffold with Stellar SDK, TypeScript, and Tailwind CSS.
+- Landing page with hero section, stats, feature grid, and how-it-works.
+- SME dashboard with invoice list, quick stats, and credit score panel.
+- Investor page with pool overview, deposit, and withdraw flows.
+- Invoice creation form with mint preview and cost estimate.
+- Invoice detail page with status timeline and owner actions.
+- WalletConnect component with Freighter API integration.
+- PoolStats component with utilization bar and APY display.
+- CreditScore component calculated from invoice repayment history.
+- InvoiceCard component with status badges and due date countdown.
+- Partial invoice co-funding by multiple investors.
+- Transaction history page with on-chain event logs.
+- Mobile-responsive navigation drawer.
+- Search, filter, and sort on SME dashboard.
+- ESLint, Prettier, and Husky for frontend code quality.
+- Next.js v15 upgrade, stellar-sdk v14, and freighter-api v6 compatibility.
+- README with project overview, setup guide, and deployment instructions.
+- Contributing guidelines.
+
+[Unreleased]: https://github.com/astera-hq/Astera/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/astera-hq/Astera/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/astera-hq/Astera/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/astera-hq/Astera/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/astera-hq/Astera/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/astera-hq/Astera/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,10 @@ Where the `type` is one of:
 | `refactor` | Non-functional code changes |
 | `test` | Adding or updating tests |
 | `style` | Formatting, whitespace (no logic changes) |
+| `ci` | CI/CD changes |
+| `build` | Build system changes |
+| `perf` | Performance improvements |
+| `revert` | Revert previous changes |
 
 Examples:
 
@@ -199,6 +203,12 @@ fix(pool): resolve withdraw edge case
 docs: update API endpoint details
 test(pool): add co-funding edge case tests
 ```
+
+## 📋 Changelog
+
+This project maintains a `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Releases are versioned using [Semantic Versioning](https://semver.org/spec/v2.0.0.html). When opening a PR that introduces a user-facing change, please ensure the change is reflected in the `Unreleased` section of `CHANGELOG.md` under the appropriate category (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`).
+
+Release notes are generated automatically from conventional commits using `git-cliff` when a version tag (`v*`) is pushed.
 
 ---
 
@@ -231,9 +241,11 @@ Before opening a PR, make sure you:
 - [ ] Code is formatted consistently (`cargo fmt`, Prettier)
 - [ ] Linting passes (`cargo clippy`, `npm run lint`)
 - [ ] Commit messages follow Conventional Commits
+- [ ] PR title follows the `type(scope): description` format
 - [ ] PR description clearly explains the change
 - [ ] New public contract functions include tests
 - [ ] No secrets or `.env.local` committed
+- [ ] `CHANGELOG.md` updated under the `Unreleased` section if the change is user-facing
 
 ### PR Description Template
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,49 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\n"
+body = """
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_preprocessors = [
+  { pattern = "\\(([^)]+)\\)!", replace = "(breaking: ${1})" },
+]
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^style", group = "Changed" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^perf", group = "Performance" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore\\(deps\\)", group = "Dependencies" },
+  { message = "^chore", group = "Changed" },
+  { message = "^ci", group = "CI" },
+  { message = "^build", group = "Build" },
+  { message = "^revert", group = "Reverted" },
+  { message = ".*", group = "Changed" },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"


### PR DESCRIPTION
## Summary

This PR adds automated changelog and release management to the CI pipeline, along with PR title format enforcement.

## Related Issue

Closes #234

## Changes
- Added `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, retrospectively filled for the last 5 inferred releases.
- Added `.github/workflows/release.yml` to automatically generate release notes on `v*` tag pushes using `git-cliff`.
- Added `.github/workflows/pr-title.yml` to enforce [Conventional Commits](https://www.conventionalcommits.org/) PR titles via `amannn/action-semantic-pull-request@v5`.
- Added `cliff.toml` configuration for `git-cliff` to generate release notes from conventional commits.
- Updated `CONTRIBUTING.md` with changelog guidelines, expanded commit type list, and a PR checklist item for changelog updates.

## Testing
- Verified `git-cliff --config cliff.toml` runs locally without errors.
- Validated YAML syntax for both workflow files.
- Confirmed PR title action supports all commit types and scopes used in the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)