### PR TITLE
feat: export SHARE_TOKEN_ID and align pool completed-invoice TTL

### DIFF
--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -182,11 +182,12 @@ const DEFAULT_MAX_WITHDRAWAL_QUEUE_AGE_DAYS: u32 = 30;
 
 const LEDGERS_PER_DAY: u32 = 17_280;
 const ACTIVE_INVOICE_TTL: u32 = LEDGERS_PER_DAY * 365;
-const COMPLETED_INVOICE_TTL: u32 = LEDGERS_PER_DAY * 30;
+// 5 years — aligned with the invoice contract's DEFAULT_COMPLETED_INVOICE_TTL so a
+// pool FundedInvoice record does not expire long before its invoice record (#636).
+const COMPLETED_INVOICE_TTL: u32 = LEDGERS_PER_DAY * 365 * 5;
 // Collateral records are kept for 90 days after settlement (repayment or
-// seizure) so auditors and the SME have time to verify the record exists.
-// This is longer than COMPLETED_INVOICE_TTL (30 days) because collateral
-// disputes may arise well after the invoice is closed.
+// seizure) so auditors and the SME have time to verify the record exists,
+// covering the post-settlement audit/dispute window.
 const SETTLEMENT_COLLATERAL_TTL: u32 = LEDGERS_PER_DAY * 90;
 const INSTANCE_BUMP_AMOUNT: u32 = LEDGERS_PER_DAY * 30;
 const INSTANCE_LIFETIME_THRESHOLD: u32 = LEDGERS_PER_DAY * 7;
@@ -2642,8 +2643,7 @@ impl FundingPool {
                 .persistent()
                 .set(&DataKey::CollateralDeposit(invoice_id), &col);
             // Use SETTLEMENT_COLLATERAL_TTL (90 days) so the seizure record
-            // outlives COMPLETED_INVOICE_TTL (30 days) and remains queryable
-            // for the full post-default audit window.
+            // remains queryable for the full post-default audit window.
             env.storage().persistent().extend_ttl(
                 &DataKey::CollateralDeposit(invoice_id),
                 SETTLEMENT_COLLATERAL_TTL,

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -11,6 +11,8 @@ NEXT_PUBLIC_POOL_CONTRACT_ID=
 NEXT_PUBLIC_USDC_TOKEN_ID=
 NEXT_PUBLIC_CREDIT_SCORE_CONTRACT_ID=
 NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID=
+# Share token used by governance to measure voting power (a user's share-token balance)
+NEXT_PUBLIC_SHARE_TOKEN_ID=
 
 # Optional: second stablecoin for labels in the Invest UI (e.g. testnet EURC SAC)
 NEXT_PUBLIC_EURC_TOKEN_ID=

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -34,6 +34,8 @@ export const INVOICE_CONTRACT_ID = process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID ?
 export const POOL_CONTRACT_ID = process.env.NEXT_PUBLIC_POOL_CONTRACT_ID ?? '';
 export const CREDIT_SCORE_CONTRACT_ID = process.env.NEXT_PUBLIC_CREDIT_SCORE_CONTRACT_ID ?? '';
 export const GOVERNANCE_CONTRACT_ID = process.env.NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID ?? '';
+// #633: share token whose balance represents a user's governance voting power
+export const SHARE_TOKEN_ID = process.env.NEXT_PUBLIC_SHARE_TOKEN_ID ?? '';
 export const USDC_TOKEN_ID = process.env.NEXT_PUBLIC_USDC_TOKEN_ID ?? '';
 export const EURC_TOKEN_ID = process.env.NEXT_PUBLIC_EURC_TOKEN_ID ?? '';
 // #111: additional stablecoin support


### PR DESCRIPTION
## Summary

**#633 — `SHARE_TOKEN_ID` for governance voting power**
- Added `export const SHARE_TOKEN_ID = process.env.NEXT_PUBLIC_SHARE_TOKEN_ID ?? '';` to `frontend/lib/stellar.ts` (following the existing token-id export pattern).
- Added `NEXT_PUBLIC_SHARE_TOKEN_ID=` to `frontend/.env.example` with an explanatory comment, so the governance page can resolve and display a user's share-token balance (voting power).

**#636 — align pool completed-invoice TTL with the invoice contract**
- `contracts/pool/src/lib.rs`: `COMPLETED_INVOICE_TTL` was `LEDGERS_PER_DAY * 30` (30 days) while the invoice contract uses `DEFAULT_COMPLETED_INVOICE_TTL = LEDGERS_PER_DAY * 365 * 5` (5 years). Pool `FundedInvoice` records therefore expired ~60x sooner than their invoice records, breaking lookups. Set it to `LEDGERS_PER_DAY * 365 * 5` to match.
- Fixed two now-stale comments that described the collateral TTL as "longer than COMPLETED_INVOICE_TTL (30 days)".

## Test plan
- [x] `cargo check -p pool --lib` passes with the TTL change.
- [x] The pool already uses 1-year (`ACTIVE_INVOICE_TTL`) and the invoice contract uses 5-year TTLs, so the new value is within existing usage.
- [x] Frontend export follows the existing `*_TOKEN_ID` pattern (type-safe).

Note (pre-existing, out of scope): the `pool` crate's **test** target currently fails to compile on `main` (`FundedInvoice` lacks `Debug` for an `assert_eq!` at `lib.rs:5742`) — unrelated to this change, which only adjusts a constant and two comments; the library compiles cleanly.

Closes #620
Closes #633
Closes #636
Closes #701