### PR TITLE
fix: resolve env var inconsistency, add missing governance env var, and add deployment/init scripts

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,6 +10,7 @@ NEXT_PUBLIC_INVOICE_CONTRACT_ID=
 NEXT_PUBLIC_POOL_CONTRACT_ID=
 NEXT_PUBLIC_USDC_TOKEN_ID=
 NEXT_PUBLIC_CREDIT_SCORE_CONTRACT_ID=
+NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID=
 
 # Optional: second stablecoin for labels in the Invest UI (e.g. testnet EURC SAC)
 NEXT_PUBLIC_EURC_TOKEN_ID=
@@ -17,6 +18,8 @@ NEXT_PUBLIC_EURC_TOKEN_ID=
 # Optional: Custom RPC URLs (defaults to public endpoints based on network)
 # NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 # NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+# NEXT_PUBLIC_SOROBAN_RPC_FALLBACK_1=https://rpc-testnet.stellar.org
+# NEXT_PUBLIC_SOROBAN_RPC_FALLBACK_2=
 
 # Monitoring & Alerts
 # Webhook URL for health-degraded / health-down alerts fired by /api/health.

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -20,9 +20,9 @@ export const NETWORK =
       ? Networks.STANDALONE
       : Networks.TESTNET;
 export const RPC_ENDPOINTS = [
-  process.env.NEXT_PUBLIC_STELLAR_RPC_URL,
-  process.env.NEXT_PUBLIC_STELLAR_RPC_FALLBACK_1,
-  process.env.NEXT_PUBLIC_STELLAR_RPC_FALLBACK_2,
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL,
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_FALLBACK_1,
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_FALLBACK_2,
   'https://soroban-testnet.stellar.org',
   'https://rpc-testnet.stellar.org',
 ].filter(Boolean) as string[];

