### PR TITLE
feat: migration hooks, admin route guard, XDR dedup, real-contract E2E (#397, #393, #391, #395)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,14 @@ jobs:
           npm rebuild @parcel/watcher --foreground-scripts || true
           node -e "require('@parcel/watcher'); console.log('parcel watcher ok after rebuild')"
 
+      # #391: @stellar/stellar-sdk and freighter-api must share a single XDR
+      # codec. Duplicate @stellar/js-xdr versions cause silent envelope
+      # decode failures during wallet signing, so fail the build if more than
+      # one resolved version is present in node_modules.
+      - name: Verify single @stellar/js-xdr version (#391)
+        run: |
+          node -e "const fs=require('fs'),cp=require('child_process');const paths=cp.execSync('find node_modules -path \"*/@stellar/js-xdr/package.json\"').toString().split('\n').filter(Boolean);const versions=[...new Set(paths.map(p=>JSON.parse(fs.readFileSync(p,'utf8')).version))];console.log('Resolved @stellar/js-xdr versions:',versions.join(', ')||'(none)');if(versions.length!==1){console.error('::error::Found '+versions.length+' @stellar/js-xdr versions; expected exactly 1. Duplicate XDR codecs cause envelope decode errors (#391).');process.exit(1);}"
+
       - name: Type-check TypeScript (includes tests)
         run: npm run typecheck
 
@@ -239,10 +247,12 @@ jobs:
       - name: Build frontend
         run: npm run build
         env:
+          # #395: real deployed testnet contract IDs, configured as repository
+          # variables. E2E must exercise real contracts, never placeholders.
           NEXT_PUBLIC_NETWORK: testnet
-          NEXT_PUBLIC_INVOICE_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
-          NEXT_PUBLIC_POOL_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
-          NEXT_PUBLIC_USDC_TOKEN_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
+          NEXT_PUBLIC_INVOICE_CONTRACT_ID: ${{ vars.TESTNET_INVOICE_CONTRACT_ID }}
+          NEXT_PUBLIC_POOL_CONTRACT_ID: ${{ vars.TESTNET_POOL_CONTRACT_ID }}
+          NEXT_PUBLIC_USDC_TOKEN_ID: ${{ vars.TESTNET_USDC_TOKEN_ID }}
 
       - name: Configure Playwright base URL
         run: |
@@ -252,10 +262,15 @@ jobs:
       - name: Run Playwright E2E tests
         run: npm run test:e2e
         env:
+          # #395: same real testnet IDs for the test run. The bare *_CONTRACT_ID
+          # vars are read by the fail-fast guard in playwright.config.ts and by
+          # the deployed-contract spec; the run fails if they are placeholders.
           NEXT_PUBLIC_NETWORK: testnet
-          NEXT_PUBLIC_INVOICE_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
-          NEXT_PUBLIC_POOL_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
-          NEXT_PUBLIC_USDC_TOKEN_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
+          NEXT_PUBLIC_INVOICE_CONTRACT_ID: ${{ vars.TESTNET_INVOICE_CONTRACT_ID }}
+          NEXT_PUBLIC_POOL_CONTRACT_ID: ${{ vars.TESTNET_POOL_CONTRACT_ID }}
+          NEXT_PUBLIC_USDC_TOKEN_ID: ${{ vars.TESTNET_USDC_TOKEN_ID }}
+          INVOICE_CONTRACT_ID: ${{ vars.TESTNET_INVOICE_CONTRACT_ID }}
+          POOL_CONTRACT_ID: ${{ vars.TESTNET_POOL_CONTRACT_ID }}
 
       - name: Upload Playwright report
         if: always()

--- a/contracts/credit_score/src/lib.rs
+++ b/contracts/credit_score/src/lib.rs
@@ -46,6 +46,10 @@ const PTS_NEW_INVOICE: u32 = 5;
 
 const LATE_PAYMENT_THRESHOLD_SECS: u64 = 7 * 24 * 60 * 60;
 const UPGRADE_TIMELOCK_SECS: u64 = 86400; // 24 hours
+/// Current on-chain storage schema version (#397). Bump by one and add a
+/// matching arm in `run_migration` whenever the persistent storage layout
+/// changes so a deployed contract can migrate state after a WASM upgrade.
+const CURRENT_MIGRATION_VERSION: u32 = 1;
 pub const MAX_PAYMENT_HISTORY: u32 = 100;
 
 #[contracttype]
@@ -116,11 +120,15 @@ pub enum DataKey {
     PoolContract,
     Initialized,
     ScoreVersion,
+    /// Size of the rolling payment-history window retained per SME.
+    MaxPaymentHistory,
     Paused,
     ProposedWasmHash,
     UpgradeScheduledAt,
     /// Semantic version stored during initialize() (#237).
     ContractVersion,
+    /// Applied storage-schema migration level (#397).
+    MigrationVersion,
     /// Configurable late-payment threshold in days (#430).
     LateThreshold,
     /// #428: Configurable score thresholds (Excellent, Very Good, Good, Fair)
@@ -283,6 +291,9 @@ impl CreditScoreContract {
         env.storage()
             .instance()
             .set(&DataKey::ContractVersion, &parse_credit_score_version());
+        env.storage()
+            .instance()
+            .set(&DataKey::MigrationVersion, &0u32);
     }
 
     /// Returns the semantic version of this deployed credit-score contract (#237).
@@ -291,6 +302,37 @@ impl CreditScoreContract {
             .instance()
             .get(&DataKey::ContractVersion)
             .unwrap_or_else(parse_credit_score_version)
+    }
+
+    /// Returns the applied storage-schema migration level (#397).
+    pub fn migration_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MigrationVersion)
+            .unwrap_or(0)
+    }
+
+    /// Run pending storage migrations after a WASM upgrade (#397).
+    ///
+    /// Admin-only and idempotent: once the contract has reached
+    /// `CURRENT_MIGRATION_VERSION` further calls are a no-op. Each migration
+    /// step transforms the persistent storage layout for one schema version
+    /// and is meant to be invoked manually after `execute_upgrade`.
+    pub fn run_migration(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        let current: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MigrationVersion)
+            .unwrap_or(0);
+        if current >= CURRENT_MIGRATION_VERSION {
+            return;
+        }
+        // Future migration arms (current -> current + 1) transform storage here.
+        env.storage()
+            .instance()
+            .set(&DataKey::MigrationVersion, &CURRENT_MIGRATION_VERSION);
     }
 
     pub fn pause(env: Env, admin: Address) {
@@ -771,6 +813,9 @@ impl CreditScoreContract {
             .publish((EVT, symbol_short!("upgraded")), (admin, now));
     }
 }
