### PR TITLE
fix: show friendly network labels

### DIFF
--- a/frontend/__tests__/lib/network-label.test.ts
+++ b/frontend/__tests__/lib/network-label.test.ts
@@ -1,0 +1,22 @@
+import { Networks } from '@stellar/stellar-sdk';
+import { formatNetworkName } from '@/lib/network-label';
+
+describe('formatNetworkName', () => {
+  it('maps Stellar network passphrases to friendly labels', () => {
+    expect(formatNetworkName(Networks.TESTNET)).toBe('Testnet');
+    expect(formatNetworkName(Networks.PUBLIC)).toBe('Mainnet');
+    expect(formatNetworkName(Networks.STANDALONE)).toBe('Local');
+  });
+
+  it('maps short network identifiers to friendly labels', () => {
+    expect(formatNetworkName('TESTNET')).toBe('Testnet');
+    expect(formatNetworkName('PUBLIC')).toBe('Mainnet');
+    expect(formatNetworkName('standalone')).toBe('Local');
+  });
+
+  it('truncates unknown long network values', () => {
+    expect(formatNetworkName('Custom Stellar Network ; January 2099')).toBe(
+      'Custom Stell...ary 2099',
+    );
+  });
+});

--- a/frontend/components/NetworkIndicator.tsx
+++ b/frontend/components/NetworkIndicator.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useStore } from '@/lib/store';
+import { formatNetworkName } from '@/lib/network-label';
 
 export default function NetworkIndicator() {
   const { networkMismatch } = useStore();
@@ -9,7 +10,8 @@ export default function NetworkIndicator() {
     return null;
   }
 
-  const walletNetworkName = networkMismatch.walletNetwork === 'PUBLIC' ? 'Mainnet' : 'Testnet';
+  const walletNetworkName = formatNetworkName(networkMismatch.walletNetwork);
+  const isMainnet = walletNetworkName === 'Mainnet';
   const isMismatched = networkMismatch.isMismatched;
 
   return (
@@ -18,18 +20,14 @@ export default function NetworkIndicator() {
         className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
           isMismatched
             ? 'bg-red-900/30 border-red-800/50 text-red-400'
-            : networkMismatch.walletNetwork === 'PUBLIC'
+            : isMainnet
               ? 'bg-blue-900/30 border-blue-800/50 text-blue-400'
               : 'bg-green-900/30 border-green-800/50 text-green-400'
         }`}
       >
         <span
           className={`w-1.5 h-1.5 rounded-full ${
-            isMismatched
-              ? 'bg-red-400'
-              : networkMismatch.walletNetwork === 'PUBLIC'
-                ? 'bg-blue-400'
-                : 'bg-green-400'
+            isMismatched ? 'bg-red-400' : isMainnet ? 'bg-blue-400' : 'bg-green-400'
           }`}
           aria-hidden="true"
         />

--- a/frontend/components/NetworkMismatchBanner.tsx
+++ b/frontend/components/NetworkMismatchBanner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useStore } from '@/lib/store';
+import { formatNetworkName } from '@/lib/network-label';
 
 export default function NetworkMismatchBanner() {
   const { networkMismatch, setNetworkMismatch } = useStore();
@@ -17,8 +18,8 @@ export default function NetworkMismatchBanner() {
     });
   };
 
-  const walletNetworkName = networkMismatch.walletNetwork === 'PUBLIC' ? 'Mainnet' : 'Testnet';
-  const appNetworkName = networkMismatch.appNetwork === 'mainnet' ? 'Mainnet' : 'Testnet';
+  const walletNetworkName = formatNetworkName(networkMismatch.walletNetwork);
+  const appNetworkName = formatNetworkName(networkMismatch.appNetwork);
 
   return (
     <div className="fixed top-16 left-0 right-0 z-40 bg-red-900/95 border-b border-red-800 backdrop-blur-sm">

--- a/frontend/lib/network-label.ts
+++ b/frontend/lib/network-label.ts
@@ -1,0 +1,26 @@
+import { Networks } from '@stellar/stellar-sdk';
+
+const NETWORK_LABELS: Record<string, string> = {
+  PUBLIC: 'Mainnet',
+  mainnet: 'Mainnet',
+  [Networks.PUBLIC]: 'Mainnet',
+  TESTNET: 'Testnet',
+  testnet: 'Testnet',
+  [Networks.TESTNET]: 'Testnet',
+  STANDALONE: 'Local',
+  standalone: 'Local',
+  local: 'Local',
+  [Networks.STANDALONE]: 'Local',
+};
+
+export function formatNetworkName(network: string | null | undefined): string {
+  const value = network?.trim();
+  if (!value) return 'Unknown';
+
+  const knownLabel = NETWORK_LABELS[value] ?? NETWORK_LABELS[value.toLowerCase()];
+  if (knownLabel) return knownLabel;
+
+  if (value.length <= 24) return value;
+
+  return `${value.slice(0, 12)}...${value.slice(-8)}`;
+}


### PR DESCRIPTION
This makes the network indicator show user-friendly names instead of raw Stellar network values.

### What changed
- Added a small formatter for known Stellar network values and passphrases.
- Updated the navbar indicator and mismatch banner to use the same labels.
- Kept a truncated fallback for unknown network values.
- Added unit coverage for the formatter.

### Checks
- `npm test -- --runTestsByPath __tests__/lib/network-label.test.ts`
- `npx eslint lib/network-label.ts components/NetworkIndicator.tsx components/NetworkMismatchBanner.tsx __tests__/lib/network-label.test.ts`

Closes #671