### PR TITLE
feat: add real-time invoice status updates via SSE (#537)

### DIFF
--- a/frontend/app/api/events/route.ts
+++ b/frontend/app/api/events/route.ts
@@ -1,0 +1,133 @@
+import { type NextRequest } from 'next/server';
+import { jwtVerify } from 'jose';
+import {
+  rpcGetEvents,
+  rpcGetLatestLedger,
+  INVOICE_CONTRACT_ID,
+  POOL_CONTRACT_ID,
+  scValToNative,
+} from '../../../lib/stellar';
+
+export const dynamic = 'force-dynamic';
+
+const JWT_SECRET = process.env.SEP10_JWT_SECRET || process.env.JWT_SECRET;
+const POLL_INTERVAL_MS = 3_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+// Look back this many ledgers on the first poll to catch very recent events
+const INITIAL_LOOKBACK_LEDGERS = 10;
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const token = searchParams.get('token');
+  const invoiceIdParam = searchParams.get('invoiceId');
+
+  if (!JWT_SECRET || !token) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  try {
+    const key = new TextEncoder().encode(JWT_SECRET);
+    await jwtVerify(token, key);
+  } catch {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const contractIds = [INVOICE_CONTRACT_ID, POOL_CONTRACT_ID].filter(Boolean);
+  if (contractIds.length === 0) {
+    return new Response('Contract IDs not configured', { status: 503 });
+  }
+
+  const encoder = new TextEncoder();
+  let lastSeenLedger = 0;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let closed = false;
+
+      const enqueue = (data: string, eventName?: string) => {
+        if (closed) return;
+        const line = eventName ? `event: ${eventName}\ndata: ${data}\n\n` : `data: ${data}\n\n`;
+        controller.enqueue(encoder.encode(line));
+      };
+
+      const poll = async () => {
+        if (closed) return;
+        try {
+          const latest = await rpcGetLatestLedger();
+          const currentLedger = latest.sequence;
+
+          if (currentLedger <= lastSeenLedger) return;
+
+          const startLedger =
+            lastSeenLedger > 0
+              ? lastSeenLedger + 1
+              : Math.max(1, currentLedger - INITIAL_LOOKBACK_LEDGERS);
+
+          const response = await rpcGetEvents({
+            startLedger,
+            filters: [{ contractIds }],
+          });
+
+          lastSeenLedger = currentLedger;
+
+          for (const raw of response.events) {
+            const e = raw as unknown as Record<string, unknown>;
+            const topic = ((e.topic as unknown[]) ?? []).map((t) =>
+              scValToNative(t as Parameters<typeof scValToNative>[0]),
+            );
+            const value = scValToNative(e.value as Parameters<typeof scValToNative>[0]);
+            const eventInvoiceId = (value as unknown[] | null)?.[0];
+
+            // Filter by invoiceId if the caller requested a specific invoice
+            if (invoiceIdParam !== null && String(eventInvoiceId) !== invoiceIdParam) {
+              continue;
+            }
+
+            enqueue(
+              JSON.stringify({
+                id: e.id,
+                contractId: e.contractId,
+                topic,
+                value,
+                ledger: e.ledger,
+                txHash: e.txHash,
+                ledgerCloseAt: (e.ledgerClosedAt ?? e.ledgerCloseAt) as string,
+              }),
+            );
+          }
+        } catch (err) {
+          console.error('[SSE /api/events] poll error:', err);
+          enqueue(JSON.stringify({ type: 'error' }), 'error');
+        }
+      };
+
+      // Initial handshake
+      enqueue(JSON.stringify({ type: 'connected' }), 'connected');
+
+      // First poll immediately, then schedule repeating poll + heartbeat
+      await poll();
+      const pollTimer = setInterval(poll, POLL_INTERVAL_MS);
+      const heartbeatTimer = setInterval(() => enqueue('', 'ping'), HEARTBEAT_INTERVAL_MS);
+
+      request.signal.addEventListener('abort', () => {
+        closed = true;
+        clearInterval(pollTimer);
+        clearInterval(heartbeatTimer);
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/frontend/lib/useContractEvents.ts
+++ b/frontend/lib/useContractEvents.ts
@@ -42,6 +42,12 @@ export function useContractEvents({
   const walletAddress = useStore((s) => s.wallet.address);
   const setRecentEvents = useStore((s) => s.setRecentEvents);
 
+  // Keep a stable ref to onEvent so the SSE effect doesn't rerun on every render
+  const onEventRef = useRef(onEvent);
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  });
+
   useEffect(() => {
     if (!enabled || typeof window === 'undefined') return;
 
@@ -86,7 +92,7 @@ export function useContractEvents({
       const prev = useStore.getState().recentEvents;
       setRecentEvents([storeEvent, ...prev].slice(0, 100));
 
-      onEvent?.(data);
+      onEventRef.current?.(data);
     };
 
     // EventSource auto-reconnects on error — onerror is informational only
@@ -102,7 +108,7 @@ export function useContractEvents({
     };
     // invoiceId and walletAddress intentionally included so the stream
     // reconnects if either changes
-  }, [enabled, invoiceId, walletAddress, setRecentEvents, onEvent]);
+  }, [enabled, invoiceId, walletAddress, setRecentEvents]);
 
   return { connected };
 }

--- a/frontend/lib/useContractEvents.ts
+++ b/frontend/lib/useContractEvents.ts
@@ -1,0 +1,149 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { mutate } from 'swr';
+import { getToken } from './auth';
+import { useStore } from './store';
+import type { StoreEvent } from './sse-events';
+
+interface ContractEvent {
+  id: string;
+  contractId: string;
+  topic: unknown[];
+  value: unknown;
+  ledger: number;
+  txHash: string;
+  ledgerCloseAt: string;
+}
+
+interface UseContractEventsOptions {
+  /** Filter the stream to events for a specific invoice */
+  invoiceId?: number;
+  /** Disable the hook without unmounting (e.g. while unauthenticated) */
+  enabled?: boolean;
+  /** Optional callback fired for every received event */
+  onEvent?: (event: ContractEvent) => void;
+}
+
+/**
+ * Opens a persistent SSE connection to /api/events and invalidates the SWR
+ * cache whenever a relevant contract event arrives.
+ *
+ * The browser's native EventSource reconnects automatically on drop, so no
+ * manual retry logic is needed here.
+ */
+export function useContractEvents({
+  invoiceId,
+  enabled = true,
+  onEvent,
+}: UseContractEventsOptions = {}) {
+  const sourceRef = useRef<EventSource | null>(null);
+  const [connected, setConnected] = useState(false);
+  const walletAddress = useStore((s) => s.wallet.address);
+  const setRecentEvents = useStore((s) => s.setRecentEvents);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+
+    const token = getToken();
+    if (!token) return;
+
+    const url = new URL('/api/events', window.location.origin);
+    url.searchParams.set('token', token);
+    if (invoiceId !== undefined) {
+      url.searchParams.set('invoiceId', String(invoiceId));
+    }
+
+    const source = new EventSource(url.toString());
+    sourceRef.current = source;
+
+    source.onopen = () => setConnected(true);
+
+    source.onmessage = (ev: MessageEvent<string>) => {
+      let data: ContractEvent & { type?: string };
+      try {
+        data = JSON.parse(ev.data) as ContractEvent & { type?: string };
+      } catch {
+        return;
+      }
+
+      // Skip control messages (connected / error)
+      if (data.type) return;
+
+      invalidateCaches(data, walletAddress);
+
+      // Prepend to Zustand recent-events list (capped at 100)
+      const storeEvent: StoreEvent = {
+        id: data.id,
+        contractId: data.contractId,
+        topic: data.topic.map(String),
+        value: data.value,
+        ledger: data.ledger,
+        ledgerCloseAt: data.ledgerCloseAt,
+        txHash: data.txHash,
+        receivedAt: Date.now(),
+      };
+      const prev = useStore.getState().recentEvents;
+      setRecentEvents([storeEvent, ...prev].slice(0, 100));
+
+      onEvent?.(data);
+    };
+
+    // EventSource auto-reconnects on error — onerror is informational only
+    source.onerror = () => {
+      setConnected(false);
+      console.warn('[useContractEvents] SSE connection error — browser will retry');
+    };
+
+    return () => {
+      source.close();
+      sourceRef.current = null;
+      setConnected(false);
+    };
+    // invoiceId and walletAddress intentionally included so the stream
+    // reconnects if either changes
+  }, [enabled, invoiceId, walletAddress, setRecentEvents, onEvent]);
+
+  return { connected };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function invalidateCaches(event: ContractEvent, walletAddress: string | null): void {
+  const [, eventType] = event.topic as [unknown, string];
+  if (typeof eventType !== 'string') return;
+
+  const value = event.value as unknown[] | null;
+  const invoiceIdFromEvent = value?.[0] as number | undefined;
+
+  switch (eventType) {
+    case 'funded':
+    case 'repaid':
+    case 'default':
+    case 'created':
+      // Always revalidate the count; also revalidate the specific invoice if known
+      void mutate('invoice-count');
+      if (invoiceIdFromEvent !== undefined) {
+        void mutate(['invoice', invoiceIdFromEvent]);
+        void mutate(['invoice-metadata', invoiceIdFromEvent]);
+        void mutate(['funded-invoice', invoiceIdFromEvent]);
+      }
+      break;
+
+    case 'deposit':
+    case 'withdraw':
+      // Revalidate all open position and token-totals entries for this wallet
+      void mutate((key) => Array.isArray(key) && key[0] === 'token-totals');
+      if (walletAddress) {
+        void mutate(
+          (key) => Array.isArray(key) && key[0] === 'position' && key[1] === walletAddress,
+        );
+      }
+      break;
+
+    default:
+      break;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #537

Replaces the polling-only model for contract event delivery with a true
Server-Sent Events (SSE) stream, so users see invoice status changes
within seconds instead of waiting for the next poll cycle.

- **`frontend/app/api/events/route.ts`** — new `GET /api/events` SSE
  endpoint.  Validates the wallet JWT (passed as `?token=` query param
  because `EventSource` cannot send custom `Authorization` headers),
  polls the Soroban RPC every 3 s for new contract events from the
  invoice and pool contracts, optionally filters by `invoiceId`, and
  streams each event as a standard SSE message.  A 30 s `ping` heartbeat
  prevents proxies from closing idle connections.  The stream is cleaned
  up on client disconnect via `request.signal`.

- **`frontend/lib/useContractEvents.ts`** — new `useContractEvents`
  hook.  Opens a native `EventSource` to `/api/events`, invalidates the
  appropriate SWR cache keys (`invoice`, `funded-invoice`, `position`,
  `token-totals`) on every arriving event, and appends each event to the
  Zustand `recentEvents` list.  `EventSource` reconnects automatically
  on drop; connection state is tracked via `useState` so callers can
  reflect live/offline status in the UI.

## Acceptance criteria met

- [x] `GET /api/events` SSE endpoint implemented in Next.js API routes
- [x] Events streamed for invoice status changes, new fundings, and repayments
- [x] Frontend invalidates SWR cache on receiving relevant events
- [x] Connection automatically reconnects on drop (EventSource native behaviour)
- [x] SSE endpoint requires wallet authentication (JWT validation — unauthenticated requests get 401)

## Test plan

- [ ] Connect wallet → open a dashboard page → verify browser DevTools
  shows an open `EventSource` to `/api/events`
- [ ] Trigger an invoice status change (e.g. fund an invoice in another
  tab) → confirm the counterparty dashboard refreshes within ~5 s
  without a manual page reload
- [ ] Disconnect network → reconnect → confirm the stream re-establishes
  automatically
- [ ] Attempt `GET /api/events` without a token → confirm 401 response
- [ ] Attempt with an expired/invalid JWT → confirm 401 response