### PR TITLE
test(share): add full test coverage for share token contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        contract: [invoice, credit_score]
+        contract: [invoice, credit_score, share]
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,7 @@ dependencies = [
 name = "share"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 

--- a/contracts/share/Cargo.toml
+++ b/contracts/share/Cargo.toml
@@ -4,10 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+proptest = "1.4"
+
+[[test]]
+name = "lib"
+path = "tests/lib.rs"
+
+[[test]]
+name = "fuzz_tests"
+path = "tests/fuzz_tests.rs"

--- a/contracts/share/tests/fuzz_tests.rs
+++ b/contracts/share/tests/fuzz_tests.rs
@@ -1,0 +1,187 @@
+#![cfg(test)]
+
+use proptest::prelude::*;
+use share::{ShareToken, ShareTokenClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup(env: &Env) -> (ShareTokenClient<'_>, Address) {
+    let contract_id = env.register(ShareToken, ());
+    let client = ShareTokenClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(
+        &admin,
+        &7u32,
+        &String::from_str(env, "Pool Shares"),
+        &String::from_str(env, "POOL"),
+    );
+    (client, admin)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    /// Invariant: total_supply always equals the sum of every holder's balance.
+    ///
+    /// After any sequence of mints and burns the accounting identity must hold.
+    /// This catches off-by-one errors in supply tracking and ensures governance
+    /// voting power (derived from share balances) cannot be manufactured out of
+    /// thin air.
+    #[test]
+    fn prop_total_supply_equals_sum_of_balances(
+        amounts in prop::collection::vec(1i128..10_000_000i128, 1..8)
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let holders: Vec<Address> = (0..amounts.len())
+            .map(|_| Address::generate(&env))
+            .collect();
+
+        let mut expected_total = 0i128;
+        for (holder, &amount) in holders.iter().zip(amounts.iter()) {
+            client.mint(holder, &amount);
+            expected_total += amount;
+        }
+
+        prop_assert_eq!(client.total_supply(), expected_total,
+            "total_supply diverged from sum of minted amounts");
+
+        let sum_of_balances: i128 = holders.iter().map(|h| client.balance(h)).sum();
+        prop_assert_eq!(sum_of_balances, expected_total,
+            "sum of individual balances diverged from total_supply");
+    }
+
+    /// Invariant: balance(addr) >= 0 after any combination of mint and partial burn.
+    ///
+    /// The contract guards against over-burn, so the balance floor is always 0.
+    #[test]
+    fn prop_balance_never_negative(
+        mint_amount in 1i128..100_000_000i128,
+        burn_fraction_pct in 0u32..100u32
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let holder = Address::generate(&env);
+
+        client.mint(&holder, &mint_amount);
+        prop_assert!(client.balance(&holder) >= 0);
+
+        // Burn a fraction so we never exceed the balance (avoiding panic from
+        // insufficient balance — that is tested separately).
+        let burn = (mint_amount * burn_fraction_pct as i128 / 100).max(0);
+        if burn > 0 {
+            client.burn(&holder, &burn);
+        }
+
+        prop_assert!(
+            client.balance(&holder) >= 0,
+            "balance went negative after burn of {} from {}",
+            burn, mint_amount
+        );
+    }
+
+    /// Invariant: allowance never underflows below 0 after transfer_from.
+    ///
+    /// Each transfer_from deducts exactly `amount` from the stored allowance.
+    /// This property verifies the deduction never produces a negative value,
+    /// guarding against allowance-accounting bugs that could allow unlimited
+    /// spending from a finite approval.
+    #[test]
+    fn prop_allowance_never_underflows(
+        mint_amount in 1i128..100_000_000i128,
+        approve_amount in 1i128..50_000_000i128,
+        transfer_pct in 1u32..100u32
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let owner = Address::generate(&env);
+        let spender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        client.mint(&owner, &mint_amount);
+        client.approve(&owner, &spender, &approve_amount);
+
+        // Transfer only what both the allowance and balance can cover.
+        let safe_transfer = (approve_amount * transfer_pct as i128 / 100)
+            .min(mint_amount)
+            .max(1);
+
+        client.transfer_from(&spender, &owner, &recipient, &safe_transfer);
+
+        let remaining = client.allowance(&owner, &spender);
+        prop_assert!(
+            remaining >= 0,
+            "allowance underflowed to {} after transfer_from of {}",
+            remaining, safe_transfer
+        );
+        prop_assert_eq!(
+            remaining,
+            approve_amount - safe_transfer,
+            "allowance deduction was not exactly transfer amount"
+        );
+    }
+
+    /// Invariant: transfer is net-zero on total_supply.
+    ///
+    /// Moving tokens between accounts must never create or destroy supply.
+    #[test]
+    fn prop_transfer_is_net_zero_on_supply(
+        mint_amount in 1i128..100_000_000i128,
+        transfer_pct in 1u32..100u32
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &mint_amount);
+        let supply_before = client.total_supply();
+
+        let transfer_amount = (mint_amount * transfer_pct as i128 / 100).max(1);
+        client.transfer(&alice, &bob, &transfer_amount);
+
+        prop_assert_eq!(
+            client.total_supply(),
+            supply_before,
+            "transfer changed total_supply"
+        );
+        prop_assert_eq!(
+            client.balance(&alice) + client.balance(&bob),
+            mint_amount,
+            "sum of alice+bob balances must equal minted amount after transfer"
+        );
+    }
+
+    /// Invariant: burn reduces total_supply by exactly the burned amount.
+    #[test]
+    fn prop_burn_reduces_supply_exactly(
+        mint_amount in 2i128..100_000_000i128,
+        burn_pct in 1u32..99u32
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let holder = Address::generate(&env);
+
+        client.mint(&holder, &mint_amount);
+        let supply_before = client.total_supply();
+
+        let burn_amount = (mint_amount * burn_pct as i128 / 100).max(1);
+        client.burn(&holder, &burn_amount);
+
+        prop_assert_eq!(
+            client.total_supply(),
+            supply_before - burn_amount,
+            "supply delta after burn must equal burn_amount exactly"
+        );
+        prop_assert_eq!(
+            client.balance(&holder),
+            mint_amount - burn_amount,
+            "holder balance after burn must be mint_amount - burn_amount"
+        );
+    }
+}

--- a/contracts/share/tests/lib.rs
+++ b/contracts/share/tests/lib.rs
@@ -145,9 +145,15 @@ fn test_transfer_from_reduces_allowance_exactly() {
 #[test]
 fn test_burn_requires_admin_auth() {
     let env = Env::default();
-    // No mock_all_auths — admin auth must be explicitly satisfied
+    env.mock_all_auths();
     let (client, _admin) = setup(&env);
     let holder = Address::generate(&env);
+
+    // Mint tokens to holder so the test isolates the auth check, not zero balance
+    client.mint(&holder, &100i128);
+
+    // Disable auth mocking — burn must fail because admin auth is not satisfied
+    env.set_auths(&[]);
     let result = client.try_burn(&holder, &100i128);
     assert!(result.is_err());
 }
@@ -161,7 +167,10 @@ fn test_transfer_requires_sender_auth() {
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
     let result = client.try_transfer(&alice, &bob, &100i128);
-    assert!(result.is_err(), "transfer must fail without sender authorization");
+    assert!(
+        result.is_err(),
+        "transfer must fail without sender authorization"
+    );
 }
 
 // ── Overflow safety ──────────────────────────────────────────────────────────

--- a/contracts/share/tests/lib.rs
+++ b/contracts/share/tests/lib.rs
@@ -1,0 +1,215 @@
+#![cfg(test)]
+
+use share::{ShareToken, ShareTokenClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup(env: &Env) -> (ShareTokenClient<'_>, Address) {
+    let contract_id = env.register(ShareToken, ());
+    let client = ShareTokenClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(
+        &admin,
+        &7u32,
+        &String::from_str(env, "Pool Shares"),
+        &String::from_str(env, "POOL"),
+    );
+    (client, admin)
+}
+
+// ── Allowance ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_approve_overwrites_existing_allowance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    client.approve(&owner, &spender, &500i128);
+    assert_eq!(client.allowance(&owner, &spender), 500);
+
+    // Lower overwrite — no residual allowance that could be double-spent
+    client.approve(&owner, &spender, &200i128);
+    assert_eq!(client.allowance(&owner, &spender), 200);
+
+    // Higher overwrite
+    client.approve(&owner, &spender, &1_000i128);
+    assert_eq!(client.allowance(&owner, &spender), 1_000);
+}
+
+#[test]
+fn test_approve_zero_clears_allowance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    client.approve(&owner, &spender, &300i128);
+    assert_eq!(client.allowance(&owner, &spender), 300);
+
+    client.approve(&owner, &spender, &0i128);
+    assert_eq!(client.allowance(&owner, &spender), 0);
+}
+
+#[test]
+fn test_allowance_for_unknown_pair_is_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+
+    assert_eq!(
+        client.allowance(&Address::generate(&env), &Address::generate(&env)),
+        0
+    );
+}
+
+#[test]
+fn test_multiple_spenders_track_allowances_independently() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+    let spender_a = Address::generate(&env);
+    let spender_b = Address::generate(&env);
+
+    client.mint(&owner, &1_000i128);
+    client.approve(&owner, &spender_a, &300i128);
+    client.approve(&owner, &spender_b, &400i128);
+
+    let recipient = Address::generate(&env);
+    client.transfer_from(&spender_a, &owner, &recipient, &100i128);
+
+    // spender_b's allowance must be unaffected
+    assert_eq!(client.allowance(&owner, &spender_a), 200);
+    assert_eq!(client.allowance(&owner, &spender_b), 400);
+}
+
+// ── transfer_from edge cases ─────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn test_transfer_from_sufficient_allowance_insufficient_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Allowance is generous but owner only holds 50 tokens
+    client.mint(&owner, &50i128);
+    client.approve(&owner, &spender, &200i128);
+    client.transfer_from(&spender, &owner, &recipient, &100i128);
+}
+
+#[test]
+fn test_transfer_from_to_self_preserves_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let addr = Address::generate(&env);
+
+    client.mint(&addr, &500i128);
+    // Approve self as spender
+    client.approve(&addr, &addr, &200i128);
+    client.transfer_from(&addr, &addr, &addr, &100i128);
+
+    assert_eq!(client.balance(&addr), 500);
+    assert_eq!(client.allowance(&addr, &addr), 100);
+    assert_eq!(client.total_supply(), 500);
+}
+
+#[test]
+fn test_transfer_from_reduces_allowance_exactly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.mint(&owner, &1_000i128);
+    client.approve(&owner, &spender, &400i128);
+    client.transfer_from(&spender, &owner, &recipient, &250i128);
+
+    assert_eq!(client.balance(&owner), 750);
+    assert_eq!(client.balance(&recipient), 250);
+    assert_eq!(client.allowance(&owner, &spender), 150);
+    assert_eq!(client.total_supply(), 1_000);
+}
+
+// ── Admin-only guards ────────────────────────────────────────────────────────
+
+#[test]
+fn test_burn_requires_admin_auth() {
+    let env = Env::default();
+    // No mock_all_auths — admin auth must be explicitly satisfied
+    let (client, _admin) = setup(&env);
+    let holder = Address::generate(&env);
+    let result = client.try_burn(&holder, &100i128);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_transfer_requires_sender_auth() {
+    let env = Env::default();
+    // No mock_all_auths — from.require_auth() must be satisfied explicitly.
+    // initialize does not require auth, so setup still succeeds.
+    let (client, _admin) = setup(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let result = client.try_transfer(&alice, &bob, &100i128);
+    assert!(result.is_err(), "transfer must fail without sender authorization");
+}
+
+// ── Overflow safety ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_mint_large_amount_no_overflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let holder = Address::generate(&env);
+
+    // i128::MAX / 2 is safely within range
+    let large = i128::MAX / 2;
+    client.mint(&holder, &large);
+    assert_eq!(client.balance(&holder), large);
+    assert_eq!(client.total_supply(), large);
+}
+
+#[test]
+fn test_transfer_of_entire_large_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let large = i128::MAX / 2;
+    client.mint(&alice, &large);
+    client.transfer(&alice, &bob, &large);
+
+    assert_eq!(client.balance(&alice), 0);
+    assert_eq!(client.balance(&bob), large);
+    assert_eq!(client.total_supply(), large);
+}
+
+#[test]
+fn test_two_large_mints_total_supply_correct() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    // Each is i128::MAX / 4 so their sum won't overflow i128
+    let quarter = i128::MAX / 4;
+    client.mint(&alice, &quarter);
+    client.mint(&bob, &quarter);
+
+    assert_eq!(client.total_supply(), quarter * 2);
+    assert_eq!(client.balance(&alice) + client.balance(&bob), quarter * 2);
+}


### PR DESCRIPTION
## Summary

Closes #578

The share token contract had zero tests despite being the voting-power primitive for governance. This PR adds a complete test suite across three layers:

- **`contracts/share/tests/lib.rs`** — 12 integration tests covering all checklist gaps: allowance overwrite, zero-approve clearing, `transfer_from` with insufficient balance, `transfer_from` to self, burn auth enforcement, sender auth on transfer, and `i128` large-value overflow safety
- **`contracts/share/tests/fuzz_tests.rs`** — 5 property-based tests (proptest, 50 cases each): `total_supply == sum of balances`, `balance >= 0` invariant, allowance-never-underflows, transfer is net-zero on supply, burn reduces supply exactly
- **`contracts/share/Cargo.toml`** — added `rlib` crate-type, `proptest = "1.4"` dev-dep, and `[[test]]` entries for both test files
- **`.github/workflows/ci.yml`** — added `share` to the rust-contracts matrix (fmt + clippy + build + test on every PR)

## Test plan

- [x] `cargo test -p share` passes locally — 33 tests total (16 inline + 12 integration + 5 fuzz)
- [x] All issue checklist items covered
- [x] CI matrix updated to run share contract on every PR