### PR TITLE
test: add unit tests for invoice/notification/wallet components + fix mobile chart overflow

### DIFF
--- a/frontend/__tests__/components/NotificationBell.test.tsx
+++ b/frontend/__tests__/components/NotificationBell.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { NotificationAlert } from '@/lib/notifications';
+
+// Capture the subscriber callback so tests can push alerts at will.
+let subscriber: ((alert: NotificationAlert) => void) | null = null;
+const unsubscribe = jest.fn();
+
+jest.mock('@/lib/notifications', () => ({
+  notificationService: {
+    subscribe: (cb: (alert: NotificationAlert) => void) => {
+      subscriber = cb;
+      return unsubscribe;
+    },
+  },
+}));
+
+// All alert types are in-app enabled for these tests.
+jest.mock('@/lib/notification-preferences', () => ({
+  isInAppEnabled: () => true,
+}));
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+import NotificationBell from '@/components/NotificationBell';
+
+function makeAlert(i: number): NotificationAlert {
+  return {
+    id: `alert-${i}-${Math.random()}`,
+    type: 'INVOICE_DUE' as NotificationAlert['type'],
+    priority: 'MEDIUM' as NotificationAlert['priority'],
+    message: `Message ${i}`,
+    timestamp: Date.now(),
+  };
+}
+
+function pushAlerts(count: number) {
+  act(() => {
+    for (let i = 0; i < count; i++) {
+      subscriber?.(makeAlert(i));
+    }
+  });
+}
+
+// The unread badge is the small red circle rendered inside the bell button.
+function getBadge(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('span.bg-red-500');
+}
+
+describe('NotificationBell unread badge (#693)', () => {
+  beforeEach(() => {
+    subscriber = null;
+    unsubscribe.mockClear();
+  });
+
+  it('hides the badge when the unread count is 0', () => {
+    const { container } = render(<NotificationBell />);
+    expect(getBadge(container)).toBeNull();
+  });
+
+  it('shows the exact count for values between 1 and 9', () => {
+    const { container } = render(<NotificationBell />);
+    pushAlerts(1);
+    expect(getBadge(container)).toHaveTextContent('1');
+
+    pushAlerts(2); // total 3
+    expect(getBadge(container)).toHaveTextContent('3');
+
+    pushAlerts(6); // total 9
+    expect(getBadge(container)).toHaveTextContent('9');
+  });
+
+  it('shows "9+" when the count exceeds 9', () => {
+    const { container } = render(<NotificationBell />);
+    pushAlerts(10);
+    expect(getBadge(container)).toHaveTextContent('9+');
+  });
+});

