### PR TITLE
test: add unit tests for pool seize_collateral accounting and invoice extension flow (#623, #624)

### DIFF
--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -4403,4 +4403,90 @@ mod test {
             InvoiceError::NoAdminChangeProposed.into()
         );
     }
+
+    // ── #624: request_extension / approve_extension unit tests ──────────────────
+
+    #[test]
+    fn test_extension_happy_path() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        let (client, admin, pool, sme) = setup(&env);
+        let id = make_invoice(&env, &client, &sme, 1_000);
+        client.mark_funded(&id, &pool);
+
+        let invoice = client.get_invoice(&id);
+        let current_due_date = invoice.due_date;
+        let new_due = current_due_date + 10 * 86_400; // 10 days extension
+
+        // Request extension
+        client.request_extension(&id, &sme, &new_due);
+        let invoice = client.get_invoice(&id);
+        assert_eq!(invoice.pending_due_date, Some(new_due));
+
+        // Approve extension by admin
+        client.approve_extension(&id, &admin);
+        let invoice = client.get_invoice(&id);
+        assert_eq!(invoice.due_date, new_due);
+        assert_eq!(invoice.pending_due_date, None);
+    }
+
+    #[test]
+    fn test_extension_too_large_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        let (client, _admin, pool, sme) = setup(&env);
+        let id = make_invoice(&env, &client, &sme, 1_000);
+        client.mark_funded(&id, &pool);
+
+        let invoice = client.get_invoice(&id);
+        let current_due_date = invoice.due_date;
+        // MAX_DUE_DATE_EXTENSION_SECS is 90 days. Request 91 days.
+        let new_due = current_due_date + 91 * 86_400;
+
+        let result = client.try_request_extension(&id, &sme, &new_due);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            InvoiceError::ExtensionTooLarge.into()
+        );
+    }
+
+    #[test]
+    fn test_extension_double_request_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        let (client, _admin, pool, sme) = setup(&env);
+        let id = make_invoice(&env, &client, &sme, 1_000);
+        client.mark_funded(&id, &pool);
+
+        let invoice = client.get_invoice(&id);
+        let current_due_date = invoice.due_date;
+        let new_due1 = current_due_date + 10 * 86_400;
+        let new_due2 = current_due_date + 20 * 86_400;
+
+        client.request_extension(&id, &sme, &new_due1);
+        let result = client.try_request_extension(&id, &sme, &new_due2);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            InvoiceError::ExtensionAlreadyPending.into()
+        );
+    }
+
+    #[test]
+    fn test_approve_no_pending_extension_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        let (client, admin, pool, sme) = setup(&env);
+        let id = make_invoice(&env, &client, &sme, 1_000);
+        client.mark_funded(&id, &pool);
+
+        let result = client.try_approve_extension(&id, &admin);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            InvoiceError::NoPendingExtension.into()
+        );
+    }
 }

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -5739,7 +5739,11 @@ mod test {
 
         let result = client.try_get_funded_invoices_batch(&ids);
 
-        assert_eq!(result, Err(Ok(PoolError::BatchTooLarge)));
+        if let Err(Ok(err)) = result {
+            assert_eq!(err, PoolError::BatchTooLarge);
+        } else {
+            panic!("Expected BatchTooLarge error");
+        }
     }
 
     #[test]
