### PR TITLE
feat: add get_sme_stats view and enforce minimum voting period

### DIFF
--- a/contracts/credit_score/src/lib.rs
+++ b/contracts/credit_score/src/lib.rs
@@ -108,6 +108,9 @@ const ADMIN_CHANGE_TIMELOCK_SECS: u64 = 172_800; // 48 hours — #565
 const CURRENT_MIGRATION_VERSION: u32 = 1;
 pub const MAX_PAYMENT_HISTORY: u32 = 100;
 
+/// Max page size for list_all_sme_stats to prevent gas exhaustion.
+const MAX_SME_PAGE_SIZE: u32 = 100;
+
 #[contracttype]
 #[derive(Clone)]
 pub struct PaymentRecord {
@@ -141,6 +144,13 @@ pub struct CreditScoreData {
     pub average_payment_days: i64,
     pub last_updated: u64,
     pub score_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct SmeScoreEntry {
+    pub sme: Address,
+    pub score: u32,
 }
 
 #[contracttype]
@@ -315,6 +325,8 @@ pub enum DataKey {
     /// #565: admin key rotation timelock
     PendingAdmin,
     AdminChangeScheduledAt,
+    SmeByIndex(u32),
+    SmeCount,
 }
 
 const EVT: Symbol = symbol_short!("CREDIT");
@@ -849,6 +861,41 @@ impl CreditScoreContract {
         }
     }
 
+    pub fn list_all_sme_stats(env: Env, page: u32, page_size: u32) -> Vec<SmeScoreEntry> {
+        let count: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SmeCount)
+            .unwrap_or(0);
+        let size = if page_size > MAX_SME_PAGE_SIZE {
+            MAX_SME_PAGE_SIZE
+        } else {
+            page_size
+        };
+        let start = page * size;
+        if start >= count {
+            return Vec::new(&env);
+        }
+        let end = (start + size).min(count);
+        let mut entries = Vec::new(&env);
+        let mut i = start;
+        while i < end {
+            if let Some(sme) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Address>(&DataKey::SmeByIndex(i))
+            {
+                let data = Self::get_or_create_credit_data(&env, &sme);
+                entries.push_back(SmeScoreEntry {
+                    sme,
+                    score: data.score,
+                });
+            }
+            i += 1;
+        }
+        entries
+    }
+
     pub fn get_payment_history(env: Env, sme: Address) -> Vec<PaymentRecord> {
         let history_len: u32 = env
             .storage()
@@ -1105,6 +1152,17 @@ impl CreditScoreContract {
         {
             data
         } else {
+            let count: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::SmeCount)
+                .unwrap_or(0);
+            env.storage()
+                .instance()
+                .set(&DataKey::SmeCount, &(count + 1));
+            env.storage()
+                .persistent()
+                .set(&DataKey::SmeByIndex(count), &sme.clone());
             let scoring_config = load_scoring_config(env);
             CreditScoreData {
                 sme: sme.clone(),

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{
 };
 
 const EVT: Symbol = symbol_short!("gov");
+const MIN_VOTING_PERIOD_SECS: u64 = 86_400;
 const DEFAULT_VOTING_PERIOD_SECS: u64 = 7 * 86_400;
 const DEFAULT_EXECUTION_DELAY_SECS: u64 = 48 * 3_600;
 const DEFAULT_QUORUM_BPS: u32 = 1_000;
@@ -151,6 +152,9 @@ impl Governance {
         }
         if pass_bps <= 5_000 || pass_bps > 10_000 {
             panic!("invalid threshold");
+        }
+        if voting_period_secs > 0 && voting_period_secs < MIN_VOTING_PERIOD_SECS {
+            panic!("voting period too short");
         }
 
         let config = GovernanceConfig {

--- a/contracts/governance/tests/lib.rs
+++ b/contracts/governance/tests/lib.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
     Address, Env, String,
 };
 
-const VOTING_PERIOD: u64 = 200;
+const VOTING_PERIOD: u64 = 86_400; // 1 day minimum
 const EXEC_DELAY: u64 = 100;
 const QUORUM_BPS: u32 = 1_000; // 10 %
 const PASS_BPS: u32 = 6_000; // 60 %


### PR DESCRIPTION

## Summary
Closes #641 
Closes #656
Closes #657 
Closes #658 

- Add list_all_sme_stats(env, page, page_size) -> Vec<SmeScoreEntry> to credit_score contract for paginated SME stats retrieval
- Track SME addresses in SmeByIndex(u32)/SmeCount storage on first credit data creation, enabling enumeration without iterating history
- Cap page_size at 100 (MAX_SME_PAGE_SIZE) to prevent gas exhaustion
- Add MIN_VOTING_PERIOD_SECS = 86_400 (1 day) check in governance initialize; reject voting_period_secs < 86_400 unless 0 (uses default)
- Update governance test VOTING_PERIOD from 200 to 86_400