### PR TITLE
fix: implement security headers, cache TTLs, contract validation, and wallet timeout

### DIFF
--- a/frontend/components/WalletConnect.tsx
+++ b/frontend/components/WalletConnect.tsx
@@ -21,12 +21,11 @@ const MAX_RETRIES = 2;
 const WALLET_TIMEOUT_MS = 10_000;
 
 function withTimeout<T>(promise: Promise<T>, ms: number = WALLET_TIMEOUT_MS): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('Wallet operation timed out after 10 s')), ms),
-    ),
-  ]);
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('Wallet operation timed out after 10 s')), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 // Network mismatch detection function

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -35,15 +35,23 @@ type SWRCacheEntry = {
   dedupingInterval: number;
 };
 
+/** Per-data-type TTLs (milliseconds). Import and refer to these directly. */
+export const CACHE_TTL = {
+  poolConfig: 5 * 60_000,
+  invoiceStatus: 15_000,
+  creditScore: 60_000,
+  walletBalance: 30_000,
+} as const;
+
 /** Per-resource SWR configuration. Import and spread into useSWR options. */
 export const CACHE_CONFIG: Record<string, SWRCacheEntry> = {
-  poolConfig: { refreshInterval: 300000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
-  invoiceCount: { refreshInterval: 15000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
-  invoice: { refreshInterval: 10000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
-  position: { refreshInterval: 15000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
-  tokens: { refreshInterval: 60000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
-  tokenTotals: { refreshInterval: 20000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
-  fundedInvoice: { refreshInterval: 10000, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: 5000 },
+  poolConfig: { refreshInterval: CACHE_TTL.poolConfig, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.poolConfig },
+  invoiceCount: { refreshInterval: CACHE_TTL.invoiceStatus, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.invoiceStatus },
+  invoice: { refreshInterval: CACHE_TTL.invoiceStatus, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.invoiceStatus },
+  position: { refreshInterval: CACHE_TTL.invoiceStatus, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.invoiceStatus },
+  tokens: { refreshInterval: CACHE_TTL.creditScore, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.creditScore },
+  tokenTotals: { refreshInterval: CACHE_TTL.walletBalance, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.walletBalance },
+  fundedInvoice: { refreshInterval: CACHE_TTL.invoiceStatus, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.invoiceStatus },
 };
 
 // Error type for contract calls

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -28,6 +28,21 @@ import type {
   GovernanceProposal,
 } from './types';
 
+// ── Contract ID validation (#399) ────────────────────────────────────────────
+
+function validateContractId(id: string, name: string): string {
+  if (!/^C[A-Z2-7]{55}$/.test(id)) {
+    throw new Error(`Invalid contract ID for ${name}: "${id}"`);
+  }
+  return id;
+}
+
+validateContractId(INVOICE_CONTRACT_ID, 'invoice');
+validateContractId(POOL_CONTRACT_ID, 'pool');
+if (GOVERNANCE_CONTRACT_ID) {
+  validateContractId(GOVERNANCE_CONTRACT_ID, 'governance');
+}
+
 // ── Mock mode (#229) ─────────────────────────────────────────────────────────
 // Set NEXT_PUBLIC_USE_MOCK=true to read from the local json-server instead of
 // making live Soroban RPC calls. Useful for frontend-only development when no

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -30,6 +30,23 @@ if (!IS_CI) {
   }
 }
 
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'nonce-{NONCE}'",
+      "style-src 'self' 'unsafe-inline'",
+      "connect-src 'self' https://horizon-testnet.stellar.org https://horizon.stellar.org",
+      "img-src 'self' data:",
+      "frame-ancestors 'none'",
+    ].join('; '),
+  },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -41,6 +58,14 @@ const nextConfig = {
       tls: false,
     };
     return config;
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
Closes #401
Closes #400
Closes #399
Closes #398

## Summary

Four frontend fixes implemented in a single PR:

1. **#401** — CSP security headers in `next.config.mjs`: added strict Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy headers via Next.js `headers()`
2. **#400** — Per-type TTLs in `cache.ts`: defined `CACHE_TTL` constants differentiated by data type (pool: 5m, invoice: 15s, credit: 60s, wallet: 30s) and applied them to both `refreshInterval` and `dedupingInterval`
3. **#399** — Contract ID validation in `contracts.ts`: added `validateContractId` with base32 regex (`/^C[A-Z2-7]{55}$/`) that runs at module load time, failing fast on malformed IDs
4. **#398** — WalletConnect timeout fix: improved `withTimeout` helper to clear the timer via `.finally()`, preventing unhandled promise rejections when the actual operation completes before the timeout