--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+# Deploy all 5 Astera contracts to Stellar testnet in dependency order.
+#
+# Usage:
+#   export DEPLOYER_KEY=<secret_key>   # required
+#   export NETWORK=testnet             # optional, defaults to testnet
+#   export RPC_URL=<soroban_rpc_url>   # optional, overrides --rpc-url
+#   export FUND_WITH_FRIENDBOT=true    # optional, fund deployer if balance is low
+#
+#   sh scripts/deploy-testnet.sh
+#
+# Output: contract IDs printed to stdout and written to deployed-testnet.env
+
+set -eu
+
+: "${DEPLOYER_KEY:?DEPLOYER_KEY not set}"
+: "${NETWORK:=testnet}"
+
+STELLAR_ARGS="--source $DEPLOYER_KEY --network $NETWORK"
+if [ -n "${RPC_URL:-}" ]; then
+  STELLAR_ARGS="$STELLAR_ARGS --rpc-url $RPC_URL"
+fi
+
+OUTPUT_FILE="${OUTPUT_FILE:-deployed-testnet.env}"
+WASM_DIR="/app/target/wasm32-unknown-unknown/release"
+
+if [ ! -d "$WASM_DIR" ]; then
+  echo "ERROR: WASM directory not found at $WASM_DIR. Build contracts first:" >&2
+  echo "  cargo build --target wasm32-unknown-unknown --release" >&2
+  exit 1
+fi
+
+# ── Optional: fund deployer via Friendbot if balance is low ──────────────
+if [ "${FUND_WITH_FRIENDBOT:-false}" = "true" ]; then
+  echo "==> Checking deployer balance..."
+  DEPLOYER_PUBLIC=$(stellar keys address "$DEPLOYER_KEY" 2>/dev/null || echo "")
+  if [ -n "$DEPLOYER_PUBLIC" ]; then
+    BALANCE=$(curl -s "https://horizon-testnet.stellar.org/accounts/$DEPLOYER_PUBLIC" | python3 -c "import sys,json; d=json.load(sys.stdin); print([b['balance'] for b in d.get('balances',[]) if b.get('asset_type')=='native'][0])" 2>/dev/null || echo "0")
+    BALANCE_INT=$(echo "$BALANCE" | cut -d. -f1)
+    if [ -z "$BALANCE_INT" ] || [ "$BALANCE_INT" -lt 100 ]; then
+      echo "==> Balance low ($BALANCE XLM), funding via Friendbot..."
+      curl -s "https://friendbot-testnet.stellar.org?addr=$DEPLOYER_PUBLIC" > /dev/null
+      echo "==> Funded."
+    else
+      echo "==> Balance sufficient ($BALANCE XLM), skipping Friendbot."
+    fi
+  fi
+fi
+
+deploy_contract() {
+  local name="$1"
+  local wasm_path="$2"
+  echo "==> Deploying $name..." >&2
+  stellar contract deploy \
+    --wasm "$wasm_path" \
+    $STELLAR_ARGS \
+    2>&1 | tail -1
+}
+
+echo "=== Deploying contracts (order: invoice -> pool -> credit_score -> share -> governance) ==="
+
+INVOICE_CONTRACT_ID=$(deploy_contract "invoice" "$WASM_DIR/invoice.wasm")
+POOL_CONTRACT_ID=$(deploy_contract "pool" "$WASM_DIR/pool.wasm")
+CREDIT_SCORE_CONTRACT_ID=$(deploy_contract "credit_score" "$WASM_DIR/credit_score.wasm")
+SHARE_CONTRACT_ID=$(deploy_contract "share" "$WASM_DIR/share.wasm")
+GOVERNANCE_CONTRACT_ID=$(deploy_contract "governance" "$WASM_DIR/governance.wasm")
+
+echo ""
+echo "=== Contract IDs ==="
+echo "  Invoice:      $INVOICE_CONTRACT_ID"
+echo "  Pool:         $POOL_CONTRACT_ID"
+echo "  Credit Score: $CREDIT_SCORE_CONTRACT_ID"
+echo "  Share:        $SHARE_CONTRACT_ID"
+echo "  Governance:   $GOVERNANCE_CONTRACT_ID"
+
+cat > "$OUTPUT_FILE" <<EOF
+INVOICE_CONTRACT_ID=$INVOICE_CONTRACT_ID
+POOL_CONTRACT_ID=$POOL_CONTRACT_ID
+CREDIT_SCORE_CONTRACT_ID=$CREDIT_SCORE_CONTRACT_ID
+SHARE_CONTRACT_ID=$SHARE_CONTRACT_ID
+GOVERNANCE_CONTRACT_ID=$GOVERNANCE_CONTRACT_ID
+EOF
+
+echo "=== Contract IDs written to $OUTPUT_FILE ==="

