### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "smart-contract"
+      - "devops"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "frontend"
+      - "devops"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "devops"
+      - "tooling"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,6 +331,25 @@ Release notes are generated automatically from conventional commits using `git-c
 
 ---
 
+## 🤖 Dependabot PRs
+
+Dependabot checks the Rust workspace, frontend npm dependencies, and GitHub
+Actions workflows for dependency updates. It opens pull requests with existing
+area labels so maintainers can route them quickly:
+
+- `smart-contract` and `devops` for Cargo workspace updates
+- `frontend` and `devops` for frontend npm updates
+- `devops` and `tooling` for GitHub Actions updates
+
+When reviewing a Dependabot PR:
+
+1. Prioritize security updates and runtime dependency updates before tooling-only changes.
+2. Confirm the affected area by checking the labels and changed lockfiles.
+3. Run the relevant local checks from the testing section above.
+4. Merge only one dependency update PR at a time when failures would be hard to isolate.
+
+---
+
 ## 📋 Pull Request Process
 
 ### Before Opening a PR


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for the Cargo workspace, frontend npm package, and GitHub Actions workflows.
- Document how maintainers should triage Dependabot pull requests in CONTRIBUTING.md.

## Related Issue
Closes #440

## Changes
- Configure weekly Cargo checks against the root workspace manifest.
- Configure weekly npm checks for `/frontend`.
- Configure monthly GitHub Actions checks.
- Use existing repository labels (`smart-contract`, `frontend`, `devops`, `tooling`) so Dependabot PR labels match the current label set.

## Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort "missing updates" unless data["updates"].is_a?(Array) && data["updates"].size == 3; puts "dependabot yaml ok"'`\n- `test -f Cargo.toml && test -f frontend/package.json && test -d .github/workflows && echo 'dependabot target directories ok'`\n- `git diff --check HEAD~1 HEAD`\n\n## Notes\nThe issue example used `/contracts` for Cargo, but this repository has its Cargo workspace manifest at the repository root, so the Dependabot Cargo directory is `/`. The example also included a `dependencies` label, but that label does not currently exist in the repository; this PR uses existing labels to satisfy the label acceptance criterion.