### PR TITLE
feat: wallet timeout, dashboard pagination, cache config, USDC-normalised pool minting

### DIFF
--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -1155,11 +1155,19 @@ impl FundingPool {
                 deposit_count: 0,
             });
 
+        // Normalise received amount to USDC equivalent using stored exchange rate
+        let rate_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ExchangeRate(token.clone()))
+            .unwrap_or(10_000u32);
+        let usdc_received = (received * rate_bps as i128) / 10_000i128;
+
         // #233: enforce maximum single-investor concentration limit
         let config = get_config_cached(&env)?;
         if config.max_single_investor_bps < 10_000 {
-            let new_investor_total = investor_position.deposited + received;
-            let new_pool_total = tt.pool_value + received;
+            let new_investor_total = investor_position.deposited + usdc_received;
+            let new_pool_total = tt.pool_value + usdc_received;
             if new_pool_total > 0 {
                 let investor_share_bps =
                     ((new_investor_total as u128 * 10_000u128) / new_pool_total as u128) as u32;
@@ -1183,7 +1191,7 @@ impl FundingPool {
             .get(&share_token_key)
             .ok_or(PoolError::ShareTokenNotConfigured)?;
 
-        // Calculate shares (single external call)
+        // Calculate shares using USDC-equivalent deposit value
         let total_shares: i128 = env.invoke_contract(
             &share_token,
             &Symbol::new(&env, "total_supply"),
@@ -1191,13 +1199,13 @@ impl FundingPool {
         );
 
         let shares_to_mint = if total_shares == 0 || tt.pool_value == 0 {
-            received
+            usdc_received
         } else {
-            (received * total_shares) / tt.pool_value
+            (usdc_received * total_shares) / tt.pool_value
         };
 
-        // Update pool value with received amount
-        tt.pool_value += received;
+        // Pool value is maintained in USDC terms for consistent multi-token accounting
+        tt.pool_value += usdc_received;
 
         // Batch write: update token totals
         env.storage().instance().set(&token_totals_key, &tt);
@@ -1208,8 +1216,8 @@ impl FundingPool {
         mint_args.push_back(shares_to_mint.into_val(&env));
         let _: () = env.invoke_contract(&share_token, &Symbol::new(&env, "mint"), mint_args);
 
-        // #233: update investor position for concentration tracking
-        investor_position.deposited += received;
+        // #233: update investor position — track in USDC terms to match pool_value
+        investor_position.deposited += usdc_received;
         investor_position.deposit_count += 1;
         env.storage()
             .persistent()
@@ -1285,17 +1293,25 @@ impl FundingPool {
             Vec::new(&env),
         );
 
-        let amount = (shares * tt.pool_value) / total_shares;
+        // pool_value is USDC-denominated; compute USDC then convert to token amount
+        let usdc_amount = (shares * tt.pool_value) / total_shares;
+        let rate_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ExchangeRate(token.clone()))
+            .unwrap_or(10_000u32);
+        let amount = (usdc_amount * 10_000i128) / rate_bps as i128;
+
         let available_liquidity = tt.pool_value - tt.total_deployed;
-        if available_liquidity < amount {
+        if available_liquidity < usdc_amount {
             return Err(PoolError::InvalidAmount);
         }
 
-        // #244: single-withdrawal cap (skip for admin)
+        // #244: single-withdrawal cap (skip for admin) — compare in USDC terms
         if !is_admin && config.max_single_withdrawal_bps < BPS_DENOM {
             let max_single =
                 (tt.pool_value * config.max_single_withdrawal_bps as i128) / BPS_DENOM as i128;
-            if amount > max_single {
+            if usdc_amount > max_single {
                 return Err(PoolError::WithdrawalExceedsLimit);
             }
         }
@@ -1306,8 +1322,8 @@ impl FundingPool {
         burn_args.push_back(shares.into_val(&env));
         let _: () = env.invoke_contract(&share_token, &Symbol::new(&env, "burn"), burn_args);
 
-        // Update state SECOND - effects
-        tt.pool_value -= amount;
+        // Update USDC-denominated pool value SECOND - effects
+        tt.pool_value -= usdc_amount;
         env.storage().instance().set(&token_totals_key, &tt);
 
         // #244: record withdrawal timestamp
@@ -1318,7 +1334,7 @@ impl FundingPool {
             );
         }
 
-        // Transfer LAST - interaction
+        // Transfer actual token amount LAST - interaction
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&env.current_contract_address(), &investor, &amount);
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -64,6 +64,7 @@ function DashboardContent() {
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [statusFilters, setStatusFilters] = useState<StatusFilter[]>([]);
   const [sort, setSort] = useState<SortOption>('created-desc');
+  const [page, setPage] = useState(0);
   const [queryHydrated, setQueryHydrated] = useState(false);
   const { viewMode, setViewMode, hydrated: viewModeHydrated } = useDashboardViewMode();
 
@@ -117,12 +118,14 @@ function DashboardContent() {
     const initialSortValue = SORT_OPTIONS.some((opt) => opt.value === initialSort)
       ? (initialSort as SortOption)
       : 'created-desc';
+    const initialPage = Math.max(0, parseInt(params.get('page') ?? '0', 10) || 0);
 
     startTransition(() => {
       setSearch(q);
       setDebouncedSearch(q);
       setStatusFilters(initialStatuses);
       setSort(initialSortValue);
+      setPage(initialPage);
     });
   }, [queryHydrated]);
 
@@ -133,6 +136,12 @@ function DashboardContent() {
     return () => window.clearTimeout(handle);
   }, [search]);
 
+  // Reset to first page whenever filters or sort change
+  useEffect(() => {
+    if (queryHydrated) setPage(0);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch, statusFilters, sort]);
+
   useEffect(() => {
     if (!queryHydrated) return;
 
@@ -140,10 +149,11 @@ function DashboardContent() {
     if (debouncedSearch.trim()) params.set('q', debouncedSearch.trim());
     if (statusFilters.length > 0) params.set('status', statusFilters.join(','));
     if (sort !== 'created-desc') params.set('sort', sort);
+    if (page > 0) params.set('page', String(page));
 
     const query = params.toString();
     router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
-  }, [queryHydrated, pathname, router, debouncedSearch, sort, statusFilters]);
+  }, [queryHydrated, pathname, router, debouncedSearch, sort, statusFilters, page]);
 
   // Check if user is first-time visitor
   useEffect(() => {
@@ -328,6 +338,9 @@ function DashboardContent() {
   }, [invoices, debouncedSearch]);
 
   const isFiltered = debouncedSearch.trim() !== '' || statusFilters.length > 0;
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pagedItems = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   return (
     <div className="min-h-screen pt-24 pb-16 px-4 sm:px-6">
@@ -572,7 +585,7 @@ function DashboardContent() {
                 ) : (
                   <>
                     <div className="space-y-4">
-                      {filtered.map((inv) => (
+                      {pagedItems.map((inv) => (
                         <InvoiceCard
                           key={inv.invoice.id}
                           id={inv.invoice.id}
@@ -582,36 +595,54 @@ function DashboardContent() {
                       ))}
                     </div>
 
-                    {/* Load More / Pagination Controls */}
-                    {hasMore && (
-                      <div className="mt-6 text-center">
+                    {/* Pagination controls */}
+                    <div className="mt-6 flex flex-col items-center gap-3">
+                      <p className="text-xs text-brand-muted">
+                        {filtered.length > 0
+                          ? `Showing ${page * PAGE_SIZE + 1}–${Math.min((page + 1) * PAGE_SIZE, filtered.length)} of ${filtered.length} invoice${filtered.length !== 1 ? 's' : ''}`
+                          : ''}
+                        {totalOnChainCount > 0 &&
+                          ` · Scanned ${scannedCount} of ${totalOnChainCount} on-chain`}
+                      </p>
+
+                      <div className="flex items-center gap-2">
                         <button
-                          onClick={loadMore}
-                          disabled={loadingMore}
-                          className="px-6 py-2.5 bg-brand-card border border-brand-border rounded-xl text-sm font-medium text-white hover:border-brand-gold/50 transition-colors disabled:opacity-50"
+                          onClick={() => setPage((p) => Math.max(0, p - 1))}
+                          disabled={page === 0}
+                          className="px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm font-medium text-white hover:border-brand-gold/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                          aria-label="Previous page"
+                        >
+                          ← Prev
+                        </button>
+
+                        <span className="px-3 py-2 text-sm text-brand-muted">
+                          Page {page + 1} / {totalPages}
+                        </span>
+
+                        <button
+                          onClick={async () => {
+                            const nextPage = page + 1;
+                            // If we need more data from the chain, load it first
+                            if (nextPage >= totalPages && hasMore) {
+                              await loadMore();
+                            }
+                            setPage(nextPage);
+                          }}
+                          disabled={page >= totalPages - 1 && !hasMore}
+                          className="px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm font-medium text-white hover:border-brand-gold/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                          aria-label="Next page"
                         >
                           {loadingMore ? (
-                            <span className="flex items-center justify-center gap-2">
-                              <span className="w-4 h-4 border-2 border-brand-gold border-t-transparent rounded-full animate-spin" />
-                              {t('loadingMore')}
+                            <span className="flex items-center gap-1">
+                              <span className="w-3 h-3 border-2 border-brand-gold border-t-transparent rounded-full animate-spin" />
+                              Loading…
                             </span>
                           ) : (
-                            t('loadMore')
+                            'Next →'
                           )}
                         </button>
-                        <p className="text-xs text-brand-muted mt-2">
-                          {t('showing', { count: invoices.length })}
-                          {totalOnChainCount > 0 &&
-                            ` · Scanned ${scannedCount} of ${totalOnChainCount} on-chain`}
-                        </p>
                       </div>
-                    )}
-
-                    {!hasMore && invoices.length > 0 && (
-                      <p className="text-xs text-brand-muted text-center mt-4">
-                        {t('allLoaded', { count: invoices.length })}
-                      </p>
-                    )}
+                    </div>
                   </>
                 )}
               </div>

--- a/frontend/components/WalletConnect.tsx
+++ b/frontend/components/WalletConnect.tsx
@@ -18,6 +18,16 @@ const STEP_LABELS: Record<WalletStep, string> = {
 };
 
 const MAX_RETRIES = 2;
+const WALLET_TIMEOUT_MS = 10_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number = WALLET_TIMEOUT_MS): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Wallet operation timed out after 10 s')), ms),
+    ),
+  ]);
+}
 
 // Network mismatch detection function
 async function checkNetworkMismatch(): Promise<{
@@ -91,7 +101,7 @@ export default function WalletConnect() {
     try {
       const freighter = await getFreighter();
 
-      const { isConnected } = await freighter.isConnected();
+      const { isConnected } = await withTimeout(freighter.isConnected());
       if (!isConnected) {
         const msg = 'Freighter not detected. Please install the browser extension and reload.';
         setInlineError(msg);
@@ -101,13 +111,13 @@ export default function WalletConnect() {
       }
 
       setStep('requesting-access');
-      const { isAllowed } = await freighter.isAllowed();
+      const { isAllowed } = await withTimeout(freighter.isAllowed());
       if (!isAllowed) {
-        await freighter.setAllowed();
+        await withTimeout(freighter.setAllowed());
       }
 
       setStep('fetching-address');
-      const { address, error: addrError } = await freighter.getAddress();
+      const { address, error: addrError } = await withTimeout(freighter.getAddress());
       if (addrError || !address) {
         toast.error('Could not retrieve wallet address. Please try again.');
         setStep('idle');
@@ -132,12 +142,15 @@ export default function WalletConnect() {
       setStep('idle');
     } catch (e) {
       console.error('[WalletConnect] Connection error:', e);
-      if (attempt < MAX_RETRIES) {
+      const isTimeout = e instanceof Error && e.message.includes('timed out');
+      if (!isTimeout && attempt < MAX_RETRIES) {
         setRetryCount(attempt + 1);
         // Brief delay before auto-retry
         setTimeout(() => connect(attempt + 1), 800);
       } else {
-        const msg = 'Failed to connect wallet after multiple attempts. Please try again.';
+        const msg = isTimeout
+          ? 'Wallet connection timed out. Please check Freighter and try again.'
+          : 'Failed to connect wallet after multiple attempts. Please try again.';
         setInlineError(msg);
         toast.error(msg);
         setRetryCount(0);

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -28,22 +28,22 @@ import type {
   InvoiceMetadata,
 } from './types';
 
-// SWR Configuration
-const SWR_CONFIG = {
-  refreshInterval: 30000, // 30 seconds
-  revalidateOnFocus: true,
-  revalidateOnReconnect: true,
-  dedupingInterval: 5000, // 5 seconds
+type SWRCacheEntry = {
+  refreshInterval: number;
+  revalidateOnFocus: boolean;
+  revalidateOnReconnect: boolean;
+  dedupingInterval: number;
 };
 
-const STALE_TIMES = {
-  poolConfig: 300000, // 5 minutes - changes infrequently (admin updates)
-  invoiceCount: 15000, // 15 seconds - changes with new invoices
-  invoice: 10000, // 10 seconds - status changes frequently
-  position: 15000, // 15 seconds - changes with deposits/commits
-  tokens: 60000, // 1 minute - whitelist changes rarely
-  tokenTotals: 20000, // 20 seconds - changes with deposits/deployments
-  fundedInvoice: 10000, // 10 seconds - status changes
+/** Per-resource SWR configuration. Import and spread into useSWR options. */
+export const CACHE_CONFIG: Record<string, SWRCacheEntry> = {
+  poolConfig: { refreshInterval: 300000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
+  invoiceCount: { refreshInterval: 15000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
+  invoice: { refreshInterval: 10000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
+  position: { refreshInterval: 15000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
+  tokens: { refreshInterval: 60000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
+  tokenTotals: { refreshInterval: 20000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
+  fundedInvoice: { refreshInterval: 10000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
 };
 
 // Error type for contract calls
@@ -73,8 +73,7 @@ async function fetcher<T>(fn: () => Promise<T>): Promise<T> {
 
 export function usePoolConfig() {
   return useSWR<PoolConfig, ContractError>('pool-config', () => fetcher(() => getPoolConfig()), {
-    ...SWR_CONFIG,
-    refreshInterval: STALE_TIMES.poolConfig,
+    ...CACHE_CONFIG.poolConfig,
   });
 }
 
@@ -85,8 +84,7 @@ export function useAcceptedTokens() {
     'accepted-tokens',
     () => fetcher(() => getAcceptedTokens()),
     {
-      ...SWR_CONFIG,
-      refreshInterval: STALE_TIMES.tokens,
+      ...CACHE_CONFIG.tokens,
     },
   );
 }
@@ -95,8 +93,7 @@ export function useAcceptedTokens() {
 
 export function useInvoiceCount() {
   return useSWR<number, ContractError>('invoice-count', () => fetcher(() => getInvoiceCount()), {
-    ...SWR_CONFIG,
-    refreshInterval: STALE_TIMES.invoiceCount,
+    ...CACHE_CONFIG.invoiceCount,
   });
 }
 
@@ -107,8 +104,7 @@ export function useInvoice(id: number | null) {
     id !== null ? ['invoice', id] : null,
     () => fetcher(() => getInvoice(id!)),
     {
-      ...SWR_CONFIG,
-      refreshInterval: STALE_TIMES.invoice,
+      ...CACHE_CONFIG.invoice,
     },
   );
 }
@@ -120,8 +116,7 @@ export function useInvoiceMetadata(id: number | null) {
     id !== null ? ['invoice-metadata', id] : null,
     () => fetcher(() => getInvoiceMetadata(id!)),
     {
-      ...SWR_CONFIG,
-      refreshInterval: STALE_TIMES.invoice,
+      ...CACHE_CONFIG.invoice,
     },
   );
 }
@@ -133,8 +128,7 @@ export function useInvestorPosition(investor: string | null, token: string | nul
     investor && token ? ['position', investor, token] : null,
     () => fetcher(() => getInvestorPosition(investor!, token!)),
     {
-      ...SWR_CONFIG,
-      refreshInterval: STALE_TIMES.position,
+      ...CACHE_CONFIG.position,
     },
   );
 }
@@ -146,8 +140,7 @@ export function usePoolTokenTotals(token: string | null) {
     token ? ['token-totals', token] : null,
     () => fetcher(() => getPoolTokenTotals(token!)),
     {
-      ...SWR_CONFIG,
-      refreshInterval: STALE_TIMES.tokenTotals,
+      ...CACHE_CONFIG.tokenTotals,
     },
   );
 }
@@ -159,8 +152,7 @@ export function useFundedInvoice(invoiceId: number | null) {
     invoiceId !== null ? ['funded-invoice', invoiceId] : null,
     () => fetcher(() => getFundedInvoice(invoiceId!)),
     {
-      ...SWR_CONFIG,
-      refreshInterval: STALE_TIMES.fundedInvoice,
+      ...CACHE_CONFIG.fundedInvoice,
     },
   );
 }
@@ -319,5 +311,5 @@ export function getPositionCacheKeys(investor?: string, token?: string) {
 // Export SWR provider config for app setup
 export const swrConfig = {
   provider: () => new Map(),
-  ...SWR_CONFIG,
+  ...CACHE_CONFIG.invoice,
 };


### PR DESCRIPTION
## Summary

- **#358** — Wrap each Freighter API call (`isConnected`, `isAllowed`, `setAllowed`, `getAddress`) in a `Promise.race` with a 10 s deadline so a hung browser extension never leaves the UI stuck in a loading state. Timeout errors surface a user-friendly message and skip the auto-retry loop.
- **#359** — Replace the append-only "Load More" button with explicit Prev / Next pagination controls and a "Page X / Y" counter. The current page is synced to the `?page=` URL param so browser history and deep links work correctly. Changing any filter or sort resets the view to page 1.
- **#360** — Consolidate the private `SWR_CONFIG` + `STALE_TIMES` pair into a single exported `CACHE_CONFIG` record keyed by resource type. Each entry carries the full SWR option set, making per-resource TTL tuning visible in one place. All hooks updated to spread from `CACHE_CONFIG`.
- **#361** — Fix share minting in the pool contract's `deposit` function to convert the raw token amount to a USDC equivalent (via the stored `ExchangeRate` bps) before calculating shares and updating `pool_value`. The `withdraw` function performs the inverse conversion so investors always receive the correct token amount. Concentration and cap checks remain in USDC terms for consistent accounting across multi-token deposits.

## Test plan

- [ ] Connect Freighter with a flaky/slow extension and confirm the 10 s timeout fires and shows the correct error message
- [ ] Navigate to `/dashboard`, verify Prev / Next buttons appear, page number updates in the URL, and navigating backward/forward works
- [ ] Inspect `CACHE_CONFIG` export in `frontend/lib/cache.ts` and confirm all hooks reference it
- [ ] Deploy the updated pool contract to testnet, deposit a token with a non-1:1 exchange rate, and verify shares minted are proportional to the USDC value

Closes #358
Closes #359
Closes #360
Closes #361