--- a/frontend/__tests__/components/WalletConnectionMonitor.test.tsx
+++ b/frontend/__tests__/components/WalletConnectionMonitor.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mutable fake store state the component reads through selectors.
+const disconnectStore = jest.fn();
+let storeState: { wallet: { connected: boolean }; disconnect: () => void } = {
+  wallet: { connected: false },
+  disconnect: disconnectStore,
+};
+
+jest.mock('@/lib/store', () => ({
+  useStore: <T,>(selector: (s: typeof storeState) => T) => selector(storeState),
+}));
+
+const pushToast = jest.fn();
+jest.mock('@/components/Toast', () => ({
+  pushToast: (...args: unknown[]) => pushToast(...args),
+}));
+
+// Default Freighter stub: still connected/allowed (no disconnect edge).
+const getFreighter = jest.fn(async () => ({
+  isAllowed: async () => ({ isAllowed: true, error: undefined }),
+  getAddress: async () => ({ address: 'G' + 'A'.repeat(55), error: undefined }),
+}));
+jest.mock('@/lib/freighter', () => ({
+  getFreighter: () => getFreighter(),
+}));
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import WalletConnectionMonitor from '@/components/WalletConnectionMonitor';
+
+describe('WalletConnectionMonitor (#692)', () => {
+  beforeEach(() => {
+    disconnectStore.mockClear();
+    pushToast.mockClear();
+    getFreighter.mockClear();
+    storeState = { wallet: { connected: false }, disconnect: disconnectStore };
+  });
+
+  it('renders without crashing when the wallet is disconnected', () => {
+    const { container } = render(<WalletConnectionMonitor />);
+    // Renders no UI.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not show a reconnect prompt when there is no active connection', () => {
+    render(<WalletConnectionMonitor />);
+    expect(pushToast).not.toHaveBeenCalled();
+    expect(disconnectStore).not.toHaveBeenCalled();
+  });
+
+  it('renders without crashing when the wallet was previously connected', () => {
+    storeState = { wallet: { connected: true }, disconnect: disconnectStore };
+    const { container, unmount } = render(<WalletConnectionMonitor />);
+    // Still renders no UI, and mounting the poller does not immediately
+    // trigger a disconnect toast for a healthy connection.
+    expect(container).toBeEmptyDOMElement();
+    expect(pushToast).not.toHaveBeenCalled();
+    // Cleanup tears down the interval/listeners without throwing.
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/frontend/__tests__/lib/contracts.test.ts
+++ b/frontend/__tests__/lib/contracts.test.ts
@@ -1,5 +1,33 @@
 import { getUserFriendlyError } from '@/lib/errorHandling';
 
+// Partially mock the stellar helpers so we can stub the RPC round-trips
+// (account fetch + simulation) while keeping the real scVal/Address helpers.
+jest.mock('@/lib/stellar', () => {
+  const actual = jest.requireActual('@/lib/stellar');
+  return { __esModule: true, ...actual, rpcExecute: jest.fn() };
+});
+
+// Keep the real SDK (TransactionBuilder, Contract, Account, Keypair, …) but stub
+// the simulation/assembly helpers so a valid build resolves to a known XDR.
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
+  return {
+    __esModule: true,
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Api: { ...actual.rpc.Api, isSimulationError: jest.fn(() => false) },
+      assembleTransaction: jest.fn(() => ({
+        build: () => ({ toXDR: () => 'BASE64_XDR_STRING' }),
+      })),
+    },
+  };
+});
+
+import * as stellar from '@/lib/stellar';
+import { Account, Keypair } from '@stellar/stellar-sdk';
+import { buildCreateInvoiceTx } from '@/lib/contracts';
+
 describe('contract error handling', () => {
   it('maps wallet rejection to user-facing message', () => {
     expect(getUserFriendlyError(new Error('USER_DECLINED_ACCESS'))).toBe(
@@ -27,5 +55,65 @@ describe('contract error handling', () => {
     expect(getUserFriendlyError(new Error('already initialized'))).toBe(
       'Contract is already initialized',
     );
+  });
+});
+
+describe('buildCreateInvoiceTx validation (#687)', () => {
+  const owner = Keypair.random().publicKey();
+  const futureDueDate = Math.floor(Date.now() / 1000) + 86_400; // +1 day
+  const rpcExecute = stellar.rpcExecute as jest.Mock;
+
+  function validParams(overrides: Partial<Parameters<typeof buildCreateInvoiceTx>[0]> = {}) {
+    return {
+      owner,
+      debtor: 'Acme Corp',
+      amount: 1_000_000n,
+      dueDate: futureDueDate,
+      description: 'Test invoice',
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    rpcExecute.mockReset();
+  });
+
+  it('rejects an empty debtor name', async () => {
+    await expect(buildCreateInvoiceTx(validParams({ debtor: '' }))).rejects.toThrow(/debtor/i);
+    await expect(buildCreateInvoiceTx(validParams({ debtor: '   ' }))).rejects.toThrow(/debtor/i);
+    // Validation should short-circuit before any RPC call is made.
+    expect(rpcExecute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-positive amount', async () => {
+    await expect(buildCreateInvoiceTx(validParams({ amount: 0n }))).rejects.toThrow(
+      /amount must be greater than zero/i,
+    );
+    await expect(buildCreateInvoiceTx(validParams({ amount: -5n }))).rejects.toThrow(
+      /amount must be greater than zero/i,
+    );
+    expect(rpcExecute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a due date in the past', async () => {
+    const pastDueDate = Math.floor(Date.now() / 1000) - 3_600; // -1 hour
+    await expect(buildCreateInvoiceTx(validParams({ dueDate: pastDueDate }))).rejects.toThrow(
+      /due date must be in the future/i,
+    );
+    expect(rpcExecute).not.toHaveBeenCalled();
+  });
+
+  it('returns a base64 XDR string for a valid call', async () => {
+    rpcExecute
+      // 1st call: getAccount → return a real Account so TransactionBuilder works.
+      .mockResolvedValueOnce(new Account(owner, '0'))
+      // 2nd call: simulateTransaction → return a (mocked-as-successful) sim.
+      .mockResolvedValueOnce({});
+
+    const xdr = await buildCreateInvoiceTx(validParams());
+
+    expect(typeof xdr).toBe('string');
+    expect(xdr).toBe('BASE64_XDR_STRING');
+    expect(rpcExecute).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/components/analytics/CreditScoreDistributionChart.tsx
+++ b/frontend/components/analytics/CreditScoreDistributionChart.tsx
@@ -45,7 +45,7 @@ export function CreditScoreDistributionChart({
         <span className="w-2 h-6 bg-cyan-500 rounded-full" />
         Credit Score Distribution
       </h3>
-      <div className="h-72">
+      <div className="h-72 overflow-x-hidden">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" />

--- a/frontend/components/analytics/InvoiceFunnelChart.tsx
+++ b/frontend/components/analytics/InvoiceFunnelChart.tsx
@@ -42,7 +42,7 @@ export function InvoiceFunnelChart({ data, isLoading }: InvoiceFunnelChartProps)
         <span className="w-2 h-6 bg-blue-500 rounded-full" />
         Invoice Funnel
       </h3>
-      <div className="h-72">
+      <div className="h-72 overflow-x-hidden">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" />

--- a/frontend/components/analytics/PoolUtilizationChart.tsx
+++ b/frontend/components/analytics/PoolUtilizationChart.tsx
@@ -33,7 +33,7 @@ export function PoolUtilizationChart({ data, isLoading }: PoolUtilizationChartPr
         <span className="w-2 h-6 bg-brand-gold rounded-full" />
         Pool Utilization
       </h3>
-      <div className="h-72">
+      <div className="h-72 overflow-x-hidden">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" />

--- a/frontend/components/analytics/YieldPerformanceChart.tsx
+++ b/frontend/components/analytics/YieldPerformanceChart.tsx
@@ -33,7 +33,7 @@ export function YieldPerformanceChart({ data, isLoading }: YieldPerformanceChart
         <span className="w-2 h-6 bg-emerald-500 rounded-full" />
         Yield Performance
       </h3>
-      <div className="h-72">
+      <div className="h-72 overflow-x-hidden">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
             <defs>

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -170,6 +170,20 @@ export async function buildCreateInvoiceTx(params: {
   verificationHash?: string;
   metadataUri?: string;
 }): Promise<string> {
+  // ── Input validation (#687) ────────────────────────────────────────────────
+  // Reject obviously invalid invoices client-side before spending an RPC round
+  // trip on a simulation that the contract would reject anyway.
+  if (!params.debtor || params.debtor.trim() === '') {
+    throw new Error('Debtor name is required');
+  }
+  if (params.amount <= 0n) {
+    throw new Error('Amount must be greater than zero');
+  }
+  const nowSecs = Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(params.dueDate) || params.dueDate <= nowSecs) {
+    throw new Error('Due date must be in the future');
+  }
+
   const account = await getRpcAccount(params.owner);
   const contract = new Contract(INVOICE_CONTRACT_ID);
 


### PR DESCRIPTION
## Summary

closes #692
closes #693
closes #685
closes #687


Bundles four related frontend issues: three test-coverage gaps and one mobile responsiveness fix. Each is a separate commit.

## Changes

### test: `buildCreateInvoiceTx` validation for invalid inputs (#687)
- Added client-side validation to `buildCreateInvoiceTx` in `frontend/lib/contracts.ts`: rejects empty/whitespace debtor, non-positive amount, and past/non-finite due dates before spending an RPC round-trip.
- Added unit tests in `frontend/__tests__/lib/contracts.test.ts` covering each invalid path and asserting a valid call resolves to a base64 XDR string.

### fix: analytics chart overflow on mobile (#685)
- Wrapped each `ResponsiveContainer` (already `width="100%"`) in an `overflow-x-hidden` container across all four analytics charts so they no longer cause horizontal scroll on narrow (375px) viewports.
- Files: `YieldPerformanceChart.tsx`, `InvoiceFunnelChart.tsx`, `CreditScoreDistributionChart.tsx`, `PoolUtilizationChart.tsx`.

### test: `NotificationBell` unread badge count (#693)
- Added `frontend/__tests__/components/NotificationBell.test.tsx`: badge hidden at 0, exact count for 1–9, and `"9+"` once the count exceeds 9.

### test: `WalletConnectionMonitor` component (#692)
- Added `frontend/__tests__/components/WalletConnectionMonitor.test.tsx`: renders when disconnected, no reconnect prompt without an active connection, and no crash/toast on a healthy previously-connected mount/unmount.

## Notes
- **#685**: the issue named `PoolStats.tsx`, but it contains no `ResponsiveContainer` — the only charts using it are the four analytics components, which already had `width="100%"`. The remaining overflow gap is what was fixed.
- **#692**: the acceptance criteria referenced `getStoredWalletAddress` and a "reconnect prompt," but the component has neither — it polls Freighter and shows a toast on the connected→disconnected edge, rendering no UI. Tests match the component's actual behavior.