@@ -7375,5 +7379,110 @@ mod test {
         let (client, admin, _usdc_id, _share_token) = setup(&env);
         let result = client.try_cancel_admin_change(&admin);
         assert_eq!(result, Err(Ok(PoolError::NoAdminChangeProposed)));
+    }
+
+    // ── #623: seize_collateral accounting & validation tests ────────────────────
+
+    #[test]
+    fn test_seize_collateral_happy_path_accounting() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+        let invoice_contract = client.get_config().invoice_contract;
+
+        client.set_collateral_config(&admin, &1_000i128, &2_000u32);
+        let principal: i128 = 5_000;
+        let required = client.required_collateral_for(&principal); // 1,000
+
+        mint(&env, &usdc_id, &investor, 10_000);
+        mint(&env, &usdc_id, &sme, required);
+
+        client.deposit(&investor, &usdc_id, &10_000);
+        client.deposit_collateral(&1u64, &sme, &usdc_id, &required);
+        let due_date = env.ledger().timestamp() + 1_000;
+        client.fund_invoice(&admin, &1u64, &principal, &sme, &due_date, &usdc_id);
+
+        // Mark invoice defaulted
+        DummyInvoiceClient::new(&env, &invoice_contract).set_invoice_defaulted(&1u64, &true);
+
+        let tt_before = client.get_token_totals(&usdc_id);
+        let pool_token_client = token::Client::new(&env, &usdc_id);
+        let pool_balance_before = pool_token_client.balance(&client.address);
+
+        client.seize_collateral(&admin, &1u64);
+
+        // 1. Check pool value increased, total deployed decreased by principal
+        let tt_after = client.get_token_totals(&usdc_id);
+        assert_eq!(tt_after.pool_value, tt_before.pool_value + required);
+        assert_eq!(tt_after.total_deployed, tt_before.total_deployed - principal);
+
+        // 2. Check the pool contract still holds the collateral amount (retained, not returned to SME)
+        let pool_balance_after = pool_token_client.balance(&client.address);
+        assert_eq!(pool_balance_after, pool_balance_before); // no tokens transferred out
+
+        // 3. Verify CollateralDeposit.settled = true and seized_at is updated
+        let col = client.get_collateral_deposit(&1u64).unwrap();
+        assert!(col.settled);
+        assert_eq!(col.seized_at, env.ledger().timestamp());
+    }
+
+    #[test]
+    fn test_seize_collateral_already_settled_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+        let invoice_contract = client.get_config().invoice_contract;
+
+        client.set_collateral_config(&admin, &1_000i128, &2_000u32);
+        let principal: i128 = 5_000;
+        let required = client.required_collateral_for(&principal);
+
+        mint(&env, &usdc_id, &investor, 10_000);
+        mint(&env, &usdc_id, &sme, required);
+
+        client.deposit(&investor, &usdc_id, &10_000);
+        client.deposit_collateral(&1u64, &sme, &usdc_id, &required);
+        let due_date = env.ledger().timestamp() + 1_000;
+        client.fund_invoice(&admin, &1u64, &principal, &sme, &due_date, &usdc_id);
+
+        DummyInvoiceClient::new(&env, &invoice_contract).set_invoice_defaulted(&1u64, &true);
+
+        client.seize_collateral(&admin, &1u64);
+
+        // Try second time — should fail with CollateralAlreadySettled
+        let result = client.try_seize_collateral(&admin, &1u64);
+        assert_eq!(result, Err(Ok(PoolError::CollateralAlreadySettled)));
+    }
+
+    #[test]
+    fn test_seize_collateral_not_defaulted_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+        let invoice_contract = client.get_config().invoice_contract;
+
+        client.set_collateral_config(&admin, &1_000i128, &2_000u32);
+        let principal: i128 = 5_000;
+        let required = client.required_collateral_for(&principal);
+
+        mint(&env, &usdc_id, &investor, 10_000);
+        mint(&env, &usdc_id, &sme, required);
+
+        client.deposit(&investor, &usdc_id, &10_000);
+        client.deposit_collateral(&1u64, &sme, &usdc_id, &required);
+        let due_date = env.ledger().timestamp() + 1_000;
+        client.fund_invoice(&admin, &1u64, &principal, &sme, &due_date, &usdc_id);
+
+        // Do NOT mark invoice defaulted
+        DummyInvoiceClient::new(&env, &invoice_contract).set_invoice_defaulted(&1u64, &false);
+
+        let result = client.try_seize_collateral(&admin, &1u64);
+        assert_eq!(result, Err(Ok(PoolError::NotDefaulted)));
     }
 }

--- a/contracts/tests/tests/integration_tests.rs
+++ b/contracts/tests/tests/integration_tests.rs
@@ -1007,7 +1007,7 @@ fn test_collateral_not_required_below_threshold() {
     assert_eq!(pool_client.required_collateral_for(&principal), 0);
 
     soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id).mint(&investor, &10_000i128);
-    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id).mint(&sme, &principal * 2);
+    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id).mint(&sme, &(principal * 2));
 
     pool_client.deposit(&investor, &usdc_id, &10_000i128);
 


### PR DESCRIPTION
Closes #623
Closes #624
Closes #625
Closes #630 

## Summary

This PR adds unit tests for two open issues and fixes two pre-existing compile errors.

---

### #623 — `pool::seize_collateral` token balance accounting tests

Added three unit tests inside `contracts/pool/src/lib.rs`:

| Test | What it verifies |
|---|---|
| `test_seize_collateral_happy_path_accounting` | Pool value increases by collateral amount; total_deployed decreases by principal; `CollateralDeposit.settled = true`; `seized_at` is set |
| `test_seize_collateral_already_settled_fails` | Second `seize_collateral` call returns `CollateralAlreadySettled` |
| `test_seize_collateral_not_defaulted_fails` | Calling on a non-defaulted invoice returns `NotDefaulted` |

---

### #624 — `invoice::request_extension / approve_extension` unit tests

Added four unit tests inside `contracts/invoice/src/lib.rs`:

| Test | What it verifies |
|---|---|
| `test_extension_happy_path` | Full request → approve → new due_date applied; `pending_due_date` cleared |
| `test_extension_too_large_fails` | Requesting > 90 days returns `ExtensionTooLarge` |
| `test_extension_double_request_fails` | Second request while one pending returns `ExtensionAlreadyPending` |
| `test_approve_no_pending_extension_fails` | Approve with no pending request returns `NoPendingExtension` |

---

### Pre-existing compile fixes (bonus)

- **`contracts/pool/src/lib.rs`**: Replaced `assert_eq!` with `if let` pattern in `test_get_funded_invoices_batch_rejects_oversized_batch` to avoid requiring `Debug` on `FundedInvoice`.
- **`contracts/tests/tests/integration_tests.rs`**: Fixed type mismatch `&principal * 2` → `&(principal * 2)`.

---

## Test Results

```
invoice --lib: test result: ok. 90 passed; 0 failed
pool --lib:    test result: ok. 149 passed; 0 failed
```

All 7 new tests pass. All pre-existing lib tests continue to pass.
