### PR TITLE
fix(contracts): typed errors, oracle key validation, and pool utilization warning event

### DIFF
--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -453,7 +453,7 @@ fn load_invoice(env: &Env, id: u64) -> Invoice {
     env.storage()
         .persistent()
         .get(&DataKey::Invoice(id))
-        .expect("invoice not found")
+        .unwrap_or_else(|| panic_with_error!(env, InvoiceError::InvoiceNotFound))
 }
 
 fn checked_default_deadline(env: &Env, due_date: u64, grace_period_days: u32) -> u64 {
@@ -2084,11 +2084,7 @@ impl InvoiceContract {
                 days, MAX_GRACE_PERIOD_OVERRIDE_DAYS
             );
         }
-        let mut invoice: Invoice = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Invoice(id))
-            .expect("invoice not found");
+        let mut invoice: Invoice = load_invoice(&env, id);
         if invoice.status != InvoiceStatus::Funded {
             panic!("grace period override only allowed on Funded invoices");
         }
@@ -3369,6 +3365,24 @@ mod test {
         // Exactly 90 days must be accepted (same cap as set_grace_period)
         client.set_invoice_grace_period(&admin, &1u64, &90u32);
         assert_eq!(client.get_invoice_grace_period(&1u64), 90);
+    }
+
+    #[test]
+    fn test_set_invoice_grace_period_missing_invoice_returns_typed_error() {
+        // #644: a non-existent invoice id must surface the typed
+        // InvoiceError::InvoiceNotFound rather than a raw "invoice not found"
+        // string panic, so clients can match on the error code.
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _pool, _owner) = setup_funded_invoice(&env);
+        let result = client.try_set_invoice_grace_period(&admin, &999u64, &14u32);
+        // set_invoice_grace_period panics via panic_with_error!, so the generated
+        // try_ client surfaces the raw soroban Error code rather than the typed
+        // enum — compare against the converted InvoiceError.
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            InvoiceError::InvoiceNotFound.into()
+        );
     }
 
     #[test]

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -837,6 +837,7 @@ fn fund_invoice_request(
         .set(&DataKey::FundedInvoice(request.invoice_id), &funded);
     set_funded_invoice_ttl(env, request.invoice_id, false);
 
+    let prev_deployed = tt.total_deployed;
     tt.total_deployed = tt
         .total_deployed
         .checked_add(request.principal)
@@ -856,9 +857,21 @@ fn fund_invoice_request(
             env.storage().instance().set(&token_totals_key, &tt);
             return Err(PoolError::UtilizationLimitExceeded);
         }
-        if utilization > config.utilization_warning_bps {
+        // #653: emit a utilization warning only when this funding *crosses* the
+        // warning threshold — i.e. utilization was below the threshold before
+        // this deployment and is at or above it now. Funding only ever raises
+        // utilization, so this edge-triggered check means the warning is not
+        // re-emitted on subsequent funding calls while already above the
+        // threshold; it fires again only after utilization drops below (via a
+        // repayment or fresh deposit) and crosses once more. Off-chain monitors
+        // get one alert per crossing instead of one per funding call.
+        let prev_utilization =
+            ((prev_deployed as u128 * 10_000u128) / tt.pool_value as u128) as u32;
+        if utilization >= config.utilization_warning_bps
+            && prev_utilization < config.utilization_warning_bps
+        {
             env.events().publish(
-                (EVT, symbol_short!("high_util")),
+                (EVT, symbol_short!("util_warn")),
                 (request.token.clone(), utilization),
             );
         }
@@ -6244,6 +6257,68 @@ mod test {
         let attacker = Address::generate(&env);
         let result = client.try_set_max_utilization(&attacker, &5_000u32);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_util_warn_emitted_only_on_threshold_crossing() {
+        // #653: the util_warn event is edge-triggered — emitted once when a
+        // funding call pushes utilization across the warning threshold (default
+        // 80%), and not re-emitted on further funding while utilization stays
+        // above it.
+        use soroban_sdk::testutils::Events;
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+        mint(&env, &usdc_id, &investor, 10_000);
+        client.deposit(&investor, &usdc_id, &10_000);
+
+        let expected_topics: soroban_sdk::Vec<soroban_sdk::Val> =
+            (EVT, symbol_short!("util_warn")).into_val(&env);
+        // env.events().all() returns the events from the most recent invocation,
+        // so checking it right after each call tells us whether *that* funding
+        // emitted the warning.
+        let warns_in_last_call = |env: &Env| {
+            env.events()
+                .all()
+                .iter()
+                .filter(|e| e.1 == expected_topics)
+                .count()
+        };
+
+        // Fund 7000 (70%) — below the warning threshold, no event.
+        client.fund_invoice(
+            &admin,
+            &1u64,
+            &7_000i128,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+        assert_eq!(warns_in_last_call(&env), 0);
+
+        // Fund 1000 more → 80%, crossing the threshold — exactly one warning.
+        client.fund_invoice(
+            &admin,
+            &2u64,
+            &1_000i128,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+        assert_eq!(warns_in_last_call(&env), 1);
+
+        // Fund 500 more → 85%, still above the threshold — no re-emission.
+        client.fund_invoice(
+            &admin,
+            &3u64,
+            &500i128,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+        assert_eq!(warns_in_last_call(&env), 0);
     }
 
     // ---- Issue #411: Share minting uses exchange rate ----

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -485,7 +485,7 @@ fn require_not_paused(env: &Env) {
         .get::<DataKey, bool>(&DataKey::Paused)
         .unwrap_or(false)
     {
-        panic!("contract is paused");
+        panic_with_error!(env, PoolError::ContractPaused);
     }
 }
 
@@ -5757,7 +5757,7 @@ mod test {
     // --- Pause mechanism tests ---
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_fund_invoice_when_paused_panics() {
         let env = Env::default();
         env.mock_all_auths();
@@ -5779,7 +5779,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_repay_invoice_when_paused_panics() {
         let env = Env::default();
         env.mock_all_auths();
@@ -5804,7 +5804,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_deposit_collateral_when_paused_panics() {
         let env = Env::default();
         env.mock_all_auths();
@@ -5850,7 +5850,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_deposit_blocked_when_paused() {
         let env = Env::default();
         env.mock_all_auths();
@@ -5863,7 +5863,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_withdraw_blocked_when_paused() {
         let env = Env::default();
         env.mock_all_auths();
@@ -5984,7 +5984,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_deposit_when_paused_panics() {
         let env = Env::default();
         env.mock_all_auths();
@@ -5997,7 +5997,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "contract is paused")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_withdraw_when_paused_panics() {
         let env = Env::default();
         env.mock_all_auths();

--- a/frontend/lib/monitoring.ts
+++ b/frontend/lib/monitoring.ts
@@ -163,8 +163,8 @@ class ContractMonitor {
         // schema: (invoice_id, principal, interest, timestamp)
         const [id, principal] = value;
         amount = BigInt(principal);
-      } else if (eventType === 'high_util') {
-        // schema: (token, utilization_bps, timestamp)
+      } else if (eventType === 'util_warn') {
+        // schema: (token, utilization_bps)
         const [token, utilizationBps] = value;
         const pct = Math.round(Number(utilizationBps) / 100);
         await notificationService.send({

--- a/oracle-service/src/index.ts
+++ b/oracle-service/src/index.ts
@@ -22,6 +22,15 @@ async function main() {
     process.exit(1);
   }
 
+  // Validate the key format up front so a malformed key fails fast at startup
+  // instead of producing a cryptic error at the first signing attempt.
+  if (!/^S[A-Z2-7]{55}$/.test(config.oracleSecretKey)) {
+    console.error(
+      'Error: ORACLE_SECRET_KEY is not a valid Stellar secret key (must start with "S" and be 56 characters).'
+    );
+    process.exit(1);
+  }
+
   if (!config.invoiceContractId) {
     console.error('Error: INVOICE_CONTRACT_ID is not set.');
     process.exit(1);


### PR DESCRIPTION
## Summary

This PR resolves four issues around error typing, startup validation, and pool observability. Each fix is in its own commit.

### `fix(invoice)` — typed `InvoiceNotFound` instead of raw panic (#644)
`load_invoice` and `set_invoice_grace_period` used `.expect("invoice not found")`, panicking with a raw string so clients couldn't detect a missing invoice by error code. Both now surface `InvoiceError::InvoiceNotFound` via `panic_with_error!`. All `load_invoice` call sites inherit the typed error through the helper.

### `fix` — validate `ORACLE_SECRET_KEY` format at startup (#650)
The oracle service only checked that `ORACLE_SECRET_KEY` was non-empty, so a malformed key failed cryptically at the first signing attempt. `main()` now validates the Stellar secret key format (`/^S[A-Z2-7]{55}$/`) and exits with a clear message if invalid.

### `fix(pool)` — typed `ContractPaused` error in `require_not_paused` (#647)
`require_not_paused` panicked with the string `"contract is paused"` instead of `PoolError::ContractPaused`. Clients catching the paused state by error code (12) could not detect it. Now uses the typed error; paused-state tests assert the code.

### `feat(pool)` — edge-triggered `util_warn` event (#653)
The pool tracked `utilization_warning_bps` but had no clean signal for monitors. `fund_invoice` / `fund_invoices_batch` (both via `fund_invoice_request`) now emit a `util_warn` event only when a funding call pushes utilization **from below the threshold to at/above it**. Because funding only ever raises utilization, the warning is not re-emitted while utilization stays high — it fires again only after utilization drops below (via a repayment or fresh deposit) and crosses anew. The frontend monitor is updated to consume `util_warn`.

## Testing
- `cargo test -p invoice -p pool` — all pass, including new regression tests:
  - `test_set_invoice_grace_period_missing_invoice_returns_typed_error`
  - `test_util_warn_emitted_only_on_threshold_crossing`
  - existing paused-state tests updated to assert `Error(Contract, #12)`

Closes #644
Closes #647
Closes #650
Closes #653
