### PR TITLE
fix: fetch live yield_bps from pool config in APYCalculator

### DIFF
--- a/frontend/__tests__/components/APYCalculator.test.tsx
+++ b/frontend/__tests__/components/APYCalculator.test.tsx
@@ -17,14 +17,15 @@ describe('APYCalculator', () => {
 
   it('renders live APY from pool config', () => {
     mockedUsePoolConfig.mockReturnValue({
-      data: { yieldBps: 500 } as any,
+      data: { yieldBps: 500 } as ReturnType<typeof usePoolConfig>['data'],
       error: undefined,
       isLoading: false,
-    } as any);
+    } as ReturnType<typeof usePoolConfig>);
 
     render(<APYCalculator />);
 
     expect(screen.getByText(/5\.00% APY/i)).toBeInTheDocument();
+    expect(screen.queryByText(/fallback APY/i)).not.toBeInTheDocument();
   });
 
   it('uses fallback APY with warning when pool config loading fails', () => {
@@ -32,11 +33,38 @@ describe('APYCalculator', () => {
       data: undefined,
       error: new Error('Contract fetch failed'),
       isLoading: false,
-    } as any);
+    } as ReturnType<typeof usePoolConfig>);
 
     render(<APYCalculator />);
 
     expect(screen.getByText(/8\.00% APY/i)).toBeInTheDocument();
     expect(screen.getByText(/fallback APY/i)).toBeInTheDocument();
