### PR TITLE
fix: responsive layout fixes for sidebar, stat cards, invest and invo…

### DIFF
--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -47,7 +47,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   return (
     <div className="min-h-screen bg-brand-dark">
       <AdminNav />
-      <main className="lg:pl-64 pt-16 pb-16">
+      <main className="md:pl-16 lg:pl-64 pt-16 pb-16">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-12">{children}</div>
       </main>
     </div>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -420,7 +420,7 @@ function DashboardContent() {
             <div className="lg:col-span-2 space-y-6">
               {/* Quick stats */}
               {loading ? (
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                   {[1, 2, 3, 4].map((n) => (
                     <div
                       key={n}
@@ -432,7 +432,7 @@ function DashboardContent() {
                   ))}
                 </div>
               ) : (
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                   {[
                     {
                       label: t('stats.totalVolume'),

--- a/frontend/app/invest/page.tsx
+++ b/frontend/app/invest/page.tsx
@@ -196,7 +196,7 @@ export default function InvestPage() {
         </div>
 
         {/* ── Top grid: Pool stats + deposit form ── */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="flex flex-col lg:flex-row gap-6">
           <div className="space-y-6">
             {loading ? (
               <PoolStatsSkeleton />

--- a/frontend/app/invoice/[id]/page.tsx
+++ b/frontend/app/invoice/[id]/page.tsx
@@ -501,7 +501,7 @@ export default function InvoiceDetailPage() {
 
           <div className="text-4xl font-bold gradient-text mb-6">{formatUSDC(metadata.amount)}</div>
 
-          <div className="grid grid-cols-2 gap-4 text-sm">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
             <div>
               <p className="text-brand-muted mb-1">Due Date</p>
               <p className="font-medium">{formatDate(metadata.dueDate)}</p>

--- a/frontend/components/AdminNav.tsx
+++ b/frontend/components/AdminNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useState } from 'react';
 
 const adminLinks = [
   {
@@ -53,40 +54,84 @@ const adminLinks = [
 
 export default function AdminNav() {
   const path = usePathname();
+  const [open, setOpen] = useState(false);
 
   return (
-    <nav className="w-64 bg-brand-card border-r border-brand-border h-[calc(100vh-64px)] fixed left-0 top-16 hidden lg:flex flex-col p-4 gap-2">
-      <div className="mb-6 px-4">
-        <h2 className="text-xs font-bold uppercase tracking-widest text-brand-muted">
-          Admin Panel
-        </h2>
-      </div>
+    <>
+      {/* Hamburger — mobile only (< 768px) */}
+      <button
+        className="md:hidden fixed top-[72px] left-4 z-50 p-2 rounded-lg bg-brand-card border border-brand-border text-brand-muted hover:text-white"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Toggle admin menu"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d={open ? 'M6 18L18 6M6 6l12 12' : 'M4 6h16M4 12h16M4 18h16'}
+          />
+        </svg>
+      </button>
 
-      {adminLinks.map((link) => {
-        const isActive =
-          path === link.href || (link.href === '/admin/dashboard' && path === '/admin');
+      {/* Mobile backdrop */}
+      {open && (
+        <div
+          className="md:hidden fixed inset-0 z-30 bg-black/50"
+          style={{ top: 64 }}
+          onClick={() => setOpen(false)}
+        />
+      )}
 
-        return (
-          <Link
-            key={link.href}
-            href={link.href}
-            className={`flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all duration-200 ${
-              isActive
-                ? 'bg-brand-gold/10 text-brand-gold shadow-inner'
-                : 'text-brand-muted hover:text-white hover:bg-brand-dark/50'
-            }`}
-          >
-            <svg
-              className={`w-5 h-5 ${isActive ? 'text-brand-gold' : 'text-brand-muted'}`}
-              fill="currentColor"
-              viewBox="0 0 24 24"
+      {/*
+       * Sidebar:
+       *  < 768px  — hidden by default, shown as full-width (w-64) when hamburger is open
+       *  768–1024px — always visible, icon-only (w-16)
+       *  ≥ 1024px  — always visible, full labels (w-64)
+       */}
+      <nav
+        className={`fixed left-0 top-16 z-40 h-[calc(100vh-64px)] bg-brand-card border-r border-brand-border overflow-y-auto flex-col gap-2
+          md:flex md:w-16 md:p-2 md:items-center
+          lg:w-64 lg:p-4 lg:items-stretch
+          ${open ? 'flex w-64 p-4' : 'hidden'}`}
+      >
+        <div className="hidden lg:block mb-6 px-4">
+          <h2 className="text-xs font-bold uppercase tracking-widest text-brand-muted">
+            Admin Panel
+          </h2>
+        </div>
+
+        {adminLinks.map((link) => {
+          const isActive =
+            path === link.href || (link.href === '/admin/dashboard' && path === '/admin');
+
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              title={link.label}
+              onClick={() => setOpen(false)}
+              className={`flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all duration-200
+                md:justify-center md:px-2
+                lg:justify-start lg:px-4
+                ${
+                  isActive
+                    ? 'bg-brand-gold/10 text-brand-gold shadow-inner'
+                    : 'text-brand-muted hover:text-white hover:bg-brand-dark/50'
+                }`}
             >
-              <path d={link.icon} />
-            </svg>
-            {link.label}
-          </Link>
-        );
-      })}
-    </nav>
+              <svg
+                className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-brand-gold' : 'text-brand-muted'}`}
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path d={link.icon} />
+              </svg>
+              <span className="md:hidden lg:block">{link.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </>
   );
 }


### PR DESCRIPTION
…ice pages 
Closes #681 
Closes #682 
Closes #683 
Closes #684 

- AdminNav: icon-only sidebar at 768-1024px, full labels at 1024px+, hamburger on mobile
- admin/layout: add md:pl-16 offset to match collapsed sidebar width
- dashboard: stat cards use grid-cols-1 on mobile, grid-cols-2 at sm, grid-cols-4 at lg
- invest page: switch top grid to flex flex-col lg:flex-row for explicit stacking on mobile
- invoice detail: inner info grid gains sm: breakpoint so it stacks on narrow screens