### PR TITLE
Add a minimal HTTP health endpoint to the oracle service for liveness probes and Docker healthchecks.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,7 @@ services:
       - ORACLE_SECRET_KEY=${ORACLE_SECRET_KEY:-}
       - INVOICE_CONTRACT_ID=${INVOICE_CONTRACT_ID:-}
       - AUTO_VERIFY_DELAY_MS=30000
+      - HEALTH_PORT=8080
     depends_on:
       stellar:
         condition: service_healthy
@@ -128,6 +129,12 @@ services:
     volumes:
       - ./oracle-service:/app
       - ./sdk:/sdk
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch(`http://127.0.0.1:${process.env.HEALTH_PORT || 8080}/health`).then((res) => process.exit(res.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     restart: unless-stopped
 
 volumes:

--- a/oracle-service/src/index.ts
+++ b/oracle-service/src/index.ts
@@ -1,3 +1,4 @@
+import * as http from 'http';
 import * as dotenv from 'dotenv';
 import { Listener } from './listener';
 import { Verifier } from './verifier';
@@ -16,7 +17,7 @@ const config: OracleConfig = {
 
 async function main() {
   console.log('=== Astera Oracle Integration Service ===');
-  
+
   if (!config.oracleSecretKey) {
     console.error('Error: ORACLE_SECRET_KEY is not set.');
     process.exit(1);
@@ -29,15 +30,34 @@ async function main() {
 
   const verifier = new Verifier(config);
   const listener = new Listener(config, verifier);
+  const healthPort = parseInt(process.env.HEALTH_PORT || '8080', 10);
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', processed: listener.processedCount }));
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'not_found' }));
+  });
 
   await listener.start();
+  server.listen(healthPort, () => {
+    console.log(`Health server listening on port ${healthPort}`);
+  });
 
   console.log('Oracle Service is running and listening for events...');
 
   // Keep alive
   process.on('SIGINT', () => {
     console.log('Shutting down...');
-    process.exit(0);
+    server.close(() => process.exit(0));
+  });
+
+  process.on('SIGTERM', () => {
+    console.log('Shutting down...');
+    server.close(() => process.exit(0));
   });
 }
 

--- a/oracle-service/src/listener.ts
+++ b/oracle-service/src/listener.ts
@@ -6,6 +6,7 @@ export class Listener {
   private config: OracleConfig;
   private verifier: Verifier;
   private horizon: Horizon.Server;
+  public processedCount = 0;
 
   constructor(config: OracleConfig, verifier: Verifier) {
     this.config = config;
@@ -40,6 +41,8 @@ export class Listener {
     }
 
     try {
+      this.processedCount += 1;
+
       // Horizon effects for Soroban events typically have the topic and value
       // This part depends on how Horizon represents contract events in effects.
       // Based on the indexer implementation:


### PR DESCRIPTION
Add a minimal HTTP health endpoint to the oracle service for liveness probes and Docker healthchecks.
Changes
Add an HTTP server to the oracle service with GET /health
Return 200 with { status: "ok", processed: listener.processedCount }
Make the health port configurable with HEALTH_PORT and default it to 8080
Track processed contract events in the oracle listener
Update Docker Compose to healthcheck the oracle service via /health
Testing
npm run build in oracle-serviceCurrently blocked locally because tsc is not installed in oracle-service/node_modules

Closes #704