### PR TITLE
fix invoice status theme classes

### DIFF
--- a/frontend/__tests__/components/InvoiceCard.test.tsx
+++ b/frontend/__tests__/components/InvoiceCard.test.tsx
@@ -59,6 +59,22 @@ describe('InvoiceCard', () => {
     expect(screen.getByText('Defaulted')).toBeInTheDocument();
   });
 
+  it('uses theme-aware Tailwind status classes for each invoice status', () => {
+    const expectedClasses: Record<string, string[]> = {
+      Pending: ['text-yellow-700', 'dark:text-yellow-400'],
+      Funded: ['text-blue-700', 'dark:text-blue-400'],
+      Paid: ['text-green-700', 'dark:text-green-400'],
+      Defaulted: ['text-red-700', 'dark:text-red-400'],
+    };
+
+    const { rerender } = render(<InvoiceCard id={1} metadata={makeMeta({ status: 'Pending' })} />);
+
+    for (const [status, classes] of Object.entries(expectedClasses)) {
+      rerender(<InvoiceCard id={1} metadata={makeMeta({ status })} />);
+      expect(screen.getByText(status)).toHaveClass(...classes);
+    }
+  });
+
   it('shows a days-left countdown for future due dates', () => {
     const meta = makeMeta({ dueDate: Math.floor(Date.now() / 1000) + 10 * 86_400 });
     render(<InvoiceCard id={1} metadata={meta} />);

--- a/frontend/components/InvoiceCard.tsx
+++ b/frontend/components/InvoiceCard.tsx
@@ -16,6 +16,13 @@ const statusLabel: Record<string, string> = {
   Defaulted: 'Defaulted',
 };
 
+const statusClass: Record<string, string> = {
+  Pending: 'bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/40 dark:text-yellow-400 dark:border-yellow-800/50',
+  Funded: 'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/40 dark:text-blue-400 dark:border-blue-800/50',
+  Paid: 'bg-green-100 text-green-700 border-green-300 dark:bg-green-900/40 dark:text-green-400 dark:border-green-800/50',
+  Defaulted: 'bg-red-100 text-red-700 border-red-300 dark:bg-red-900/40 dark:text-red-400 dark:border-red-800/50',
+};
+
 export default function InvoiceCard({ id, metadata, fundedAmount }: Props) {
   const days = daysUntil(metadata.dueDate);
   const isOverdue = days < 0;
@@ -53,7 +60,9 @@ export default function InvoiceCard({ id, metadata, fundedAmount }: Props) {
           </div>
         </div>
         <span
-          className={`text-xs font-medium px-2.5 py-1 rounded-full flex-shrink-0 badge-${metadata.status.toLowerCase()}`}
+          className={`text-xs font-medium px-2.5 py-1 rounded-full flex-shrink-0 border ${
+            statusClass[metadata.status] ?? 'bg-slate-100 text-slate-700 border-slate-300 dark:bg-slate-900/40 dark:text-slate-400 dark:border-slate-800/50'
+          }`}
         >
           {statusLabel[metadata.status] ?? metadata.status}
         </span>


### PR DESCRIPTION
## Summary

<!-- Brief description of what changed and why. -->

## Related Issue

<!-- Every PR should close or reference at least one issue. -->
Closes #

## Type of Change

<!-- Check all that apply. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Test-only change
- [ ] DevOps / CI change

## Changes

<!-- List the key changes: new files, modified functions, removed code. -->
-
-

## Testing Performed

<!-- Describe how you verified the changes work. -->
-

## Smart Contract Security Checklist

<!-- Required for any change to `contracts/`. Delete section if not applicable. -->

- [ ] CEI pattern followed (checks before effects before interactions)
- [ ] All arithmetic uses checked operations (`checked_add`, `checked_sub`, `saturating_*`) — no bare `+` or `*` without overflow guard
- [ ] New state-changing functions have reentrancy guard (`non_reentrant_start` / `non_reentrant_end`)
- [ ] New admin functions emit events
- [ ] No `panic!()` with string messages — typed errors (`PoolError`, `InvoiceError`) used instead
- [ ] Storage TTL extended in all functions that touch persistent state
- [ ] Fuzz test added or updated for new invariants

## Checklist

- [ ] Tests added or updated (`cargo test` / `npm test` passes)
- [ ] Documentation updated (README, inline docs, API reference)
- [ ] For security or incident-response changes, at least one core team approval is noted in this PR
- [ ] `cargo fmt` and `cargo clippy -- -D warnings` pass (if contracts changed)
- [ ] `npm run lint` and `npm run build` pass (if frontend changed)
- [ ] No secrets, private keys, or production contract IDs in code
- [ ] API reference updated if contract interface changed
- [ ] PR title is descriptive and follows `type(scope): description` convention
- [ ] Smart contract security checklist above completed (if `contracts/` changed)

## Screenshots (UI changes only)

<!-- Add before/after screenshots for any frontend changes. -->
Closes #388 