### PR TITLE
feat: add credit score improvement tips and recommendations UI for SM…

### DIFF
--- a/frontend/__tests__/components/CreditScore.test.tsx
+++ b/frontend/__tests__/components/CreditScore.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CreditScore from '@/components/CreditScore';
 
@@ -30,5 +30,37 @@ describe('CreditScore', () => {
   it('surfaces the total invoice count in the summary line', () => {
     render(<CreditScore paid={2} funded={1} defaulted={1} totalVolume={0n} />);
     expect(screen.getByText(/Based on 4 invoice\(s\)/)).toBeInTheDocument();
+  });
+
+  it('renders the collapsed improvement panel by default', () => {
+    render(<CreditScore paid={3} funded={0} defaulted={2} totalVolume={0n} />);
+    expect(screen.getByText('Improve your score')).toBeInTheDocument();
+    expect(screen.queryByText('Current Stats vs. Recommendations')).not.toBeInTheDocument();
+  });
+
+  it('expands the improvement panel when toggled', () => {
+    render(<CreditScore paid={3} funded={0} defaulted={2} totalVolume={0n} />);
+    fireEvent.click(screen.getByText('Improve your score'));
+    expect(screen.getByText('Current Stats vs. Recommendations')).toBeInTheDocument();
+  });
+
+  it('shows at least 3 actionable recommendations when expanded', () => {
+    render(<CreditScore paid={3} funded={0} defaulted={2} totalVolume={0n} />);
+    fireEvent.click(screen.getByText('Improve your score'));
+    expect(screen.getByText('On-time payments')).toBeInTheDocument();
+    expect(screen.getByText('Defaults')).toBeInTheDocument();
+    expect(screen.getByText('Payment speed')).toBeInTheDocument();
+    expect(screen.getByText('Invoice volume')).toBeInTheDocument();
+  });
+
+  it('shows the next milestone when not at the top tier', () => {
+    render(<CreditScore paid={3} funded={0} defaulted={2} totalVolume={0n} />);
+    fireEvent.click(screen.getByText('Improve your score'));
+    expect(screen.getByText(/Next Milestone:/)).toBeInTheDocument();
+  });
+
+  it('shows points to next tier in progress bar', () => {
+    render(<CreditScore paid={3} funded={0} defaulted={2} totalVolume={0n} />);
+    expect(screen.getByText(/pts to/)).toBeInTheDocument();
   });
 });