--- a/scripts/init-contracts.sh
+++ b/scripts/init-contracts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+# Initialize all 5 Astera contracts in dependency order after deployment.
+#
+# Usage:
+#   export DEPLOYER_KEY=<secret_key>  # or use --source <key_alias>
+#   export NETWORK=testnet             # or mainnet / standalone
+#   export RPC_URL=<soroban_rpc_url>   # optional, overrides --rpc-url
+#
+#   # Source contract IDs (either set these or source a deployed.env file)
+#   export SHARE_CONTRACT_ID=...
+#   export INVOICE_CONTRACT_ID=...
+#   export POOL_CONTRACT_ID=...
+#   export CREDIT_SCORE_CONTRACT_ID=...
+#   export GOVERNANCE_CONTRACT_ID=...
+#
+#   sh scripts/init-contracts.sh
+
+set -eu
+
+: "${DEPLOYER_KEY:?DEPLOYER_KEY not set}"
+: "${NETWORK:=testnet}"
+: "${SHARE_CONTRACT_ID:?SHARE_CONTRACT_ID not set}"
+: "${INVOICE_CONTRACT_ID:?INVOICE_CONTRACT_ID not set}"
+: "${POOL_CONTRACT_ID:?POOL_CONTRACT_ID not set}"
+: "${CREDIT_SCORE_CONTRACT_ID:?CREDIT_SCORE_CONTRACT_ID not set}"
+: "${GOVERNANCE_CONTRACT_ID:?GOVERNANCE_CONTRACT_ID not set}"
+: "${ADMIN_ADDRESS:?ADMIN_ADDRESS not set}"
+: "${USDC_TOKEN_ID:?USDC_TOKEN_ID not set}"
+
+STELLAR_ARGS="--source $DEPLOYER_KEY --network $NETWORK"
+if [ -n "${RPC_URL:-}" ]; then
+  STELLAR_ARGS="$STELLAR_ARGS --rpc-url $RPC_URL"
+fi
+
+invoke() {
+  local contract_id="$1"
+  shift
+  echo "==> initialize $1 ($contract_id)..."
+  if ! stellar contract invoke --id "$contract_id" $STELLAR_ARGS -- "$@" 2>&1; then
+    echo "ERROR: Failed to initialize $1. Check if already initialized." >&2
+    return 1
+  fi
+}
+
+# Order: share -> invoice -> pool -> credit_score -> governance
+
+echo "=== Initializing contracts (order: share -> invoice -> pool -> credit_score -> governance) ==="
+
+invoke "$SHARE_CONTRACT_ID" \
+  initialize \
+  --admin "$ADMIN_ADDRESS" \
+  --decimals 7 \
+  --name '"Astera Share Token"' \
+  --symbol '"ASTR"'
+
+invoke "$INVOICE_CONTRACT_ID" \
+  initialize \
+  --admin "$ADMIN_ADDRESS" \
+  --pool "$POOL_CONTRACT_ID" \
+  --max_invoice_amount 10000000000000 \
+  --expiration_duration_secs 2592000 \
+  --grace_period_days 30
+
+invoke "$POOL_CONTRACT_ID" \
+  initialize \
+  --admin "$ADMIN_ADDRESS" \
+  --initial_token "$USDC_TOKEN_ID" \
+  --initial_share_token "$SHARE_CONTRACT_ID" \
+  --invoice_contract "$INVOICE_CONTRACT_ID"
+
+invoke "$CREDIT_SCORE_CONTRACT_ID" \
+  initialize \
+  --admin "$ADMIN_ADDRESS" \
+  --invoice_contract "$INVOICE_CONTRACT_ID" \
+  --pool_contract "$POOL_CONTRACT_ID"
+
+invoke "$GOVERNANCE_CONTRACT_ID" \
+  initialize \
+  --admin "$ADMIN_ADDRESS" \
+  --share_token "$SHARE_CONTRACT_ID" \
+  --voting_period_secs 604800 \
+  --quorum_bps 1000 \
+  --pass_bps 5100 \
+  --execution_delay_secs 86400 \
+  --min_share_balance 10000000
+
+echo "=== All contracts initialized successfully ==="


### PR DESCRIPTION
## Summary

This PR resolves all 4 issues assigned to me in one go.

### Changes

**Issue #631** — Fixed env var naming inconsistency between `stellar.ts` and `.env.example`:
- Renamed `NEXT_PUBLIC_STELLAR_RPC_URL` to `NEXT_PUBLIC_SOROBAN_RPC_URL` in `frontend/lib/stellar.ts`
- Renamed fallback vars `NEXT_PUBLIC_STELLAR_RPC_FALLBACK_1` and `_2` to `NEXT_PUBLIC_SOROBAN_RPC_FALLBACK_1` and `_2`
- Added the fallback variables to `frontend/.env.example`

**Issue #628** — Added `NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID` to `frontend/.env.example`

**Issue #627** — Added `scripts/init-contracts.sh` to initialize all 5 contracts (share → invoice → pool → credit_score → governance) after deployment with sensible defaults

**Issue #626** — Added `scripts/deploy-testnet.sh` to deploy all 5 contracts to Stellar testnet in dependency order, save contract IDs to `deployed-testnet.env`, and optionally fund via Friendbot

Closes #631
Closes #628
Closes #627
Closes #626