+  });
+
+  it('shows loading skeleton while config is fetching on initial load', () => {
+    mockedUsePoolConfig.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+    } as ReturnType<typeof usePoolConfig>);
+
+    render(<APYCalculator />);
+
+    expect(screen.getByRole('status', { name: 'Loading earnings calculator' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Earnings calculator/ })).not.toBeInTheDocument();
+  });
+
+  it('renders calculator body when data is available (yieldBps fetched, not hardcoded)', () => {
+    mockedUsePoolConfig.mockReturnValue({
+      data: { yieldBps: 1200 } as ReturnType<typeof usePoolConfig>['data'],
+      error: undefined,
+      isLoading: false,
+    } as ReturnType<typeof usePoolConfig>);
+
+    render(<APYCalculator />);
+
+    expect(screen.getByText(/12\.00% APY/i)).toBeInTheDocument();
+    expect(screen.getByText(/Earnings calculator/i)).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/APYCalculator.tsx
+++ b/frontend/components/APYCalculator.tsx
@@ -6,21 +6,26 @@ import { useMemo, useState } from 'react';
 import { usePoolConfig } from '@/lib/cache';
 import { formatApyPercent, projectedInterestStroops } from '@/lib/apy';
 import { formatUSDC, toStroops } from '@/lib/stellar';
+import { Skeleton } from '@/components/Skeleton';
 
 const DEFAULT_LOCK_DAYS = '30';
 const DEFAULT_YIELD_BPS = 800;
 
 /**
- * Real-time projection of simple interest over a chosen horizon using the pool’s yield rate.
+ * Real-time projection of simple interest over a chosen horizon using the pool's yield rate.
+ *
+ * Fetches the live `yield_bps` from the pool contract’s `get_config()` on mount
+ * (via SWR-backed `usePoolConfig`). Falls back to {@link DEFAULT_YIELD_BPS} when
+ * the contract read fails, and shows a loading skeleton during initial fetch.
  */
 export function APYCalculator({ className = '' }: { className?: string }) {
   const [depositInput, setDepositInput] = useState('');
   const [lockDaysInput, setLockDaysInput] = useState(DEFAULT_LOCK_DAYS);
-  const { data: poolConfig, error, isLoading } = usePoolConfig();
+  const { data: poolConfig, isLoading } = usePoolConfig();
 
-  const yieldBps = poolConfig?.yieldBps ?? (error ? DEFAULT_YIELD_BPS : null);
-  const hasValidPoolRate = yieldBps !== null && yieldBps >= 0;
-  const isFallbackRate = !!error && yieldBps === DEFAULT_YIELD_BPS;
+  const yieldBps = poolConfig?.yieldBps ?? DEFAULT_YIELD_BPS;
+  const hasValidPoolRate = yieldBps >= 0;
+  const isFallbackRate = !poolConfig;
 
   const { interestStroops, totalStroops } = useMemo(() => {
     if (yieldBps === null || yieldBps < 0) {
@@ -45,16 +50,16 @@ export function APYCalculator({ className = '' }: { className?: string }) {
     };
   }, [depositInput, lockDaysInput, yieldBps]);
 
+  if (isLoading) {
+    return <APYCalculatorSkeleton className={className} />;
+  }
+
   return (
     <div className={`p-6 bg-brand-card border border-brand-border rounded-2xl ${className}`.trim()}>
       <h2 className="text-lg font-semibold mb-1">Earnings calculator</h2>
       <p className="text-xs text-brand-muted mb-4">
         Model projected returns using the pool&apos;s current rate (
-        {isLoading
-          ? 'loading…'
-          : hasValidPoolRate
-            ? `${formatApyPercent(yieldBps!)}% APY`
-            : 'rate unavailable'}
+        {hasValidPoolRate ? `${formatApyPercent(yieldBps!)}% APY` : 'rate unavailable'}
         ).
       </p>
 
@@ -69,7 +74,7 @@ export function APYCalculator({ className = '' }: { className?: string }) {
               placeholder="0.00"
               value={depositInput}
               onChange={(e) => setDepositInput(e.target.value)}
-              disabled={isLoading || !hasValidPoolRate}
+              disabled={!hasValidPoolRate}
               className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-3 text-white placeholder-brand-muted focus:outline-none focus:border-brand-gold text-lg disabled:opacity-50"
             />
             <span className="absolute right-4 top-1/2 -translate-y-1/2 text-brand-muted text-sm font-medium">
@@ -86,7 +91,7 @@ export function APYCalculator({ className = '' }: { className?: string }) {
             step="1"
             value={lockDaysInput}
             onChange={(e) => setLockDaysInput(e.target.value)}
-            disabled={isLoading || !hasValidPoolRate}
+            disabled={!hasValidPoolRate}
             className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-3 text-white placeholder-brand-muted focus:outline-none focus:border-brand-gold text-lg disabled:opacity-50"
           />
         </div>
@@ -95,8 +100,8 @@ export function APYCalculator({ className = '' }: { className?: string }) {
           <div className="p-4 bg-brand-dark border border-brand-border rounded-xl">
             <p className="text-xs text-brand-muted mb-1">Projected interest</p>
             <p className="text-xl font-semibold text-brand-gold">
-              {isLoading || !hasValidPoolRate
-                ? '—'
+              {!hasValidPoolRate
+                ? '---'
                 : depositInput && parseFloat(depositInput) > 0
                   ? formatUSDC(interestStroops)
                   : formatUSDC(0n)}
@@ -105,8 +110,8 @@ export function APYCalculator({ className = '' }: { className?: string }) {
           <div className="p-4 bg-brand-dark border border-brand-border rounded-xl">
             <p className="text-xs text-brand-muted mb-1">Total at maturity</p>
             <p className="text-xl font-semibold text-white">
-              {isLoading || !hasValidPoolRate
-                ? '—'
+              {!hasValidPoolRate
+                ? '---'
                 : depositInput && parseFloat(depositInput) > 0
                   ? formatUSDC(totalStroops)
                   : formatUSDC(0n)}
@@ -126,8 +131,45 @@ export function APYCalculator({ className = '' }: { className?: string }) {
         <strong className="text-brand-muted">Disclaimer:</strong> This projection uses the
         pool&apos;s configured yield rate and assumes continuous linear accrual like on-chain
         invoice interest. Actual returns depend on invoice repayment timing, utilization, and pool
-        parameters — nothing is guaranteed.
+        parameters -- nothing is guaranteed.
       </p>
+    </div>
+  );
+}
+
+export function APYCalculatorSkeleton({ className = '' }: { className?: string }) {
+  return (
+    <div
+      className={`p-6 bg-brand-card border border-brand-border rounded-2xl ${className}`.trim()}
+      role="status"
+      aria-label="Loading earnings calculator"
+    >
+      <Skeleton className="h-6 w-44 mb-2" />
+      <Skeleton className="h-3 w-72 mb-6" />
+
+      <div className="space-y-4">
+        <div>
+          <Skeleton className="h-4 w-36 mb-3" />
+          <Skeleton className="h-12 w-full rounded-xl" />
+        </div>
+        <div>
+          <Skeleton className="h-4 w-28 mb-3" />
+          <Skeleton className="h-12 w-full rounded-xl" />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
+          <div className="p-4 bg-brand-dark border border-brand-border rounded-xl">
+            <Skeleton className="h-3 w-28 mb-2" />
+            <Skeleton className="h-6 w-32" />
+          </div>
+          <div className="p-4 bg-brand-dark border border-brand-border rounded-xl">
+            <Skeleton className="h-3 w-32 mb-2" />
+            <Skeleton className="h-6 w-32" />
+          </div>
+        </div>
+      </div>
+
+      <Skeleton className="h-4 w-full mt-6" />
+      <Skeleton className="h-3 w-3/5 mt-2" />
     </div>
   );
 }

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -45,13 +45,48 @@ export const CACHE_TTL = {
 
 /** Per-resource SWR configuration. Import and spread into useSWR options. */
 export const CACHE_CONFIG: Record<string, SWRCacheEntry> = {
-  poolConfig: { refreshInterval: CACHE_TTL.poolConfig, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.poolConfig },
-  invoiceCount: { refreshInterval: CACHE_TTL.invoiceStatus, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.invoiceStatus },
-  invoice: { refreshInterval: CACHE_TTL.invoiceStatus, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.invoiceStatus },
-  position: { refreshInterval: CACHE_TTL.invoiceStatus, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.invoiceStatus },
-  tokens: { refreshInterval: CACHE_TTL.creditScore, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.creditScore },
-  tokenTotals: { refreshInterval: CACHE_TTL.walletBalance, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.walletBalance },
-  fundedInvoice: { refreshInterval: CACHE_TTL.invoiceStatus, revalidateOnFocus: true, revalidateOnReconnect: true, dedupingInterval: CACHE_TTL.invoiceStatus },
+  poolConfig: {
+    refreshInterval: CACHE_TTL.poolConfig,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.poolConfig,
+  },
+  invoiceCount: {
+    refreshInterval: CACHE_TTL.invoiceStatus,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.invoiceStatus,
+  },
+  invoice: {
+    refreshInterval: CACHE_TTL.invoiceStatus,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.invoiceStatus,
+  },
+  position: {
+    refreshInterval: CACHE_TTL.invoiceStatus,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.invoiceStatus,
+  },
+  tokens: {
+    refreshInterval: CACHE_TTL.creditScore,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.creditScore,
+  },
+  tokenTotals: {
+    refreshInterval: CACHE_TTL.walletBalance,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.walletBalance,
+  },
+  fundedInvoice: {
+    refreshInterval: CACHE_TTL.invoiceStatus,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.invoiceStatus,
+  },
 };
 
 // Error type for contract calls
@@ -286,6 +321,11 @@ export function useSetYield(admin: string) {
   return useSWRMutation<unknown, ContractError, string, { admin: string; signedXdr: string }>(
     'set-yield',
     setYieldMutation,
+    {
+      onSuccess: () => {
+        mutate('pool-config');
+      },
+    },
   );
 }
 


### PR DESCRIPTION
Closes #351

---

Previously APYCalculator used an error-only fallback of 800 bps and
showed a plain 'loading...' text during initial fetch. Now it:

- Returns a layout-matching skeleton during the initial config fetch
- Falls back to DEFAULT_YIELD_BPS when the contract read fails
- Uses live poolConfig.yieldBps when data is available
- Invalidates the pool-config SWR cache after set_yield mutations
  so the calculator updates without a page reload

Added tests: loading skeleton rendering, live rate display,
and explicit verification that yieldBps is fetched (not hardcoded).
