### PR TITLE
docs(#273): add cross-contract authorization matrix and annotations

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,8 @@ All smart contracts follow these security practices:
 
 ### Access Control Matrix
 
+> See the full [Authorization Matrix](./docs/authorization-matrix.md) for a complete cross-contract call table and auditor checklist.
+
 | Operation | Invoice Contract | Pool Contract | Credit Score |
 |-----------|-----------------|---------------|--------------|
 | Initialize | Admin | Admin | Admin |

--- a/contracts/credit_score/src/lib.rs
+++ b/contracts/credit_score/src/lib.rs
@@ -1,5 +1,10 @@
 #![no_std]
 
+// === AUTHORIZED CALLERS ===
+// - Admin: initialize(), admin-only setters
+// - Pool contract: record_payment(), record_default() (pool address stored in config)
+// - Anyone: view functions (get_credit_score)
+
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String, Symbol, Vec,
 };

--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -1,5 +1,11 @@
 #![no_std]
 
+// === AUTHORIZED CALLERS ===
+// - Admin: initialize(), admin-only setters
+// - Pool contract: mark_funded(), mark_paid(), mark_defaulted()
+// - Oracle: mark_verified(), mark_disputed()
+// - Anyone: read-only view functions (e.g., get_invoice)
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, String,
     Symbol, Vec,

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -1,3 +1,9 @@
+// === AUTHORIZED CALLERS ===
+// - Admin: pause(), unpause(), set_yield(), add_token(), admin-only setters
+// - Pool contract: N/A (this is the pool contract)
+// - Invoice contract: may call pool for state reads
+// - Anyone: public view functions
+
 // IMPLEMENTATION APPROACH for #222 - Pool Token Removal Safety Checks
 //
 // RECON FINDINGS:

--- a/docs/authorization-matrix.md
+++ b/docs/authorization-matrix.md
@@ -1,0 +1,59 @@
+# Authorization Matrix — Cross-Contract Call Matrix
+
+This document summarizes which contracts (or external actors) are authorized to call specific entry points in other contracts. It is intended for auditors, contributors, and operators to verify access control policies quickly.
+
+## Cross-Contract Call Table
+
+| Caller | Target Contract | Function | Authorization Check |
+|--------|-----------------|----------|--------------------|
+| Pool | Invoice | `mark_funded(id)` | `require_auth()` — `pool_contract` address stored in Invoice config |
+| Pool | Invoice | `mark_paid(id)` | `pool_contract` address check (invoice.owner or pool) |
+| Pool | Invoice | `mark_defaulted(id)` | `pool_contract` address check |
+| Pool | CreditScore | `record_payment(id, sme, status)` | `pool_contract` address stored in CreditScore config |
+| Oracle | Invoice | `mark_verified(id, hash)` | `oracle` address stored in Invoice config |
+| Oracle | Invoice | `mark_disputed(id)` | `oracle` address check |
+| Admin | All Contracts | `pause()`, `unpause()` | Admin address stored in each contract config; `require_auth(admin)` |
+| Admin | Pool | `set_yield()`, `add_token()`, etc. | Admin address check |
+| Anyone | Invoice | `get_invoice(id)` | Read-only — no auth required |
+| Anyone | Invoice | `check_expiration(id)` | Public keeper — no auth required |
+
+
+## Verification Checklist (for auditors)
+
+For each row in the table above, verify the following:
+
+- [ ] The authorization check (e.g., `require_auth()` or explicit stored address comparison) is present in the on-chain code for the target function.
+- [ ] The authorized address is set and validated during `initialize()` and cannot be changed without admin authorization.
+- [ ] There is a unit test demonstrating that an unauthorized caller is rejected for this function.
+- [ ] If the call crosses contracts (contract A calling contract B), ensure that the caller's contract address is stored in the callee's configuration and used for the authorization check.
+
+
+## Code Annotation Guidance
+
+Add a short comment block at the top of each contract file describing its authorized callers. Example:
+
+```rust
+// === AUTHORIZED CALLERS ===
+// - Admin: pause(), unpause(), admin-only setters
+// - Pool contract: mark_funded(), mark_paid(), mark_defaulted()
+// - Oracle: mark_verified(), mark_disputed()
+// - Anyone: read-only view functions
+```
+
+Include this block in:
+- `contracts/invoice/src/lib.rs`
+- `contracts/pool/src/lib.rs`
+- `contracts/credit_score/src/lib.rs`
+
+
+## Notes and Rationale
+
+- Storing the caller contract address in the callee's initialization (e.g., `invoice.initialize(admin, pool_contract, ...)`) makes authorization checks explicit and auditable.
+- Use `require_auth()` for externally-signed admin calls; use `env::invoker()`/`contract` client checks or compare `caller == stored_contract_address` for contract-to-contract calls.
+- For sensitive state-changing operations, prefer *both* `require_auth()` and explicit stored-address checks where applicable to protect against accidental misconfiguration.
+
+
+## Change Log
+
+- 2026-04-29 — Initial draft (issue #273)
+


### PR DESCRIPTION
Adds docs/authorization-matrix.md containing the cross-contract call table and an auditor checklist. Annotates top of Invoice, Pool, and Credit Score contract files with an 'AUTHORIZED CALLERS' block. Updates SECURITY.md to reference the authorization matrix.

Acceptance criteria:
- docs/authorization-matrix.md created
- Cross-contract calls listed
- Verification checklist present
- Contracts annotated with comment block at top
- SECURITY.md links to the authorization matrix

This branch is based on upstream/main and merges cleanly.

#273 