### PR TITLE
ci(frontend): run tsc --noEmit in CI; fix test typings and update loc…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,9 @@ jobs:
           npm rebuild @parcel/watcher --foreground-scripts || true
           node -e "require('@parcel/watcher'); console.log('parcel watcher ok after rebuild')"
 
+      - name: Type-check TypeScript (includes tests)
+        run: npm run typecheck
+
       - name: Run ESLint
         run: npm run lint
 

--- a/frontend/__tests__/components/PoolStats.test.tsx
+++ b/frontend/__tests__/components/PoolStats.test.tsx
@@ -10,6 +10,10 @@ const baseConfig: PoolConfig = {
   yieldBps: 800, // 8.0%
   factoringFeeBps: 250, // 2.50%
   compoundInterest: false,
+  proposedYieldBps: 0,
+  yieldProposalAt: 0,
+  yieldTimelockSecs: 0,
+  maxSingleInvestorBps: 10000,
 };
 
 function totals(deposited: bigint, deployed: bigint): PoolTokenTotals {

--- a/frontend/__tests__/components/error-boundary.test.tsx
+++ b/frontend/__tests__/components/error-boundary.test.tsx
@@ -7,9 +7,10 @@ jest.mock('@sentry/nextjs', () => ({
   captureException: jest.fn(),
 }));
 
-function ThrowingComponent() {
+const ThrowingComponent: React.FC = () => {
   throw new Error('render failure');
-}
+  return <div />;
+};
 
 describe('ErrorBoundary', () => {
   const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/frontend/__tests__/hooks/useSseEvents.test.ts
+++ b/frontend/__tests__/hooks/useSseEvents.test.ts
@@ -144,9 +144,12 @@ describe('useSseEvents Hook', () => {
   it('should update role when role prop changes', () => {
     (useStore as unknown as jest.Mock).mockReturnValue(jest.fn());
 
-    const { rerender } = renderHook(({ role }) => useSseEvents({ role, enabled: true }), {
-      initialProps: { role: 'SME' as const },
-    });
+    const { rerender } = renderHook(
+      ({ role }: { role: 'SME' | 'Investor' }) => useSseEvents({ role, enabled: true }),
+      {
+        initialProps: { role: 'SME' },
+      },
+    );
 
     expect(sseEventsService.setRole).toHaveBeenCalledWith('SME');
 

--- a/frontend/__tests__/lib/dashboardFilters.test.ts
+++ b/frontend/__tests__/lib/dashboardFilters.test.ts
@@ -1,4 +1,5 @@
 import { filterInvoicesByStatuses } from '@/lib/dashboardFilters';
+import type { Invoice } from '@/lib/types';
 
 describe('filterInvoicesByStatuses', () => {
   it('filters invoice rows by selected statuses', () => {
@@ -6,9 +7,12 @@ describe('filterInvoicesByStatuses', () => {
       { invoice: { status: 'Pending' } },
       { invoice: { status: 'Funded' } },
       { invoice: { status: 'Paid' } },
-    ] as const;
+    ];
 
-    const result = filterInvoicesByStatuses(rows, ['Pending', 'Paid']);
+    const result = filterInvoicesByStatuses(rows as unknown as { invoice: Invoice }[], [
+      'Pending',
+      'Paid',
+    ]);
     expect(result).toHaveLength(2);
     expect(result.map((row) => row.invoice.status)).toEqual(['Pending', 'Paid']);
   });

--- a/frontend/__tests__/lib/sse-events.test.ts
+++ b/frontend/__tests__/lib/sse-events.test.ts
@@ -228,7 +228,7 @@ describe('SSE Events Polling Service', () => {
     });
 
     it('should map default event to error toast', () => {
-      const toastConfig = EVENT_TOAST_MAP['default']();
+      const toastConfig = EVENT_TOAST_MAP['default'](undefined);
       expect(toastConfig.kind).toBe('error');
       expect(toastConfig.title).toBe('Invoice Defaulted');
     });

--- a/frontend/__tests__/lib/store.test.tsx
+++ b/frontend/__tests__/lib/store.test.tsx
@@ -12,7 +12,7 @@ describe('useStore', () => {
 
   it('has correct initial state', () => {
     const { result } = renderHook(() => useStore());
-    
+
     expect(result.current.wallet).toEqual({
       address: null,
       connected: false,
@@ -24,7 +24,7 @@ describe('useStore', () => {
 
   it('updates wallet state', () => {
     const { result } = renderHook(() => useStore());
-    
+
     act(() => {
       result.current.setWallet({
         address: 'GDUMMY...',
@@ -32,7 +32,7 @@ describe('useStore', () => {
         network: 'testnet',
       });
     });
-    
+
     expect(result.current.wallet).toEqual({
       address: 'GDUMMY...',
       connected: true,
@@ -43,16 +43,21 @@ describe('useStore', () => {
   it('updates pool config', () => {
     const { result } = renderHook(() => useStore());
     const mockConfig = {
-      invoice_contract: 'CONTRACT1',
+      invoiceContract: 'CONTRACT1',
       admin: 'ADMIN1',
-      yield_bps: 800,
-      compound_interest: false,
+      yieldBps: 800,
+      factoringFeeBps: 0,
+      compoundInterest: false,
+      proposedYieldBps: 0,
+      yieldProposalAt: 0,
+      yieldTimelockSecs: 0,
+      maxSingleInvestorBps: 10000,
     };
-    
+
     act(() => {
       result.current.setPoolConfig(mockConfig);
     });
-    
+
     expect(result.current.poolConfig).toEqual(mockConfig);
   });
 
@@ -63,36 +68,36 @@ describe('useStore', () => {
       available: 5000000000n,
       deployed: 5000000000n,
       earned: 0n,
-      deposit_count: 1,
+      depositCount: 1,
     };
-    
+
     act(() => {
       result.current.setPosition(mockPosition);
     });
-    
+
     expect(result.current.position).toEqual(mockPosition);
   });
 
   it('clears position when set to null', () => {
     const { result } = renderHook(() => useStore());
-    
+
     act(() => {
       result.current.setPosition({
         deposited: 10000000000n,
         available: 5000000000n,
         deployed: 5000000000n,
         earned: 0n,
-        deposit_count: 1,
+        depositCount: 1,
       });
       result.current.setPosition(null);
     });
-    
+
     expect(result.current.position).toBeNull();
   });
 
   it('disconnect resets wallet and position', () => {
     const { result } = renderHook(() => useStore());
-    
+
     act(() => {
       result.current.setWallet({
         address: 'GDUMMY...',
@@ -104,11 +109,11 @@ describe('useStore', () => {
         available: 5000000000n,
         deployed: 5000000000n,
         earned: 0n,
-        deposit_count: 1,
+        depositCount: 1,
       });
       result.current.disconnect();
     });
-    
+
     expect(result.current.wallet).toEqual({
       address: null,
       connected: false,
@@ -125,7 +130,7 @@ describe('useStore', () => {
       available: 5000000000n,
       deployed: 5000000000n,
       earned: 0n,
-      deposit_count: 1,
+      depositCount: 1,
     };
 
     act(() => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5596,6 +5596,19 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
@@ -5609,10 +5622,36 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
       "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
@@ -15197,7 +15236,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "start:e2e": "next build && next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "prepare": "cd .. && git config core.hooksPath frontend/.husky",
     "test": "jest",


### PR DESCRIPTION
Close #392 

**PR Title**  
ci(frontend): run tsc in CI & fix test typings

**PR Summary**  
- **Purpose**: Add TypeScript type-checking for the frontend (including test files) to CI, and fix test typings so the project type-checks under TypeScript 5.
- **Branch**: fix/typescript-jest-ci

**What Changed**
- **CI**: run frontend type-check before build — ci.yml  
- **Scripts**: added `typecheck` script to frontend package.json — package.json  
- **Deps / lockfile**: synced package-lock.json after installing optional native bindings — package-lock.json  
- **Tests**: corrected typings in tests to match current types and signatures:
  - PoolStats.test.tsx  
  - error-boundary.test.tsx  
  - useSseEvents.test.ts  
  - dashboardFilters.test.ts  
  - sse-events.test.ts  
  - store.test.tsx

**Motivation / Background**  
- The project upgraded to TypeScript 5; older `@types/jest` versions can override built-in types and cause incorrect typing for tests. CI previously did not run `tsc` on test files, allowing type regressions in tests to slip through.
- This change ensures `tsc --noEmit` runs for the frontend in CI so test files are type-checked and type regressions are caught before merge.

**Acceptance Criteria (verified)**
- **@types/jest** is compatible with TypeScript 5 in package.json.  
- Running `tsc --noEmit` in the frontend workspace passes locally after fixes.  
- CI now runs `npm run typecheck` in the frontend job prior to building.

**How to Test Locally**
1. From repository root:
```bash
cd frontend
npm install --include=optional
npm run typecheck
npm run lint
```
2. Run the frontend build (optional):
```bash
npm run build
```
3. Run tests (optional):
```bash
npm test
```