--- a/frontend/components/CreditScore.tsx
+++ b/frontend/components/CreditScore.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 interface PaymentRecord {
   invoiceId: number;
@@ -20,6 +20,28 @@ interface Props {
   previousScore?: number;
 }
 
+const SCORE_TIERS = [
+  { name: 'Very Poor', min: 200 },
+  { name: 'Poor', min: 500 },
+  { name: 'Fair', min: 580 },
+  { name: 'Good', min: 670 },
+  { name: 'Very Good', min: 740 },
+  { name: 'Excellent', min: 800 },
+];
+
+const PTS_PAID_ON_TIME = 30;
+const PTS_PAID_LATE = 15;
+const PTS_DEFAULTED = 50;
+const PTS_NEW_INVOICE = 5;
+
+const TIER_BENEFITS: Record<string, string> = {
+  Poor: 'Unlock basic funding limits ($5,000 per invoice)',
+  Fair: 'Increase per-invoice limit to $10,000 and reduce factoring fees',
+  Good: 'Unlock higher funding limits ($25,000) and preferential fee tiers',
+  'Very Good': 'Access premium funding ($50,000+) and lowest factoring fees',
+  Excellent: 'Maximum funding limits and exclusive pool access',
+};
+
 export default function CreditScore({
   paid,
   funded,
@@ -29,10 +51,10 @@ export default function CreditScore({
   previousScore,
 }: Props) {
   const total = paid + funded + defaulted;
+  const [showImprovement, setShowImprovement] = useState(false);
 
-  // Simple score: 300–850 based on repayment rate and volume
   const repaymentRate = total > 0 ? paid / total : 0;
-  const volumeBonus = Math.min(Number(totalVolume) / 1e10, 50); // up to 50 pts
+  const volumeBonus = Math.min(Number(totalVolume) / 1e10, 50);
   const score = Math.round(300 + repaymentRate * 500 + volumeBonus);
 
   const scoreChange = previousScore ? score - previousScore : null;
@@ -41,7 +63,7 @@ export default function CreditScore({
   const scoreLabel =
     score >= 750 ? 'Excellent' : score >= 650 ? 'Good' : score >= 550 ? 'Fair' : 'Building';
 
-  const arc = Math.round(((score - 300) / 550) * 180); // 0–180 degrees
+  const arc = Math.round(((score - 300) / 550) * 180);
 
   const avgPaymentDays = useMemo(() => {
     if (paymentHistory.length === 0) return 0;
@@ -54,6 +76,84 @@ export default function CreditScore({
     }, 0);
     return Math.round(totalDays / onTimePaid.length);
   }, [paymentHistory]);
+
+  const nextTier = useMemo(() => {
+    for (const tier of SCORE_TIERS) {
+      if (score < tier.min) {
+        return tier;
+      }
+    }
+    return null;
+  }, [score]);
+
+  const currentTier = useMemo(() => {
+    let tier = SCORE_TIERS[0];
+    for (const t of SCORE_TIERS) {
+      if (score >= t.min) {
+        tier = t;
+      }
+    }
+    return tier;
+  }, [score]);
+
+  const pointsToNext = nextTier ? nextTier.min - score : 0;
+
+  const recommendations = useMemo(() => {
+    const recs: { factor: string; stat: string; impact: string; tip: string }[] = [];
+
+    const onTimeRate = total > 0 ? paid / total : 0;
+    recs.push({
+      factor: 'On-time payments',
+      stat: `${paid}/${total} (${Math.round(onTimeRate * 100)}%)`,
+      impact: 'High',
+      tip:
+        onTimeRate < 0.8
+          ? `Pay your next ${Math.ceil((0.8 * total - paid))} invoices on time to reach Good tier`
+          : 'Keep up the great on-time payment record',
+    });
+
+    recs.push({
+      factor: 'Defaults',
+      stat: defaulted > 0 ? `${defaulted} default${defaulted > 1 ? 's' : ''}` : 'None',
+      impact: 'High',
+      tip:
+        defaulted > 0
+          ? 'Avoid defaults — each costs 50 points'
+          : 'No defaults — maintain this record',
+    });
+
+    const lateCount = paymentHistory.filter((p) => p.status === 'Late').length;
+    recs.push({
+      factor: 'Payment speed',
+      stat:
+        avgPaymentDays > 0
+          ? avgPaymentDays > 0
+            ? `Avg ${avgPaymentDays} days ${avgPaymentDays > 0 ? 'late' : 'early'}`
+            : 'N/A'
+          : lateCount > 0
+            ? `${lateCount} late payment(s)`
+            : 'No data',
+      impact: 'Medium',
+      tip:
+        avgPaymentDays > 0
+          ? 'Try to pay within the due date to boost your score'
+          : 'Pay invoices as early as possible for maximum points',
+    });
+
+    recs.push({
+      factor: 'Invoice volume',
+      stat: `${total} total`,
+      impact: 'Low',
+      tip:
+        total < 5
+          ? `Create ${5 - total} more invoices to build history faster (+${PTS_NEW_INVOICE} pts at 5 invoices)`
+          : total < 10
+            ? 'Reach 10 invoices for another score bonus'
+            : 'Strong invoice history — keep building',
+    });
+
+    return recs;
+  }, [paid, defaulted, total, avgPaymentDays, paymentHistory]);
 
   return (
     <div className="space-y-6">
@@ -104,6 +204,127 @@ export default function CreditScore({
           <p className="text-center text-brand-muted text-sm mt-4">
             Create and repay invoices to build your score.
           </p>
+        )}
+
+        {/* Score Tier Progress Bar */}
+        {nextTier && (
+          <div className="mt-6 pt-6 border-t border-brand-border">
+            <div className="flex justify-between text-xs text-brand-muted mb-2">
+              <span>
+                {currentTier.name} ({score})
+              </span>
+              <span>
+                {nextTier.name} ({nextTier.min})
+              </span>
+            </div>
+            <div className="relative h-3 bg-brand-border rounded-full overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-brand-border to-green-500 rounded-full transition-all"
+                style={{
+                  width: `${
+                    ((score - currentTier.min) / (nextTier.min - currentTier.min)) * 100
+                  }%`,
+                }}
+              />
+              <div
+                className="absolute top-0 h-full w-0.5 bg-white/50"
+                style={{
+                  left: `${
+                    ((score - currentTier.min) / (nextTier.min - currentTier.min)) * 100
+                  }%`,
+                }}
+              />
+            </div>
+            <div className="text-xs text-brand-muted mt-2 text-center">
+              {pointsToNext} pts to {nextTier.name}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Score Improvement Panel (collapsed by default) */}
+      <div className="bg-brand-card border border-brand-border rounded-2xl overflow-hidden">
+        <button
+          onClick={() => setShowImprovement(!showImprovement)}
+          className="w-full p-6 text-left flex items-center justify-between hover:bg-brand-border/20 transition"
+        >
+          <h3 className="text-lg font-semibold">Improve your score</h3>
+          <svg
+            className={`w-5 h-5 text-brand-muted transition-transform ${
+              showImprovement ? 'rotate-180' : ''
+            }`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {showImprovement && (
+          <div className="px-6 pb-6 space-y-6">
+            {/* Score Breakdown Table */}
+            <div>
+              <h4 className="text-sm font-semibold text-brand-muted uppercase tracking-wider mb-3">
+                Current Stats vs. Recommendations
+              </h4>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-brand-border">
+                      <th className="text-left text-brand-muted py-2 px-2">Factor</th>
+                      <th className="text-left text-brand-muted py-2 px-2">Your Stats</th>
+                      <th className="text-left text-brand-muted py-2 px-2">Impact</th>
+                      <th className="text-left text-brand-muted py-2 px-2">Tip</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recommendations.map((rec, i) => (
+                      <tr key={i} className="border-b border-brand-border/50">
+                        <td className="py-3 px-2 font-medium">{rec.factor}</td>
+                        <td className="py-3 px-2 text-brand-muted">{rec.stat}</td>
+                        <td className="py-3 px-2">
+                          <span
+                            className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+                              rec.impact === 'High'
+                                ? 'bg-red-500/20 text-red-400'
+                                : rec.impact === 'Medium'
+                                  ? 'bg-yellow-500/20 text-yellow-400'
+                                  : 'bg-blue-500/20 text-blue-400'
+                            }`}
+                          >
+                            {rec.impact}
+                          </span>
+                        </td>
+                        <td className="py-3 px-2 text-brand-muted text-xs">{rec.tip}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Next Milestone */}
+            {nextTier && (
+              <div className="p-4 bg-brand-border/30 rounded-xl">
+                <h4 className="text-sm font-semibold mb-2">Next Milestone: {nextTier.name}</h4>
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="text-2xl font-bold">{nextTier.min}</div>
+                  <div className="text-xs text-brand-muted">
+                    {pointsToNext} points away
+                  </div>
+                </div>
+                <p className="text-sm text-brand-muted">
+                  {TIER_BENEFITS[nextTier.name] || 'Unlock new benefits at this tier'}
+                </p>
+                {pointsToNext <= PTS_PAID_ON_TIME * 2 && (
+                  <p className="text-sm text-green-400 mt-2">
+                    Pay {Math.ceil(pointsToNext / PTS_PAID_ON_TIME)} more invoice{Math.ceil(pointsToNext / PTS_PAID_ON_TIME) > 1 ? 's' : ''} on time (+{Math.ceil(pointsToNext / PTS_PAID_ON_TIME) * PTS_PAID_ON_TIME} pts) to reach {nextTier.name} tier and {TIER_BENEFITS[nextTier.name]?.toLowerCase()}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
Closes #276

## Summary
Extends the `CreditScore` component with an actionable improvement panel 
that helps SMEs understand their score and what steps to take next.

## Changes
- `frontend/components/CreditScore.tsx` — added score breakdown panel, 
  progress bar, recommendations table, and next milestone card
- `frontend/components/CreditScore.test.tsx` — added tests for new panel

## Acceptance Criteria
- [x] Score breakdown panel shows current stats with context (4 factors: on-time payments, defaults, payment speed, invoice volume)
- [x] Progress bar shows distance to next tier using contract constants from `lib.rs`
- [x] At least 3 actionable recommendations shown (4 displayed deterministically from payment history)
- [x] Next milestone benefit clearly described (funding limits, fee tiers, points away)
- [x] Panel collapsed by default with "Improve your score ▼" toggle

## Type of Change
- [x] New feature

## How to Test
1. Open the SME dashboard and view the credit score component
2. Click "Improve your score ▼" — panel should expand
3. Verify breakdown table shows 4 factors with Impact badges and Tips
4. Verify progress bar shows current position between tiers
5. Verify next milestone card shows target score and benefits

## Checklist
- [x] Self-reviewed my own code
- [x] No `console.log` or debug code left in
- [x] Branch is up to date with `main`