### PR TITLE
fix: resolve issues #635, #638, #621, #632

### DIFF
--- a/.github/workflows/testnet-deploy.yml
+++ b/.github/workflows/testnet-deploy.yml
@@ -1,0 +1,52 @@
+name: Testnet Deploy
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  deploy:
+    name: Deploy to Testnet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli@22.6.0
+
+      - name: Build contracts
+        run: cargo build --target wasm32-unknown-unknown --release -p invoice -p pool -p credit_score -p share -p governance
+
+      - name: Deploy contracts to testnet
+        run: |
+          mkdir -p /app && ln -sf "${{ github.workspace }}/target" /app/target
+          DEPLOYER_KEY="${{ secrets.TESTNET_DEPLOYER_KEY }}" \
+          NETWORK=testnet \
+          sh scripts/deploy-testnet.sh
+
+      - name: Initialize contracts
+        run: |
+          source deployed-testnet.env
+          DEPLOYER_KEY="${{ secrets.TESTNET_DEPLOYER_KEY }}" \
+          NETWORK=testnet \
+          ADMIN_ADDRESS="${{ secrets.TESTNET_ADMIN_ADDRESS }}" \
+          USDC_TOKEN_ID="${{ secrets.TESTNET_USDC_TOKEN_ID }}" \
+          sh scripts/init-contracts.sh
+
+      - name: Smoke test contracts
+        run: |
+          source deployed-testnet.env
+          bash scripts/smoke-test-testnet.sh
+
+      - name: Upload deployment artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deployed-testnet-env
+          path: deployed-testnet.env

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -1531,7 +1531,7 @@ impl FundingPool {
         bump_instance(&env);
         Self::require_not_paused(&env);
         if shares <= 0 {
-            return Err(PoolError::InvalidAmount);
+            return Err(PoolError::ZeroAmount);
         }
         Self::assert_accepted_token(&env, &token)?;
 
@@ -1547,6 +1547,22 @@ impl FundingPool {
             if request.investor == investor {
                 return Err(PoolError::AlreadyQueuedForWithdrawal);
             }
+        }
+
+        let investor_pos_key = DataKey::InvestorPosition(investor.clone(), token.clone());
+        let position: InvestorPosition = env
+            .storage()
+            .persistent()
+            .get(&investor_pos_key)
+            .unwrap_or(InvestorPosition {
+                deposited: 0,
+                available: 0,
+                deployed: 0,
+                earned: 0,
+                deposit_count: 0,
+            });
+        if shares > position.available {
+            return Err(PoolError::WithdrawalExceedsLimit);
         }
 
         Self::non_reentrant_start(&env);

--- a/contracts/tests/tests/integration_tests.rs
+++ b/contracts/tests/tests/integration_tests.rs
@@ -1553,3 +1553,108 @@ fn test_token_removal_blocked_with_active_deposits() {
         "EURC should still be in accepted_tokens after failed removal"
     );
 }
