### PR TITLE
fix: resolve issues #629, #634, #637, #639

### DIFF
--- a/contracts/credit_score/src/lib.rs
+++ b/contracts/credit_score/src/lib.rs
@@ -749,9 +749,7 @@ impl CreditScoreContract {
             .get(&DataKey::PoolContract)
             .expect("not initialized");
 
-        if caller != pool {
-            pool.require_auth();
-        }
+        pool.require_auth();
 
         require_not_paused(&env);
 
@@ -809,9 +807,7 @@ impl CreditScoreContract {
             .get(&DataKey::PoolContract)
             .expect("not initialized");
 
-        if caller != pool {
-            pool.require_auth();
-        }
+        pool.require_auth();
 
         require_not_paused(&env);
 

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -3200,7 +3200,10 @@ impl FundingPool {
         Self::require_not_paused(&env);
         Self::assert_accepted_token(&env, &token)?;
 
-        if bps == 0 || bps > BPS_DENOM {
+        if bps == 0 {
+            return Err(PoolError::ZeroAmount);
+        }
+        if bps > BPS_DENOM {
             return Err(PoolError::InvalidAmount);
         }
 

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -61,6 +61,7 @@ function validateContractId(id: string, name: string): string {
 
 validateContractId(INVOICE_CONTRACT_ID, 'invoice');
 validateContractId(POOL_CONTRACT_ID, 'pool');
+validateContractId(CREDIT_SCORE_CONTRACT_ID, 'credit_score');
 if (GOVERNANCE_CONTRACT_ID) {
   validateContractId(GOVERNANCE_CONTRACT_ID, 'governance');
 }

--- a/scripts/smoke-test-testnet.sh
+++ b/scripts/smoke-test-testnet.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# #634: Quick smoke-test for testnet deployments.
+# Iterates all contract IDs from env vars and calls version() on each.
+# Exits non-zero if any contract call fails.
+#
+# Usage:
+#   export INVOICE_CONTRACT_ID=...
+#   export POOL_CONTRACT_ID=...
+#   export CREDIT_SCORE_CONTRACT_ID=...
+#   export GOVERNANCE_CONTRACT_ID=...
+#   bash scripts/smoke-test-testnet.sh
+#
+# Environment:
+#   STELLAR_RPC_URL          — Soroban RPC endpoint (default: https://soroban-testnet.stellar.org)
+#   STELLAR_NETWORK_PASSPHRASE — network passphrase (default: Test SDF Network ; September 2015)
+
+set -eu
+
+RPC_URL="${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}"
+PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
+FAILED=0
+
+CONTRACTS=(
+  "INVOICE_CONTRACT_ID"
+  "POOL_CONTRACT_ID"
+  "CREDIT_SCORE_CONTRACT_ID"
+  "GOVERNANCE_CONTRACT_ID"
+)
+
+echo "==> Smoke-testing contracts on testnet"
+echo "    RPC URL: $RPC_URL"
+echo ""
+
+for VAR in "${CONTRACTS[@]}"; do
+  ID="${!VAR:-}"
+  if [ -z "$ID" ]; then
+    echo "  [SKIP] $VAR is not set"
+    continue
+  fi
+
+  echo -n "  $VAR ($ID) ... "
+  OUTPUT=$(stellar contract invoke \
+    --id "$ID" \
+    --rpc-url "$RPC_URL" \
+    --network-passphrase "$PASSPHRASE" \
+    -- \
+    version 2>&1) && RC=$? || RC=$?
+
+  if [ "$RC" -eq 0 ] && [ -n "$OUTPUT" ]; then
+    echo "OK — version: $OUTPUT"
+  else
+    echo "FAIL (exit=$RC)"
+    echo "    stderr: $OUTPUT"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "==> All contracts passed smoke test"
+else
+  echo "==> $FAILED contract(s) FAILED smoke test"
+fi
+exit "$FAILED"


### PR DESCRIPTION
## Summary

This PR resolves four assigned issues:

### #639 — pool: guard transfer_co_fund_share against zero-share transfers
Returns PoolError::ZeroAmount when bps == 0 instead of PoolError::InvalidAmount, preventing wasteful zero-value transfers and event spam.

### #637 — credit_score: enforce pool contract authorization
Replaced the bypassable `if caller != pool { pool.require_auth(); }` pattern with `pool.require_auth()` in both `record_payment` and `record_default`, ensuring only the configured pool contract can record credit history.

### #634 — feat: add testnet smoke-test script
Added `scripts/smoke-test-testnet.sh` that iterates all 4 contract IDs from env vars, calls `version()` on each, and exits non-zero if any call fails.

### #629 — frontend: add CREDIT_SCORE_CONTRACT_ID validation at module init
Added `validateContractId(CREDIT_SCORE_CONTRACT_ID, 'credit_score')` alongside existing invoice/pool/governance validation in `frontend/lib/contracts.ts`.

Closes #629
Closes #634
Closes #637
Closes #639
