### PR TITLE
feat add oracle price feed integration tests

### DIFF
--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -59,6 +59,13 @@ pub struct ExchangeRateBounds {
 
 #[contracttype]
 #[derive(Clone)]
+pub struct OraclePrice {
+    pub price_bps: u32,
+    pub updated_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
 pub struct InvestorPosition {
     pub deposited: i128,
     pub available: i128,
@@ -143,6 +150,7 @@ pub enum DataKey {
     // #111: exchange rate for each accepted token (bps of USD, e.g. 10000 = 1:1 USD)
     ExchangeRate(Address),
     ExchangeRateBounds(Address),
+    PriceOracle(Address),
     // #109: KYC / investor whitelist
     KycRequired,
     InvestorKyc(Address),
@@ -245,6 +253,64 @@ fn required_collateral(principal: i128, config: &CollateralConfig) -> i128 {
         return 0;
     }
     ((principal as u128 * config.collateral_bps as u128) / BPS_DENOM as u128) as i128
+}
+
+fn div_ceil_i128(numerator: i128, denominator: i128) -> i128 {
+    if denominator <= 0 {
+        panic!("division denominator must be positive");
+    }
+    (numerator + denominator - 1) / denominator
+}
+
+fn validated_exchange_rate(env: &Env, token: &Address) -> u32 {
+    let oracle: Option<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKey::PriceOracle(token.clone()));
+
+    match oracle {
+        Some(oracle_id) => {
+            let mut args = Vec::new(env);
+            args.push_back(token.clone().into_val(env));
+            let price: OraclePrice =
+                env.invoke_contract(&oracle_id, &Symbol::new(env, "latest_price"), args);
+
+            if price.price_bps == 0 {
+                panic!("oracle price must be positive");
+            }
+
+            let now = env.ledger().timestamp();
+            if price.updated_at > now || now - price.updated_at > 86_400 {
+                panic!("oracle price is stale");
+            }
+
+            price.price_bps
+        }
+        None => env
+            .storage()
+            .instance()
+            .get(&DataKey::ExchangeRate(token.clone()))
+            .unwrap_or(10_000u32),
+    }
+}
+
+fn required_collateral_amount(
+    env: &Env,
+    token: &Address,
+    principal: i128,
+    config: &CollateralConfig,
+) -> i128 {
+    let required_usd = required_collateral(principal, config);
+    if required_usd == 0 {
+        return 0;
+    }
+    let rate_bps = validated_exchange_rate(env, token) as i128;
+    div_ceil_i128(required_usd * BPS_DENOM as i128, rate_bps)
+}
+
+fn collateral_value(env: &Env, token: &Address, amount: i128) -> i128 {
+    let rate_bps = validated_exchange_rate(env, token) as i128;
+    (amount * rate_bps) / BPS_DENOM as i128
 }
 
 fn fund_invoice_request(
@@ -642,11 +708,7 @@ impl FundingPool {
             .unwrap_or_default();
 
         let snapshot_key = DataKey::InvestorRewardSnapshot(investor.clone(), token.clone());
-        let last_rps: i128 = env
-            .storage()
-            .persistent()
-            .get(&snapshot_key)
-            .unwrap_or(0);
+        let last_rps: i128 = env.storage().persistent().get(&snapshot_key).unwrap_or(0);
 
         let share_token: Address = env
             .storage()
@@ -654,15 +716,12 @@ impl FundingPool {
             .get(&DataKey::ShareToken(token.clone()))
             .unwrap();
 
-        let investor_shares: i128 = env.invoke_contract(
-            &share_token,
-            &Symbol::new(&env, "balance"),
-            {
+        let investor_shares: i128 =
+            env.invoke_contract(&share_token, &Symbol::new(&env, "balance"), {
                 let mut args = Vec::new(&env);
                 args.push_back(investor.clone().into_val(&env));
                 args
-            },
-        );
+            });
 
         let claimable = if investor_shares > 0 && tt.reward_per_share > last_rps {
             ((tt.reward_per_share - last_rps) * investor_shares) / REWARD_PRECISION
@@ -734,7 +793,9 @@ impl FundingPool {
                     if d.settled {
                         panic!("collateral already settled");
                     }
-                    if d.amount < req_collateral {
+                    let required_amount =
+                        required_collateral_amount(&env, &d.token, principal, &collateral_cfg);
+                    if d.amount < required_amount {
                         panic!("insufficient collateral deposited");
                     }
                 }
@@ -989,6 +1050,7 @@ impl FundingPool {
         if amount <= 0 {
             panic!("collateral amount must be positive");
         }
+        let _ = validated_exchange_rate(&env, &token);
 
         // Prevent depositing collateral for an already-funded invoice.
         if env
@@ -1095,7 +1157,8 @@ impl FundingPool {
 
         // The seized collateral reduces the effective loss: add it to pool_value and
         // reduce total_deployed by the original principal (the invoice is now a loss).
-        tt.pool_value += col.amount;
+        let seized_value = collateral_value(&env, &col.token, col.amount);
+        tt.pool_value += seized_value;
         tt.total_deployed -= record.principal;
         env.storage().instance().set(&token_totals_key, &tt);
 
@@ -1393,13 +1456,29 @@ impl FundingPool {
             .publish((EVT, symbol_short!("set_rate")), (admin, token, rate_bps));
     }
 
+    /// Set an oracle contract for live token price validation.
+    /// The oracle must expose `latest_price(token: Address) -> OraclePrice`.
+    pub fn set_price_oracle(env: Env, admin: Address, token: Address, oracle: Address) {
+        admin.require_auth();
+        bump_instance(&env);
+        Self::require_admin(&env, &admin);
+        Self::assert_accepted_token(&env, &token);
+        env.storage()
+            .instance()
+            .set(&DataKey::PriceOracle(token.clone()), &oracle);
+        env.events()
+            .publish((EVT, symbol_short!("set_orcl")), (admin, token, oracle));
+    }
+
+    pub fn get_price_oracle(env: Env, token: Address) -> Option<Address> {
+        bump_instance(&env);
+        env.storage().instance().get(&DataKey::PriceOracle(token))
+    }
+
     /// Returns the USD exchange rate for `token` in bps (defaults to 10000 = 1:1).
     pub fn get_exchange_rate(env: Env, token: Address) -> u32 {
         bump_instance(&env);
-        env.storage()
-            .instance()
-            .get(&DataKey::ExchangeRate(token))
-            .unwrap_or(10_000u32)
+        validated_exchange_rate(&env, &token)
     }
 
     pub fn get_rate_bounds(env: Env, token: Address) -> ExchangeRateBounds {

--- a/contracts/tests/integration_tests.rs
+++ b/contracts/tests/integration_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::{
+    contract, contractimpl, contracttype,
     testutils::{Address as _, Ledger},
     Address, Env, String,
 };
@@ -28,6 +29,190 @@ mod share {
     soroban_sdk::contractimport!(
         file = "../target/wasm32-unknown-unknown/release/share.wasm"
     );
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum MockOracleKey {
+    PriceBps,
+    UpdatedAt,
+    Unavailable,
+}
+
+#[contract]
+struct MockOracle;
+
+#[contractimpl]
+impl MockOracle {
+    pub fn initialize(env: Env, price_bps: u32, updated_at: u64) {
+        env.storage()
+            .instance()
+            .set(&MockOracleKey::PriceBps, &price_bps);
+        env.storage()
+            .instance()
+            .set(&MockOracleKey::UpdatedAt, &updated_at);
+        env.storage()
+            .instance()
+            .set(&MockOracleKey::Unavailable, &false);
+    }
+
+    pub fn set_price(env: Env, price_bps: u32, updated_at: u64) {
+        env.storage()
+            .instance()
+            .set(&MockOracleKey::PriceBps, &price_bps);
+        env.storage()
+            .instance()
+            .set(&MockOracleKey::UpdatedAt, &updated_at);
+    }
+
+    pub fn set_unavailable(env: Env, unavailable: bool) {
+        env.storage()
+            .instance()
+            .set(&MockOracleKey::Unavailable, &unavailable);
+    }
+
+    pub fn latest_price(env: Env, _token: Address) -> pool::OraclePrice {
+        let unavailable: bool = env
+            .storage()
+            .instance()
+            .get(&MockOracleKey::Unavailable)
+            .unwrap_or(false);
+        if unavailable {
+            panic!("oracle unavailable");
+        }
+
+        pool::OraclePrice {
+            price_bps: env
+                .storage()
+                .instance()
+                .get(&MockOracleKey::PriceBps)
+                .unwrap_or(10_000),
+            updated_at: env
+                .storage()
+                .instance()
+                .get(&MockOracleKey::UpdatedAt)
+                .unwrap_or(0),
+        }
+    }
+}
+
+struct TestContracts {
+    env: Env,
+    admin: Address,
+    sme: Address,
+    investor: Address,
+    usdc_id: Address,
+    pool_id: Address,
+    oracle_id: Address,
+}
+
+fn setup_oracle_pool() -> TestContracts {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 100_000);
+
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let invoice_id = env.register_contract_wasm(None, invoice::WASM);
+    let pool_id = env.register_contract_wasm(None, pool::WASM);
+    let share_id = env.register_contract_wasm(None, share::WASM);
+    let oracle_id = env.register_contract(None, MockOracle);
+    let usdc_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+
+    let invoice_client = invoice::Client::new(&env, &invoice_id);
+    let pool_client = pool::Client::new(&env, &pool_id);
+    let share_client = share::Client::new(&env, &share_id);
+    let oracle_client = MockOracleClient::new(&env, &oracle_id);
+
+    invoice_client.initialize(&admin, &pool_id, &10_000_000_000i128, &30u64 * 86_400u64);
+    share_client.initialize(
+        &admin,
+        &7u32,
+        &String::from_str(&env, "Pool Shares"),
+        &String::from_str(&env, "POOL"),
+    );
+    pool_client.initialize(&admin, &usdc_id, &share_id, &invoice_id);
+    oracle_client.initialize(&10_000u32, &env.ledger().timestamp());
+    pool_client.set_price_oracle(&admin, &usdc_id, &oracle_id);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id)
+        .mint(&investor, &20_000_000_000i128);
+    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id)
+        .mint(&sme, &20_000_000_000i128);
+
+    TestContracts {
+        env,
+        admin,
+        sme,
+        investor,
+        usdc_id,
+        pool_id,
+        oracle_id,
+    }
+}
+
+#[test]
+#[should_panic(expected = "oracle price is stale")]
+fn test_stale_oracle_price_rejected() {
+    let ctx = setup_oracle_pool();
+    let pool_client = pool::Client::new(&ctx.env, &ctx.pool_id);
+    let oracle_client = MockOracleClient::new(&ctx.env, &ctx.oracle_id);
+
+    oracle_client.set_price(&10_000u32, &(ctx.env.ledger().timestamp() - 86_401));
+    pool_client.deposit_collateral(&1u64, &ctx.sme, &ctx.usdc_id, &2_000i128);
+}
+
+#[test]
+#[should_panic(expected = "oracle price must be positive")]
+fn test_oracle_zero_price_handled() {
+    let ctx = setup_oracle_pool();
+    let pool_client = pool::Client::new(&ctx.env, &ctx.pool_id);
+    let oracle_client = MockOracleClient::new(&ctx.env, &ctx.oracle_id);
+
+    oracle_client.set_price(&0u32, &ctx.env.ledger().timestamp());
+    pool_client.deposit_collateral(&1u64, &ctx.sme, &ctx.usdc_id, &2_000i128);
+}
+
+#[test]
+fn test_price_change_between_deposit_and_seizure() {
+    let ctx = setup_oracle_pool();
+    let pool_client = pool::Client::new(&ctx.env, &ctx.pool_id);
+    let oracle_client = MockOracleClient::new(&ctx.env, &ctx.oracle_id);
+
+    pool_client.set_collateral_config(&ctx.admin, &1i128, &2_000u32);
+    pool_client.deposit(&ctx.investor, &ctx.usdc_id, &20_000i128);
+    pool_client.deposit_collateral(&1u64, &ctx.sme, &ctx.usdc_id, &2_000i128);
+
+    let due_date = ctx.env.ledger().timestamp() + 30 * 86_400;
+    pool_client.fund_invoice(
+        &ctx.admin,
+        &1u64,
+        &10_000i128,
+        &ctx.sme,
+        &due_date,
+        &ctx.usdc_id,
+    );
+
+    oracle_client.set_price(&5_000u32, &ctx.env.ledger().timestamp());
+    pool_client.seize_collateral(&ctx.admin, &1u64);
+
+    let totals = pool_client.get_token_totals(&ctx.usdc_id);
+    assert_eq!(totals.pool_value, 21_000i128);
+    assert_eq!(totals.total_deployed, 0i128);
+}
+
+#[test]
+#[should_panic(expected = "oracle unavailable")]
+fn test_oracle_unavailable_fallback() {
+    let ctx = setup_oracle_pool();
+    let pool_client = pool::Client::new(&ctx.env, &ctx.pool_id);
+    let oracle_client = MockOracleClient::new(&ctx.env, &ctx.oracle_id);
+
+    oracle_client.set_unavailable(&true);
+    pool_client.deposit_collateral(&1u64, &ctx.sme, &ctx.usdc_id, &2_000i128);
 }
 
 /// Integration test: Complete invoice lifecycle with pool funding and credit scoring


### PR DESCRIPTION
## Summary

<!-- Brief description of what changed and why. -->

## Related Issue

<!-- Every PR should close or reference at least one issue. -->
Closes #

## Type of Change

<!-- Check all that apply. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Test-only change
- [ ] DevOps / CI change

## Changes

<!-- List the key changes: new files, modified functions, removed code. -->
-
-

## Testing Performed

<!-- Describe how you verified the changes work. -->
-

## Smart Contract Security Checklist

<!-- Required for any change to `contracts/`. Delete section if not applicable. -->

- [ ] CEI pattern followed (checks before effects before interactions)
- [ ] All arithmetic uses checked operations (`checked_add`, `checked_sub`, `saturating_*`) — no bare `+` or `*` without overflow guard
- [ ] New state-changing functions have reentrancy guard (`non_reentrant_start` / `non_reentrant_end`)
- [ ] New admin functions emit events
- [ ] No `panic!()` with string messages — typed errors (`PoolError`, `InvoiceError`) used instead
- [ ] Storage TTL extended in all functions that touch persistent state
- [ ] Fuzz test added or updated for new invariants

## Checklist

- [ ] Tests added or updated (`cargo test` / `npm test` passes)
- [ ] Documentation updated (README, inline docs, API reference)
- [ ] For security or incident-response changes, at least one core team approval is noted in this PR
- [ ] `cargo fmt` and `cargo clippy -- -D warnings` pass (if contracts changed)
- [ ] `npm run lint` and `npm run build` pass (if frontend changed)
- [ ] No secrets, private keys, or production contract IDs in code
- [ ] API reference updated if contract interface changed
- [ ] PR title is descriptive and follows `type(scope): description` convention
- [ ] Smart contract security checklist above completed (if `contracts/` changed)

## Screenshots (UI changes only)

<!-- Add before/after screenshots for any frontend changes. -->
Closes #418 