+
+/// Integration test: Oracle verification + funding flow (Issue #621)
+#[test]
+fn test_oracle_verified_funding_flow() {
+    let env = test_env();
+    env.mock_all_auths_allowing_non_root_auth();
+    env.ledger().with_mut(|l| l.timestamp = 100_000);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let invoice_addr = env.register_contract_wasm(None, invoice::WASM);
+    let pool_addr = env.register_contract_wasm(None, pool::WASM);
+    let share_addr = env.register_contract_wasm(None, share::WASM);
+    let usdc_addr = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    let invoice_client = invoice::Client::new(&env, &invoice_addr);
+    let pool_client = pool::Client::new(&env, &pool_addr);
+    let share_client = share::Client::new(&env, &share_addr);
+
+    invoice_client.initialize(
+        &admin,
+        &pool_addr,
+        &10_000_000_000i128,
+        &(30u64 * 86_400u64),
+        &7u32,
+    );
+    share_client.initialize(
+        &admin,
+        &7u32,
+        &String::from_str(&env, "Pool Shares"),
+        &String::from_str(&env, "POOL"),
+    );
+    initialize_pool(&pool_client, &admin, &usdc_addr, &share_addr, &invoice_addr);
+
+    // Configure oracle on the invoice contract
+    invoice_client.set_oracle(&admin, &oracle);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_addr)
+        .mint(&investor, &10_000_000_000i128);
+    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_addr)
+        .mint(&sme, &10_000_000_000i128);
+
+    pool_client.deposit(&investor, &usdc_addr, &5_000_000_000i128);
+
+    // Create invoice — starts in AwaitingVerification because oracle is configured
+    let due_date = env.ledger().timestamp() + 30 * 86_400;
+    let inv_id = invoice_client.create_invoice(
+        &sme,
+        &String::from_str(&env, "ACME Corp"),
+        &2_000_000_000i128,
+        &due_date,
+        &String::from_str(&env, "Invoice #OVF-001"),
+        &String::from_str(&env, "hash_ovf"),
+        &metadata_url(&env),
+    );
+    assert_eq!(inv_id, 1);
+
+    let invoice = invoice_client.get_invoice(&inv_id);
+    assert_eq!(
+        invoice.status,
+        invoice::InvoiceStatus::AwaitingVerification
+    );
+
+    // mark_funded should be blocked while invoice is AwaitingVerification
+    let block_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        invoice_client.mark_funded(&inv_id, &pool_addr);
+    }));
+    assert!(block_result.is_err());
+
+    // Oracle approves the invoice
+    invoice_client.verify_invoice(
+        &inv_id,
+        &oracle,
+        &true,
+        &String::from_str(&env, ""),
+        &String::from_str(&env, "hash_ovf"),
+    );
+
+    let invoice = invoice_client.get_invoice(&inv_id);
+    assert_eq!(invoice.status, invoice::InvoiceStatus::Verified);
+    assert!(invoice.oracle_verified);
+
+    // Admin opens co-funding and invoice is funded
+    pool_client.fund_invoice(
+        &admin,
+        &inv_id,
+        &2_000_000_000i128,
+        &sme,
+        &due_date,
+        &usdc_addr,
+    );
+    invoice_client.mark_funded(&inv_id, &pool_addr);
+
+    let invoice = invoice_client.get_invoice(&inv_id);
+    assert_eq!(invoice.status, invoice::InvoiceStatus::Funded);
+
+    let totals = pool_client.get_token_totals(&usdc_addr);
+    assert_eq!(totals.total_deployed, 2_000_000_000i128);
+}


### PR DESCRIPTION
## Summary

### #635 — decrease SME outstanding on cancel
Already present in `cancel_invoice` on upstream main. Verified, no code change needed.

### #638 — Validate withdrawal shares against available position
Added an early check in `request_withdrawal` (pool contract) that returns `PoolError::WithdrawalExceedsLimit` when `shares > position.available` and `PoolError::ZeroAmount` when `shares <= 0`.

**Files changed:** `contracts/pool/src/lib.rs`

### #621 — Integration test for oracle verification + funding flow
Added `test_oracle_verified_funding_flow` that:
1. Configures an oracle on the invoice contract
2. Creates an invoice (starts in `AwaitingVerification`)
3. Verifies `mark_funded` is blocked while in `AwaitingVerification`
4. Has the oracle approve via `verify_invoice` → invoice moves to `Verified`
5. Admin funds via pool → invoice marked `Funded`

**Files changed:** `contracts/tests/tests/integration_tests.rs`

### #632 — Testnet deploy workflow on release tags
Added `.github/workflows/testnet-deploy.yml` that triggers on `v*` tags:
- Builds WASM contracts (`wasm32-unknown-unknown`)
- Deploys via `scripts/deploy-testnet.sh`
- Initializes via `scripts/init-contracts.sh`
- Runs smoke test
- Uploads deployment artifacts

**Files changed:** `.github/workflows/testnet-deploy.yml`

closes #635
closes #638 
closes #632 
closes #621