+
+#[cfg(test)]
+extern crate std;
 
 #[cfg(test)]
 mod test {
@@ -1714,7 +1759,14 @@ mod test {
         let due_date = 200_000u64;
 
         // Via record_payment (on time)
-        client.record_payment(&pool, &1, &sme, &1_000_000_000i128, &due_date, &(due_date - 1000));
+        client.record_payment(
+            &pool,
+            &1,
+            &sme,
+            &1_000_000_000i128,
+            &due_date,
+            &(due_date - 1000),
+        );
         let after_payment = client.get_credit_score(&sme);
         assert_eq!(after_payment.total_invoices, 1);
         assert_eq!(after_payment.paid_on_time, 1);
@@ -2072,5 +2124,36 @@ mod test {
             score_lenient,
             score_strict
         );
+    }
+
+    #[test]
+    fn test_run_migration_bumps_version_and_is_idempotent() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _invoice, _pool) = setup(&env);
+
+        // Fresh deployment starts at migration level 0.
+        assert_eq!(client.migration_version(), 0);
+
+        // Running the migration advances to the current schema version while
+        // preserving existing state (the contract stays at the same version).
+        let version_before = client.version();
+        client.run_migration(&admin);
+        assert_eq!(client.migration_version(), CURRENT_MIGRATION_VERSION);
+        assert_eq!(client.version(), version_before);
+
+        // Re-running is a no-op (idempotent).
+        client.run_migration(&admin);
+        assert_eq!(client.migration_version(), CURRENT_MIGRATION_VERSION);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_run_migration_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _invoice, _pool) = setup(&env);
+        let attacker = Address::generate(&env);
+        client.run_migration(&attacker);
     }
 }

--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -88,6 +88,15 @@ pub enum InvoiceError {
     DateOverflow = 9,
     // #406: metadata URL validation
     InvalidMetadata = 10,
+    // Per-field length validation (used by validate_invoice_strings)
+    DescriptionTooLong = 11,
+    DebtorNameTooLong = 12,
+    VerificationHashTooLong = 13,
+    // Due-date extension flow (request_extension / approve_extension)
+    ExtensionAlreadyPending = 14,
+    InvalidDueDateExtension = 15,
+    ExtensionTooLarge = 16,
+    NoPendingExtension = 17,
 }
 
 #[contracttype]
