### PR TITLE
test: cover APY zero edge cases

### DIFF
--- a/frontend/__tests__/lib/apy.test.ts
+++ b/frontend/__tests__/lib/apy.test.ts
@@ -1,6 +1,12 @@
 import { projectedInterestStroops, formatApyPercent } from '@/lib/apy';
 
 describe('projectedInterestStroops', () => {
+  it('returns 0 for the requested zero-value edge cases', () => {
+    expect(projectedInterestStroops(0n, 800, 86400)).toBe(0n);
+    expect(projectedInterestStroops(1000000n, 800, 0)).toBe(0n);
+    expect(projectedInterestStroops(1000000n, 0, 86400)).toBe(0n);
+  });
+
   it('returns 0 for zero principal', () => {
     expect(projectedInterestStroops(0n, 800, 30)).toBe(0n);
   });
@@ -31,7 +37,7 @@ describe('projectedInterestStroops', () => {
     // 30 days interest should be approximately 6.575 USDC
     const principal = 10000000000n; // 1000 USDC
     const interest = projectedInterestStroops(principal, 800, 30);
-    
+
     // Expected: (10000000000 * 800 * 30 * 86400) / (10000 * 31536000)
     // = 20,736,000,000,000,000 / 315,360,000,000
     // ≈ 65,753,424 (6.5753424 USDC in stroops)
@@ -42,7 +48,7 @@ describe('projectedInterestStroops', () => {
   it('calculates interest correctly for 365 days at 8% APY', () => {
     const principal = 10000000000n; // 1000 USDC
     const interest = projectedInterestStroops(principal, 800, 365);
-    
+
     // After 1 year at 8%, should be approximately 80 USDC interest
     expect(interest).toBeGreaterThan(0n);
     // Should be close to 8% of principal
@@ -53,7 +59,7 @@ describe('projectedInterestStroops', () => {
     const principal = 10000000000n;
     const interest1 = projectedInterestStroops(principal, 800, 30.9);
     const interest2 = projectedInterestStroops(principal, 800, 30);
-    
+
     expect(interest1).toBe(interest2);
   });
 });


### PR DESCRIPTION
Adds the explicit edge-case coverage requested for `projectedInterestStroops`.

### What changed
- Covered zero principal.
- Covered zero elapsed time.
- Covered zero APY.

### Checks
- `npm test -- --runTestsByPath __tests__/lib/apy.test.ts`
- `npx eslint __tests__/lib/apy.test.ts lib/apy.ts`

Closes #691