### PR TITLE
fix: resolve multiple assigned issues (#413, #410, #409)

### DIFF
--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -698,9 +698,10 @@ impl InvoiceContract {
         let daily_reset_key = DataKey::DailyInvoiceResetTime(owner.clone());
         let reset_time: u64 = env.storage().instance().get(&daily_reset_key).unwrap_or(0);
         let mut daily_count: u32 = env.storage().instance().get(&daily_count_key).unwrap_or(0);
-        if now >= reset_time + SECS_PER_DAY {
+        if now >= reset_time {
             daily_count = 0;
-            env.storage().instance().set(&daily_reset_key, &now);
+            let next_reset = (now / SECS_PER_DAY + 1) * SECS_PER_DAY;
+            env.storage().instance().set(&daily_reset_key, &next_reset);
         }
         if daily_count >= daily_limit {
             panic!("daily invoice limit exceeded");
@@ -1300,7 +1301,6 @@ impl InvoiceContract {
     // ── Existing view / setter methods (unchanged) ────────────────────────────
 
     pub fn get_invoice(env: Env, id: u64) -> Invoice {
-        bump_instance(&env);
         let inv = load_invoice(&env, id);
         maybe_expire_pending_invoice(&env, inv)
     }

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -112,6 +112,8 @@ pub enum PoolError {
     YieldChangeNotReady = 32,
     // #367: unsupported token decimal precision
     UnsupportedTokenDecimals = 36,
+    // #413: invalid collateral threshold
+    InvalidThreshold = 37,
 }
 
 type PoolResult<T> = Result<T, PoolError>;
@@ -1922,8 +1924,11 @@ impl FundingPool {
         if threshold < 0 {
             return Err(PoolError::InvalidAmount);
         }
+        if collateral_bps == 0 {
+            return Err(PoolError::InvalidThreshold);
+        }
         if collateral_bps > BPS_DENOM {
-            return Err(PoolError::InvalidAmount);
+            return Err(PoolError::InvalidThreshold);
         }
         let cfg = CollateralConfig {
             threshold,


### PR DESCRIPTION
## Changes

### #413 — set_collateral_config validation
Added `InvalidThreshold` error variant and validation ensuring `collateral_bps > 0` and `collateral_bps <= 10000`. This prevents the rug-pull vector where an admin could set the collateral ratio to 0% and seize all borrower collateral.

### #410 — get_invoice() side-effect removal
Removed `bump_instance()` call from `get_invoice()` to eliminate TTL extension side-effects in a view function. TTL extension only occurs in state-changing functions.

### #409 — daily_reset timestamp drift fix
Changed the daily reset mechanism from relative offset (`last_reset + 86400`) to UTC day boundary anchoring (`(now / 86400 + 1) * 86400`), eliminating cumulative drift over time.

### #412 — remove_token (already implemented)
The `remove_token` function already validates deployed capital via `TokenHasDeployedCapital`, pending withdrawals, and active share balances. No additional changes needed.

Closes #413
Closes #410
Closes #409
Closes #412