@@ -1920,14 +1929,19 @@ mod test {
                 new_due_date: u64,
             ) {
                 invoice_contract.require_auth();
-                env.storage().instance().set(&symbol_short!("upd_id"), &invoice_id);
+                env.storage()
+                    .instance()
+                    .set(&symbol_short!("upd_id"), &invoice_id);
                 env.storage()
                     .instance()
                     .set(&symbol_short!("upd_due"), &new_due_date);
             }
 
             pub fn last_updated_invoice_id(env: Env) -> u64 {
-                env.storage().instance().get(&symbol_short!("upd_id")).unwrap_or(0)
+                env.storage()
+                    .instance()
+                    .get(&symbol_short!("upd_id"))
+                    .unwrap_or(0)
             }
 
             pub fn last_updated_due_date(env: Env) -> u64 {
@@ -2727,10 +2741,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let (client, _admin, _pool, sme) = setup(&env);
-        let long_desc = String::from_bytes(
-            &env,
-            &[b'a'; (MAX_DESCRIPTION_LEN as usize) + 1],
-        );
+        let long_desc = String::from_bytes(&env, &[b'a'; (MAX_DESCRIPTION_LEN as usize) + 1]);
         let result = client.try_create_invoice(
             &sme,
             &String::from_str(&env, "Debtor Corp"),
@@ -2815,8 +2826,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let (client, _admin, _pool, sme) = setup(&env);
-        let long_hash =
-            String::from_bytes(&env, &[b'h'; (MAX_VERIFICATION_HASH_LEN as usize) + 1]);
+        let long_hash = String::from_bytes(&env, &[b'h'; (MAX_VERIFICATION_HASH_LEN as usize) + 1]);
         let result = client.try_create_invoice(
             &sme,
             &String::from_str(&env, "Debtor Corp"),

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -117,6 +117,10 @@ pub enum PoolError {
     NegativeAmount = 38,
     // fee-on-transfer token mismatch
     TransferMismatch = 39,
+    // #109: investor not KYC-approved
+    KycNotApproved = 40,
+    // collateral threshold/ratio validation
+    InvalidThreshold = 41,
 }
 
 type PoolResult<T> = Result<T, PoolError>;
@@ -154,6 +158,10 @@ const COMPLETED_INVOICE_TTL: u32 = LEDGERS_PER_DAY * 30;
 const INSTANCE_BUMP_AMOUNT: u32 = LEDGERS_PER_DAY * 30;
 const INSTANCE_LIFETIME_THRESHOLD: u32 = LEDGERS_PER_DAY * 7;
 const UPGRADE_TIMELOCK_SECS: u64 = 86400; // 24 hours
+/// Current on-chain storage schema version (#397). Bump by one and add a
+/// matching arm in `run_migration` whenever the persistent storage layout
+/// changes so a deployed contract can migrate state after a WASM upgrade.
+const CURRENT_MIGRATION_VERSION: u32 = 1;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -511,12 +519,7 @@ fn calculate_total_due(
     Ok((total_interest, total_due))
 }
 
-fn release_collateral(
-    env: &Env,
-    invoice_id: u64,
-    released_by: &Address,
-    settled_at: u64,
-) {
+fn release_collateral(env: &Env, invoice_id: u64, released_by: &Address, settled_at: u64) {
     if let Some(mut col) = env
         .storage()
         .persistent()
@@ -856,6 +859,38 @@ impl FundingPool {
             .instance()
             .get(&DataKey::ContractVersion)
             .unwrap_or_else(parse_pool_version)
+    }
+
+    /// Returns the applied storage-schema migration level (#397).
+    pub fn migration_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MigrationVersion)
+            .unwrap_or(0)
+    }
+
+    /// Run pending storage migrations after a WASM upgrade (#397).
+    ///
+    /// Admin-only and idempotent: once the contract has reached
+    /// `CURRENT_MIGRATION_VERSION` further calls are a no-op. Each migration
+    /// step transforms the persistent storage layout for one schema version
+    /// and is meant to be invoked manually after `execute_upgrade`.
+    pub fn run_migration(env: Env, admin: Address) -> Result<(), PoolError> {
+        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
+        let current: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MigrationVersion)
+            .unwrap_or(0);
+        if current >= CURRENT_MIGRATION_VERSION {
+            return Ok(());
+        }
+        // Future migration arms (current -> current + 1) transform storage here.
+        env.storage()
+            .instance()
+            .set(&DataKey::MigrationVersion, &CURRENT_MIGRATION_VERSION);
+        Ok(())
     }
 
     pub fn pause(env: Env, admin: Address) -> Result<(), PoolError> {
@@ -4175,7 +4210,8 @@ mod test {
         let initial_due_date = env.ledger().timestamp() + SECS_PER_DAY;
         client.fund_invoice(&admin, &1u64, &5_000i128, &sme, &initial_due_date, &usdc_id);
 
-        env.ledger().with_mut(|l| l.timestamp = initial_due_date + (5 * SECS_PER_DAY));
+        env.ledger()
+            .with_mut(|l| l.timestamp = initial_due_date + (5 * SECS_PER_DAY));
         let capped_amount = client.estimate_repayment(&1u64);
 
         let extended_due_date = initial_due_date + (10 * SECS_PER_DAY);

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -1,0 +1,112 @@
+# Contract Upgrades & State Migrations
+
+This document describes how the Astera Soroban contracts (`invoice`, `pool`,
+`credit_score`) are upgraded in place and how their persistent storage layout is
+migrated after an upgrade. For the operational deploy runbook see
+[`contract-upgrade-guide.md`](./contract-upgrade-guide.md); this document focuses
+on the on-chain mechanism and the version/migration hooks added in #397.
+
+## Overview
+
+Each contract supports an in-place WASM upgrade behind a 24-hour timelock, plus a
+manually-invoked migration hook that transforms persistent storage when the
+schema changes between versions. Two independent version numbers are tracked:
+
+| Function | Returns | Meaning |
+| --- | --- | --- |
+| `version()` | semantic version struct | The compiled package version (`CARGO_PKG_VERSION`), recorded at `initialize()`. |
+| `migration_version()` | `u32` | The applied storage-schema migration level. Starts at `0`, advanced by `run_migration`. |
+
+All upgrade and migration entry points are **admin-only** — the caller must be the
+admin recorded at `initialize()` and must authorize the call.
+
+## Upgrade flow (timelocked)
+
+The WASM hash is proposed first and can only be executed once the timelock has
+elapsed, giving stakeholders a window to react to a malicious or mistaken
+proposal.
+
+```text
+admin ──propose_upgrade(wasm_hash)──▶ ProposedWasmHash + UpgradeScheduledAt stored
+                                       (emits "upg_prop" with the unlock timestamp)
+        ... 24h timelock (UPGRADE_TIMELOCK_SECS) ...
+admin ──execute_upgrade()───────────▶ env.deployer().update_current_contract_wasm(hash)
+                                       (emits "upgraded")
+```
+
+- `propose_upgrade(admin, wasm_hash)` — records the candidate WASM hash and the
+  current ledger timestamp.
+- `execute_upgrade(admin)` — reverts unless `now >= scheduled_at + 24h`, then
+  swaps the contract's WASM via `env.deployer().update_current_contract_wasm`.
+
+Re-proposing simply overwrites the pending hash and resets the timelock.
+
+## Migration flow
+
+After `execute_upgrade` installs new code, persistent storage written by the old
+code may need transforming. `run_migration` performs that transformation:
+
+```rust
+pub fn run_migration(env: Env, admin: Address) /* -> Result<(), PoolError> in pool */ {
+    admin.require_auth();
+    // admin check
+    let current = migration_version(); // defaults to 0
+    if current >= CURRENT_MIGRATION_VERSION {
+        return; // idempotent no-op once fully migrated
+    }
+    // migration arms (current -> current + 1) transform storage here
+    set(MigrationVersion, CURRENT_MIGRATION_VERSION);
+}
+```
+
+Properties:
+
+- **Manual** — run once by the admin immediately after `execute_upgrade`. It is
+  not triggered automatically by the upgrade.
+- **Idempotent** — once `migration_version() == CURRENT_MIGRATION_VERSION`,
+  further calls are a no-op, so it is safe to retry.
+- **Forward-only** — each release bumps `CURRENT_MIGRATION_VERSION` by one and
+  adds a migration arm transforming the previous layout to the new one.
+
+### Adding a migration
+
+When a release changes the persistent storage layout:
+
+1. Bump `CURRENT_MIGRATION_VERSION` by one in the contract.
+2. Add the transformation for the step `current -> current + 1` in
+   `run_migration` (read old entries, write the new shape, remove stale keys).
+3. Add a test that seeds old-shape state, runs the migration, and asserts the new
+   shape and that unrelated state is preserved.
+
+## Upgrade + migration runbook
+
+```bash
+# 1. Build and upload the new WASM, capture its hash
+stellar contract install --wasm target/wasm32-unknown-unknown/release/<contract>.wasm
+
+# 2. Propose the upgrade (starts the 24h timelock)
+stellar contract invoke --id <CONTRACT_ID> --source admin -- \
+  propose_upgrade --admin <ADMIN> --wasm_hash <WASM_HASH>
+
+# 3. After 24h, execute the upgrade
+stellar contract invoke --id <CONTRACT_ID> --source admin -- execute_upgrade --admin <ADMIN>
+
+# 4. Run the storage migration
+stellar contract invoke --id <CONTRACT_ID> --source admin -- run_migration --admin <ADMIN>
+
+# 5. Verify
+stellar contract invoke --id <CONTRACT_ID> -- version
+stellar contract invoke --id <CONTRACT_ID> -- migration_version
+```
+
+## Per-contract status
+
+| Contract | `version()` | `propose_upgrade` / `execute_upgrade` | `run_migration` / `migration_version` |
+| --- | --- | --- | --- |
+| `invoice` | ✅ | ✅ | ✅ |
+| `pool` | ✅ | ✅ | ✅ |
+| `credit_score` | ✅ | ✅ | ✅ |
+
+`CURRENT_MIGRATION_VERSION` is currently `1` in each contract; freshly
+initialized contracts start at `migration_version() == 0` until `run_migration`
+is invoked.

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,58 +1,15 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useStore } from '@/lib/store';
-import { getPoolConfig } from '@/lib/contracts';
+import { useAdminGuard } from '@/hooks/useAdminGuard';
 import AdminNav from '@/components/AdminNav';
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
-  const { wallet, poolConfig, setPoolConfig } = useStore();
-  const [loading, setLoading] = useState(true);
-  const [authorized, setAuthorized] = useState<boolean | null>(null);
+  // Central client-side guard for every /admin page (#393). Reads the admin
+  // role from the contract and redirects non-admins to /dashboard before any
+  // admin UI renders.
+  const { status } = useAdminGuard();
 
-  useEffect(() => {
-    async function checkAuth() {
-      setLoading(true);
-      try {
-        let currentPoolConfig = poolConfig;
-        if (!currentPoolConfig) {
-          currentPoolConfig = await getPoolConfig();
-          setPoolConfig(currentPoolConfig);
-        }
-
-        if (wallet.connected && wallet.address && currentPoolConfig) {
-          try {
-            // Prefer cryptographic verification via SEP-0010 JWT
-            const { verifyToken, getToken } = await import('@/lib/auth');
-            const token = getToken();
-            const v = await verifyToken(token);
-            if (v?.authenticated && v?.account === currentPoolConfig.admin) {
-              setAuthorized(true);
-            } else if (wallet.address === currentPoolConfig.admin) {
-              // fallback to raw address match (non-cryptographic)
-              setAuthorized(true);
-            } else {
-              setAuthorized(false);
-            }
-          } catch (e) {
-            console.warn('Auth verification failed, falling back to address match', e);
-            setAuthorized(wallet.address === currentPoolConfig.admin);
-          }
-        } else if (!wallet.connected) {
-          setAuthorized(null);
-        }
-      } catch (e) {
-        console.error('Failed to get pool admin:', e);
-        setAuthorized(false);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    checkAuth();
-  }, [wallet.connected, wallet.address, poolConfig, setPoolConfig]);
-
-  if (loading) {
+  if (status === 'loading') {
     return (
       <div className="min-h-screen flex items-center justify-center bg-brand-dark pt-16">
         <div className="w-8 h-8 border-2 border-brand-gold border-t-transparent rounded-full animate-spin" />
@@ -60,7 +17,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     );
   }
 
-  if (authorized === null) {
+  if (status === 'unauthenticated') {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center bg-brand-dark pt-16 text-center px-6">
         <div className="text-4xl mb-6">◈</div>
@@ -77,17 +34,12 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     );
   }
 
-  if (!authorized) {
+  // A denied wallet is being redirected to /dashboard; render nothing so admin
+  // controls never flash for unauthorized users.
+  if (status !== 'authorized') {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-brand-dark pt-16 text-center px-6">
-        <div className="w-16 h-16 bg-red-900/20 border border-red-800/50 rounded-full flex items-center justify-center text-red-500 mb-6 font-bold text-2xl">
-          !
-        </div>
-        <h1 className="text-2xl font-bold mb-2 text-white">Access Denied</h1>
-        <p className="text-brand-muted max-w-md">
-          Your connected wallet ({wallet.address}) is not authorized to access the administration
-          panel.
-        </p>
+      <div className="min-h-screen flex items-center justify-center bg-brand-dark pt-16">
+        <div className="w-8 h-8 border-2 border-brand-gold border-t-transparent rounded-full animate-spin" />
       </div>
     );
   }

--- a/frontend/e2e/admin-guard.spec.ts
+++ b/frontend/e2e/admin-guard.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { freighterMockScript, MOCK_ADDRESS } from './mocks/freighter';
+
+test.describe('Admin route guard (#393)', () => {
+  test.skip(!!process.env.CI, 'Admin role checks need live contract config in CI.');
+
+  test('non-admin wallet visiting /admin is redirected to /dashboard', async ({ page }) => {
+    // Connect a non-admin wallet via the Freighter mock and auto-reconnect.
+    await page.addInitScript(
+      freighterMockScript({ isConnected: true, isAllowed: true, address: MOCK_ADDRESS }),
+    );
+    await page.addInitScript((addr: string) => {
+      // WalletConnect auto-reconnects when an address is stored.
+      localStorage.setItem('astera_wallet_address', addr);
+    }, MOCK_ADDRESS);
+    await page.route('**/*freighter-api*', (route) => {
+      route.fulfill({
+        contentType: 'application/javascript',
+        body: `
+          export const isConnected = () => Promise.resolve({ isConnected: true });
+          export const isAllowed = () => Promise.resolve({ isAllowed: true });
+          export const setAllowed = () => Promise.resolve({ isAllowed: true });
+          export const getAddress = () => Promise.resolve({ address: '${MOCK_ADDRESS}', error: null });
+          export const signTransaction = (xdr) => Promise.resolve({ signedTxXdr: xdr + '_signed', error: null });
+          export const getNetwork = () => Promise.resolve({ network: 'TESTNET', networkPassphrase: 'Test SDF Network ; September 2015' });
+        `,
+      });
+    });
+
+    await page.goto('/admin');
+
+    // MOCK_ADDRESS is not the pool admin, so useAdminGuard must redirect away
+    // from /admin (to /dashboard) before any admin UI renders.
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
+  });
+});

--- a/frontend/e2e/contract-ids.ts
+++ b/frontend/e2e/contract-ids.ts
@@ -1,0 +1,61 @@
+/**
+ * Contract-ID resolution and validation for E2E tests (#395).
+ *
+ * E2E tests previously ran against a zeroed placeholder contract ID
+ * (`CAAAA…D2KM`), so they never exercised a real deployed contract and gave
+ * false confidence. This module resolves the IDs from the environment and, in
+ * CI, fails fast if they are missing or still a placeholder.
+ */
+
+/** Zeroed contract address historically used as a placeholder. */
+const ZERO_CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+
+/** A Stellar contract ID is 56 chars and starts with `C`. */
+function isWellFormed(id: string | undefined): id is string {
+  return !!id && id.length === 56 && id.startsWith('C');
+}
+
+/** True when an ID is missing, malformed, or an obvious zeroed placeholder. */
+export function isPlaceholderContractId(id: string | undefined): boolean {
+  if (!isWellFormed(id)) return true;
+  if (id === ZERO_CONTRACT_ID) return true;
+  // Any near-all-`A` body is a zeroed/placeholder address.
+  if (/^CA{40,}/.test(id)) return true;
+  return false;
+}
+
+/**
+ * Resolve a contract ID, accepting either the bare name (e.g.
+ * `INVOICE_CONTRACT_ID`, as exported by the CI deploy step) or the
+ * `NEXT_PUBLIC_`-prefixed variant the frontend build consumes.
+ */
+function resolve(name: string): string | undefined {
+  return process.env[name] ?? process.env[`NEXT_PUBLIC_${name}`];
+}
+
+export const INVOICE_CONTRACT_ID = resolve('INVOICE_CONTRACT_ID');
+export const POOL_CONTRACT_ID = resolve('POOL_CONTRACT_ID');
+
+/** True only when real (non-placeholder) invoice + pool IDs are configured. */
+export const hasRealContractIds =
+  !isPlaceholderContractId(INVOICE_CONTRACT_ID) && !isPlaceholderContractId(POOL_CONTRACT_ID);
+
+/**
+ * In CI, real testnet contract IDs are mandatory — throw with an actionable
+ * message otherwise so the run fails loudly instead of silently skipping
+ * contract interaction.
+ */
+export function assertRealContractIds(): void {
+  const missing: string[] = [];
+  if (isPlaceholderContractId(INVOICE_CONTRACT_ID)) missing.push('INVOICE_CONTRACT_ID');
+  if (isPlaceholderContractId(POOL_CONTRACT_ID)) missing.push('POOL_CONTRACT_ID');
+  if (missing.length > 0) {
+    throw new Error(
+      `E2E contract IDs are missing or placeholders: ${missing.join(', ')}.\n` +
+        'Set real deployed testnet contract IDs before running E2E in CI — e.g. the ' +
+        'repository variables TESTNET_INVOICE_CONTRACT_ID / TESTNET_POOL_CONTRACT_ID, ' +
+        'wired into NEXT_PUBLIC_INVOICE_CONTRACT_ID / NEXT_PUBLIC_POOL_CONTRACT_ID. ' +
+        'See .github/workflows/ci.yml (e2e-tests job).',
+    );
+  }
+}

--- a/frontend/e2e/contract-read.spec.ts
+++ b/frontend/e2e/contract-read.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import {
+  rpc,
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  Account,
+  Keypair,
+  scValToNative,
+} from '@stellar/stellar-sdk';
+import { INVOICE_CONTRACT_ID, hasRealContractIds } from './contract-ids';
+
+const RPC_URL = process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+
+/**
+ * Real contract integration check (#395).
+ *
+ * Runs only when real testnet contract IDs are configured. It calls a real
+ * read-only method (`get_invoice_count`) on the deployed invoice contract via
+ * Soroban RPC simulation and asserts a concrete result — so XDR/method-name
+ * regressions against the real contract are actually caught.
+ */
+test.describe('Deployed contract interaction (#395)', () => {
+  test.skip(!hasRealContractIds, 'Requires real testnet contract IDs (see e2e/contract-ids.ts).');
+
+  test('invoice get_invoice_count returns a numeric count from the deployed contract', async () => {
+    const server = new rpc.Server(RPC_URL);
+    const source = new Account(Keypair.random().publicKey(), '0');
+    const contract = new Contract(INVOICE_CONTRACT_ID as string);
+
+    const tx = new TransactionBuilder(source, {
+      fee: BASE_FEE,
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(contract.call('get_invoice_count'))
+      .setTimeout(30)
+      .build();
+
+    const sim = await server.simulateTransaction(tx);
+
+    expect(rpc.Api.isSimulationError(sim)).toBe(false);
+    expect(rpc.Api.isSimulationSuccess(sim)).toBe(true);
+
+    const success = sim as rpc.Api.SimulateTransactionSuccessResponse;
+    expect(success.result?.retval).toBeDefined();
+
+    const count = scValToNative(success.result!.retval);
+    // u64 decodes to a bigint; it must be a non-negative count.
+    expect(typeof count).toBe('bigint');
+    expect(count >= 0n).toBe(true);
+  });
+});

--- a/frontend/hooks/useAdminGuard.ts
+++ b/frontend/hooks/useAdminGuard.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useStore } from '@/lib/store';
+import { getPoolConfig } from '@/lib/contracts';
+
+/**
+ * Result of the client-side admin role check.
+ *
+ * - `loading`         — the role check is still in flight.
+ * - `unauthenticated` — no wallet is connected yet.
+ * - `authorized`      — the connected wallet is the on-chain pool admin.
+ * - `denied`          — the connected wallet is not the admin; a redirect to
+ *                       {@link AdminGuardOptions.redirectTo} has been issued.
+ */
+export type AdminGuardStatus = 'loading' | 'unauthenticated' | 'authorized' | 'denied';
+
+export interface AdminGuardResult {
+  status: AdminGuardStatus;
+  /** True only when the connected wallet is verified as the pool admin. */
+  isAdmin: boolean;
+}
+
+export interface AdminGuardOptions {
+  /** Where to send non-admin users. Defaults to `/dashboard`. */
+  redirectTo?: string;
+}
+
+/**
+ * Client-side route guard for `/admin` pages (#393).
+ *
+ * The admin role is read from the contract (`getPoolConfig().admin`) — never a
+ * local flag — and, when available, cryptographically confirmed via the
+ * SEP-0010 JWT. A non-admin (or unverifiable) wallet is redirected to
+ * `redirectTo` before any admin UI renders, so admin controls never flash for
+ * unauthorized users.
+ *
+ * Apply this in the `/admin` layout (which wraps every admin page) or directly
+ * in an individual admin page component.
+ */
+export function useAdminGuard(options: AdminGuardOptions = {}): AdminGuardResult {
+  const { redirectTo = '/dashboard' } = options;
+  const { wallet, poolConfig, setPoolConfig } = useStore();
+  const router = useRouter();
+  const [status, setStatus] = useState<AdminGuardStatus>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function check() {
+      setStatus('loading');
+      try {
+        // Admin identity comes from the contract, not a client-held flag.
+        let config = poolConfig;
+        if (!config) {
+          config = await getPoolConfig();
+          if (cancelled) return;
+          setPoolConfig(config);
+        }
+
+        if (!wallet.connected || !wallet.address) {
+          if (!cancelled) setStatus('unauthenticated');
+          return;
+        }
+
+        let authorized = false;
+        try {
+          // Prefer cryptographic verification via the SEP-0010 JWT.
+          const { verifyToken, getToken } = await import('@/lib/auth');
+          const verified = await verifyToken(getToken());
+          authorized =
+            (verified?.authenticated && verified?.account === config.admin) ||
+            wallet.address === config.admin;
+        } catch {
+          // Fall back to a raw address match if verification is unavailable.
+          authorized = wallet.address === config.admin;
+        }
+
+        if (cancelled) return;
+
+        if (authorized) {
+          setStatus('authorized');
+        } else {
+          // Redirect before any admin UI renders.
+          setStatus('denied');
+          router.replace(redirectTo);
+        }
+      } catch (e) {
+        // Treat any failure to establish admin identity as not-authorized and
+        // route the user away rather than rendering admin controls.
+        console.error('[useAdminGuard] admin check failed:', e);
+        if (cancelled) return;
+        setStatus('denied');
+        router.replace(redirectTo);
+      }
+    }
+
+    void check();
+    return () => {
+      cancelled = true;
+    };
+  }, [wallet.connected, wallet.address, poolConfig, setPoolConfig, router, redirectTo]);
+
+  return { status, isAdmin: status === 'authorized' };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@sentry/nextjs": "9.18.0",
         "@stellar/freighter-api": "^6.0.1",
-        "@stellar/js-xdr": "^4.0.0",
+        "@stellar/js-xdr": "^3.1.2",
         "@stellar/stellar-sdk": "^14.6.1",
         "@swc/helpers": "^0.5.23",
         "jose": "^6.2.3",
@@ -104,6 +104,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3419,6 +3420,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3428,7 +3430,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
       "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -4810,7 +4811,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4845,6 +4845,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5199,6 +5200,7 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -6440,13 +6442,10 @@
       }
     },
     "node_modules/@stellar/js-xdr": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
-      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
-      "engines": {
-        "node": ">=20.0.0",
-        "pnpm": ">=9.0.0"
-      }
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@stellar/stellar-base": {
       "version": "14.1.0",
@@ -6463,11 +6462,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/@stellar/stellar-base/node_modules/@stellar/js-xdr": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
-      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
     },
     "node_modules/@stellar/stellar-sdk": {
       "version": "14.6.1",
@@ -6703,6 +6697,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
       "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6863,6 +6858,7 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -6969,7 +6965,6 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6979,7 +6974,6 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -7130,6 +7124,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -7167,6 +7162,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -7309,6 +7305,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -7793,7 +7790,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -7802,26 +7798,22 @@
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "peer": true
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "peer": true
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ=="
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "peer": true
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA=="
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -7831,14 +7823,12 @@
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "peer": true
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA=="
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -7850,7 +7840,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -7859,7 +7848,6 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -7867,14 +7855,12 @@
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "peer": true
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ=="
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -7890,7 +7876,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -7903,7 +7888,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -7915,7 +7899,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -7929,7 +7912,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -7938,14 +7920,12 @@
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "peer": true
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "peer": true
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -7960,6 +7940,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7991,7 +7972,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -8039,6 +8019,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8802,6 +8783,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9030,7 +9012,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -9408,7 +9389,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -9970,7 +9952,6 @@
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
       "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.3"
@@ -10154,8 +10135,7 @@
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "peer": true
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -10269,6 +10249,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10470,6 +10451,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10950,7 +10932,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -11581,8 +11562,7 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "peer": true
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
@@ -13670,6 +13650,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13984,7 +13965,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
       "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -14373,14 +14353,14 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "peer": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
       "version": "15.5.18",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
       "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
@@ -15236,6 +15216,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15279,6 +15260,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15665,6 +15647,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15677,6 +15660,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -15705,12 +15689,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -15794,7 +15780,8 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -16062,6 +16049,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -17077,7 +17065,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -17175,6 +17162,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17386,6 +17374,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17484,6 +17473,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17664,6 +17654,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18006,7 +17997,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -18106,7 +18096,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -18118,7 +18107,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -18131,7 +18119,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -18139,14 +18126,12 @@
     "node_modules/webpack/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "peer": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -18155,7 +18140,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -18401,6 +18385,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18866,6 +18851,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@sentry/nextjs": "9.18.0",
     "@stellar/freighter-api": "^6.0.1",
-    "@stellar/js-xdr": "^4.0.0",
+    "@stellar/js-xdr": "^3.1.2",
     "@stellar/stellar-sdk": "^14.6.1",
     "@swc/helpers": "^0.5.23",
     "jose": "^6.2.3",
@@ -75,6 +75,7 @@
   },
   "overrides": {
     "serialize-javascript": "7.0.5",
-    "rollup": "4.60.4"
+    "rollup": "4.60.4",
+    "@stellar/js-xdr": "^3.1.2"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
+import { assertRealContractIds } from './e2e/contract-ids';
+
+// #395: in CI, refuse to run against placeholder contract IDs. Locally this is
+// allowed so mock-based specs can run without a deployment.
+if (process.env.CI) {
+  assertRealContractIds();
+}
 
 const defaultBaseURL = 'http://localhost:3000';
 const parsedBaseURL = new URL(process.env.PLAYWRIGHT_BASE_URL ?? defaultBaseURL);


### PR DESCRIPTION
Implements four assigned issues in a single PR.

## #397 — Contract upgrade path with version migration hooks
`invoice` already exposed `version()`, `migration_version()` and `run_migration()` plus the timelocked `propose_upgrade`/`execute_upgrade` flow. This brings the other two contracts to parity:

- **pool** and **credit_score**: add `run_migration(admin)` + `migration_version()` and a `CURRENT_MIGRATION_VERSION` constant, mirroring the invoice hook. Both are admin-only and idempotent (no-op once at the current schema version). `credit_score` also now initializes `MigrationVersion` to `0`.
- Added a `credit_score` integration test (`migration_version` 0→1, version preserved, idempotent re-run, non-admin rejected).
- New `docs/upgrades.md` documenting the version/migration model and the propose → timelock → execute → migrate runbook.

All three contracts now satisfy: `upgrade` path (timelocked propose/execute), `migrate` hook, admin-gating, and a `version()`/`migration_version()` view.

## #393 — Client-side admin role verification
- New `frontend/hooks/useAdminGuard.ts`: reads the admin role from the contract (`getPoolConfig().admin`, cryptographically confirmed via the SEP-0010 JWT when available — never a local flag), exposes loading/unauthenticated/authorized/denied states, and **redirects non-admins to `/dashboard` before any admin UI renders**.
- `app/admin/layout.tsx` now drives its states from the hook. Because the layout wraps every `/admin` page, the guard applies to all of them.
- New E2E test: a non-admin wallet visiting `/admin` is redirected to `/dashboard`.

## #391 — @stellar/stellar-sdk / freighter-api XDR mismatch
Root cause: `@stellar/stellar-base@14` (pulled by `stellar-sdk@14`) requires `@stellar/js-xdr@^3.1.2`, but `package.json` declared a direct `@stellar/js-xdr@^4.0.0`, so **two XDR codecs** were installed. (`freighter-api@6` no longer bundles the SDK, so the SDK/freighter pins themselves are already compatible.)

- Pinned the direct dep to `^3.1.2` and added an `overrides` entry so a single XDR version resolves. Verified locally: `npm ls @stellar/js-xdr` → single `3.1.2`.
- Added a CI step in the `frontend` job that fails if more than one `@stellar/js-xdr` version is installed.

## #395 — E2E tests use real contract IDs, not placeholders
- New `frontend/e2e/contract-ids.ts` resolves contract IDs from env and, in CI, **fails fast** if they are missing or the zeroed placeholder. Wired into `playwright.config.ts`.
- CI `e2e-tests` job now uses real testnet IDs from **repository variables** (`TESTNET_INVOICE_CONTRACT_ID` / `TESTNET_POOL_CONTRACT_ID` / `TESTNET_USDC_TOKEN_ID`) instead of the hardcoded `CAAAA…D2KM` placeholder.
- New E2E test calls a real deployed method (`invoice.get_invoice_count`) via Soroban RPC simulation and asserts the result. It auto-skips locally when no real IDs are configured.

> **Action required for #395:** set the `TESTNET_*_CONTRACT_ID` repository variables to your long-lived testnet deployment. Until then the E2E job will fail fast with a clear message — by design, since the previous green runs never touched a real contract.

## Test plan
- [x] `cargo build --workspace` and `cargo build --target wasm32-unknown-unknown --release` (invoice, pool, credit_score) succeed.
- [x] `cargo test -p credit_score` — migration tests pass.
- [x] `frontend`: `npx tsc --noEmit` and `eslint` clean on all changed/new files.
- [x] `npm ls @stellar/js-xdr` shows a single `3.1.2`; the new CI dedupe check passes locally.

## Heads-up: pre-existing breakage on `main` (out of scope)
The Rust `contracts/` workspace **does not compile on `main`** (confirmed against a pristine `upstream/main`), independent of these issues. To build/verify the #397 migration hooks I made the minimal compile-unblocking fixes:
- Added missing error-enum variants referenced but not defined: `InvoiceError` (`DescriptionTooLong`, `DebtorNameTooLong`, `VerificationHashTooLong`, `ExtensionAlreadyPending`, `InvalidDueDateExtension`, `ExtensionTooLarge`, `NoPendingExtension`), `PoolError` (`KycNotApproved`, `InvalidThreshold`), and a `MaxPaymentHistory` `DataKey` in `credit_score`.
- Added `#[cfg(test)] extern crate std;` to `credit_score` so its `no_std` test module compiles.

These restore the wasm build. The following remain **pre-existing and out of scope** for these four issues:
- `pool`/`invoice` **test modules** don't compile (`soroban_sdk::Val` no longer implements `PartialEq`, used by many existing `assert_eq!` event assertions). For this reason the pool migration test was kept in `credit_score` only.
- `credit_score` has an unenforced payment-history cap (`append_payment_record` is dead code), causing two pre-existing failing tests (`test_payment_history_rolling_window_caps_at_100`, `test_prop_payment_history_ordering`).

Closes #397
Closes #395
Closes #393
Closes #391
