### PR TITLE
fix/feat: due-date expiry check, borrower auth, credit score funding signal, and dark mode

### DIFF
--- a/contracts/credit_score/src/lib.rs
+++ b/contracts/credit_score/src/lib.rs
@@ -793,6 +793,51 @@ impl CreditScoreContract {
         );
     }
 
+    /// Record that the borrower's invoice has been successfully funded (#534).
+    /// Being funded is a positive demand signal — lenders deployed capital,
+    /// which is evidence of creditworthiness. The weight is intentionally light
+    /// so funding events alone cannot override a poor repayment history.
+    ///
+    /// Idempotent: duplicate calls for the same invoice_id are silently ignored.
+    pub fn record_funding(
+        env: Env,
+        _caller: Address,
+        invoice_id: u64,
+        sme: Address,
+        amount: i128,
+    ) {
+        let pool: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PoolContract)
+            .expect("not initialized");
+
+        pool.require_auth();
+
+        require_not_paused(&env);
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::InvoiceProcessed(invoice_id))
+        {
+            return;
+        }
+
+        let mut credit_data = Self::get_or_create_credit_data(&env, &sme);
+        credit_data.total_volume = credit_data.total_volume.saturating_add(amount);
+        credit_data.last_updated = env.ledger().timestamp();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::CreditScore(sme.clone()), &credit_data);
+
+        env.events().publish(
+            (EVT, symbol_short!("funded")),
+            (sme, invoice_id, amount, env.ledger().timestamp()),
+        );
+    }
+
     pub fn record_default(
         env: Env,
         _caller: Address,

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -459,6 +459,7 @@ const EVT: Symbol = symbol_short!("POOL");
 #[contractclient(name = "CreditScoreClient")]
 pub trait CreditScoreContract {
     fn get_credit_score(env: Env, sme: Address) -> CreditScoreData;
+    fn record_funding(env: Env, caller: Address, invoice_id: u64, sme: Address, amount: i128);
 }
 
 /// Cross-contract interface to the invoice contract (#385, #386).
@@ -917,6 +918,19 @@ fn fund_invoice_request(
             env.ledger().timestamp(),
         ),
     );
+
+    // #534: notify the credit score contract that this borrower secured funding.
+    // Non-fatal — a cross-contract failure must not revert a successful funding.
+    if let Some(cs_contract) = get_credit_score_contract(env) {
+        let cs_client = CreditScoreClient::new(env, &cs_contract);
+        let _ = cs_client.try_record_funding(
+            &env.current_contract_address(),
+            &request.invoice_id,
+            &request.sme,
+            &request.principal,
+        );
+    }
+
     Ok(())
 }
 

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -147,6 +147,8 @@ pub enum PoolError {
     NoAdminChangeProposed = 56,
     // #655: estimate_repayment rejects an as_of_timestamp earlier than now
     TimestampInPast = 57,
+    // #531: funding rejected because the invoice due date has already passed
+    InvoiceExpired = 58,
 }
 
 type PoolResult<T> = Result<T, PoolError>;
@@ -816,6 +818,12 @@ fn fund_invoice_request(
     }
 
     let now = env.ledger().timestamp();
+
+    // #531: reject funding if the invoice due date has already passed
+    if now >= request.due_date {
+        return Err(PoolError::InvoiceExpired);
+    }
+
     let factoring_fee = resolve_factoring_fee(
         env,
         config,

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -2280,6 +2280,11 @@ impl FundingPool {
             .get(&funded_invoice_key)
             .ok_or(PoolError::InvoiceNotFound)?;
 
+        // #536: only the invoice's borrower (SME) may repay their own invoice
+        if payer != record.sme {
+            return Err(PoolError::Unauthorized);
+        }
+
         let now = env.ledger().timestamp();
         let (total_interest, total_due) = calculate_total_due(&record, &config, now)?;
         let total_interest_i128 = u128_to_i128(total_interest)?;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -24,6 +24,43 @@
   --text-secondary: #334155;
 }
 
+/* ---- Light mode: override hardcoded Tailwind brand colors ---- */
+:root.light .bg-brand-dark {
+  background-color: #f1f5f9 !important;
+}
+:root.light .bg-brand-card {
+  background-color: #ffffff !important;
+}
+:root.light .bg-brand-navy {
+  background-color: #f8fafc !important;
+}
+:root.light .border-brand-border {
+  border-color: #e2e8f0 !important;
+}
+:root.light .text-white {
+  color: #0f172a !important;
+}
+:root.light .text-brand-muted {
+  color: #64748b !important;
+}
+:root.light .placeholder-brand-muted::placeholder {
+  color: #94a3b8 !important;
+}
+:root.light .bg-brand-dark\/80 {
+  background-color: rgba(248, 250, 252, 0.9) !important;
+}
+:root.light input,
+:root.light textarea,
+:root.light select {
+  background-color: #f8fafc;
+  color: #0f172a;
+  border-color: #e2e8f0;
+}
+:root.light input::placeholder,
+:root.light textarea::placeholder {
+  color: #94a3b8;
+}
+
 * {
   box-sizing: border-box;
   margin: 0;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -33,8 +33,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const messages = await getMessages();
 
   return (
-    <html lang={locale}>
+    <html lang={locale} suppressHydrationWarning>
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){var t=localStorage.getItem('astera-theme');var m=window.matchMedia('(prefers-color-scheme: light)').matches;if(t==='light'||(t===null&&m))document.documentElement.classList.add('light');})()`,
+          }}
+        />
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#ffffff" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/frontend/components/APYCalculator.tsx
+++ b/frontend/components/APYCalculator.tsx
@@ -55,9 +55,9 @@ export function APYCalculator({ className = '' }: { className?: string }) {
   }
 
   return (
-    <div className={`p-6 bg-brand-card border border-brand-border rounded-2xl ${className}`.trim()}>
-      <h2 className="text-lg font-semibold mb-1">Earnings calculator</h2>
-      <p className="text-xs text-brand-muted mb-4">
+    <div className={`p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl ${className}`.trim()}>
+      <h2 className="text-lg font-semibold mb-1 text-[var(--text-primary)]">Earnings calculator</h2>
+      <p className="text-xs text-[var(--muted)] mb-4">
         Model projected returns using the pool&apos;s current rate (
         {hasValidPoolRate ? `${formatApyPercent(yieldBps!)}% APY` : 'rate unavailable'}
         ).
@@ -65,7 +65,7 @@ export function APYCalculator({ className = '' }: { className?: string }) {
 
       <div className="space-y-4">
         <div>
-          <label className="block text-sm text-brand-muted mb-2">Deposit amount (USDC)</label>
+          <label className="block text-sm text-[var(--muted)] mb-2">Deposit amount (USDC)</label>
           <div className="relative">
             <input
               type="number"
@@ -75,16 +75,16 @@ export function APYCalculator({ className = '' }: { className?: string }) {
               value={depositInput}
               onChange={(e) => setDepositInput(e.target.value)}
               disabled={!hasValidPoolRate}
-              className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-3 text-white placeholder-brand-muted focus:outline-none focus:border-brand-gold text-lg disabled:opacity-50"
+              className="w-full bg-[var(--bg)] border border-[var(--border)] rounded-xl px-4 py-3 text-[var(--text-primary)] placeholder-[var(--muted)] focus:outline-none focus:border-brand-gold text-lg disabled:opacity-50"
             />
-            <span className="absolute right-4 top-1/2 -translate-y-1/2 text-brand-muted text-sm font-medium">
+            <span className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--muted)] text-sm font-medium">
               USDC
             </span>
           </div>
         </div>
 
         <div>
-          <label className="block text-sm text-brand-muted mb-2">Lock period (days)</label>
+          <label className="block text-sm text-[var(--muted)] mb-2">Lock period (days)</label>
           <input
             type="number"
             min="1"
@@ -92,13 +92,13 @@ export function APYCalculator({ className = '' }: { className?: string }) {
             value={lockDaysInput}
             onChange={(e) => setLockDaysInput(e.target.value)}
             disabled={!hasValidPoolRate}
-            className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-3 text-white placeholder-brand-muted focus:outline-none focus:border-brand-gold text-lg disabled:opacity-50"
+            className="w-full bg-[var(--bg)] border border-[var(--border)] rounded-xl px-4 py-3 text-[var(--text-primary)] placeholder-[var(--muted)] focus:outline-none focus:border-brand-gold text-lg disabled:opacity-50"
           />
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
-          <div className="p-4 bg-brand-dark border border-brand-border rounded-xl">
-            <p className="text-xs text-brand-muted mb-1">Projected interest</p>
+          <div className="p-4 bg-[var(--bg)] border border-[var(--border)] rounded-xl">
+            <p className="text-xs text-[var(--muted)] mb-1">Projected interest</p>
             <p className="text-xl font-semibold text-brand-gold">
               {!hasValidPoolRate
                 ? '---'
@@ -107,9 +107,9 @@ export function APYCalculator({ className = '' }: { className?: string }) {
                   : formatUSDC(0n)}
             </p>
           </div>
-          <div className="p-4 bg-brand-dark border border-brand-border rounded-xl">
-            <p className="text-xs text-brand-muted mb-1">Total at maturity</p>
-            <p className="text-xl font-semibold text-white">
+          <div className="p-4 bg-[var(--bg)] border border-[var(--border)] rounded-xl">
+            <p className="text-xs text-[var(--muted)] mb-1">Total at maturity</p>
+            <p className="text-xl font-semibold text-[var(--text-primary)]">
               {!hasValidPoolRate
                 ? '---'
                 : depositInput && parseFloat(depositInput) > 0
@@ -121,14 +121,14 @@ export function APYCalculator({ className = '' }: { className?: string }) {
       </div>
 
       {isFallbackRate && (
-        <p className="mt-4 text-xs text-yellow-300">
+        <p className="mt-4 text-xs text-yellow-600 dark:text-yellow-300">
           Failed to load live pool configuration. Using fallback APY of{' '}
           {formatApyPercent(DEFAULT_YIELD_BPS)}%.
         </p>
       )}
 
-      <p className="mt-4 text-xs text-brand-muted leading-relaxed border-t border-brand-border pt-4">
-        <strong className="text-brand-muted">Disclaimer:</strong> This projection uses the
+      <p className="mt-4 text-xs text-[var(--muted)] leading-relaxed border-t border-[var(--border)] pt-4">
+        <strong className="text-[var(--muted)]">Disclaimer:</strong> This projection uses the
         pool&apos;s configured yield rate and assumes continuous linear accrual like on-chain
         invoice interest. Actual returns depend on invoice repayment timing, utilization, and pool
         parameters -- nothing is guaranteed.

--- a/frontend/components/CreditScore.tsx
+++ b/frontend/components/CreditScore.tsx
@@ -183,7 +183,7 @@ export default function CreditScore({
       )}
 
       {/* Score Overview Card */}
-      <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
+      <div className="p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl">
         <h2 className="text-lg font-semibold mb-6">On-Chain Credit Score</h2>
 
         {/* Staleness warning: score was computed under a previous scoring config */}
@@ -217,7 +217,7 @@ export default function CreditScore({
         {/* Score display with change indicator */}
         <div className="text-center mb-8">
           <div className={`text-5xl font-bold mb-2 ${scoreColor}`}>{score}</div>
-          <div className="text-brand-muted text-sm mb-1">{scoreLabel}</div>
+          <div className="text-[var(--muted)] text-sm mb-1">{scoreLabel}</div>
           {scoreChange !== null && (
             <div
               className={`text-xs font-medium ${
@@ -228,7 +228,7 @@ export default function CreditScore({
               {scoreChange} since last invoice
             </div>
           )}
-          <div className="text-xs text-brand-muted/60 mt-2">Based on {total} invoice(s)</div>
+          <div className="text-xs text-[var(--muted)]/60 mt-2">Based on {total} invoice(s)</div>
         </div>
 
         {/* Score Breakdown */}
@@ -240,28 +240,28 @@ export default function CreditScore({
 
         {/* Additional Stats */}
         {total > 0 && (
-          <div className="mt-6 pt-6 border-t border-brand-border grid grid-cols-2 gap-4">
+          <div className="mt-6 pt-6 border-t border-[var(--border)] grid grid-cols-2 gap-4">
             <div>
-              <div className="text-xs text-brand-muted mb-1">Repayment Rate</div>
+              <div className="text-xs text-[var(--muted)] mb-1">Repayment Rate</div>
               <div className="text-lg font-semibold">{Math.round(repaymentRate * 100)}%</div>
             </div>
             <div>
-              <div className="text-xs text-brand-muted mb-1">Average Payment Days</div>
+              <div className="text-xs text-[var(--muted)] mb-1">Average Payment Days</div>
               <div className="text-lg font-semibold">{avgPaymentDays} days</div>
             </div>
           </div>
         )}
 
         {total === 0 && (
-          <p className="text-center text-brand-muted text-sm mt-4">
+          <p className="text-center text-[var(--muted)] text-sm mt-4">
             Create and repay invoices to build your score.
           </p>
         )}
 
         {/* Score Tier Progress Bar */}
         {nextTier && currentTier && (
-          <div className="mt-6 pt-6 border-t border-brand-border">
-            <div className="flex justify-between text-xs text-brand-muted mb-2">
+          <div className="mt-6 pt-6 border-t border-[var(--border)]">
+            <div className="flex justify-between text-xs text-[var(--muted)] mb-2">
               <span>
                 {currentTier.name} ({score})
               </span>
@@ -283,7 +283,7 @@ export default function CreditScore({
                 }}
               />
             </div>
-            <div className="text-xs text-brand-muted mt-2 text-center">
+            <div className="text-xs text-[var(--muted)] mt-2 text-center">
               {pointsToNext} pts to {nextTier.name}
             </div>
           </div>
@@ -291,14 +291,14 @@ export default function CreditScore({
       </div>
 
       {/* Score Improvement Panel (collapsed by default) */}
-      <div className="bg-brand-card border border-brand-border rounded-2xl overflow-hidden">
+      <div className="bg-[var(--card)] border border-[var(--border)] rounded-2xl overflow-hidden">
         <button
           onClick={() => setShowImprovement(!showImprovement)}
           className="w-full p-6 text-left flex items-center justify-between hover:bg-brand-border/20 transition"
         >
           <h3 className="text-lg font-semibold">Improve your score</h3>
           <svg
-            className={`w-5 h-5 text-brand-muted transition-transform ${
+            className={`w-5 h-5 text-[var(--muted)] transition-transform ${
               showImprovement ? 'rotate-180' : ''
             }`}
             fill="none"
@@ -313,24 +313,24 @@ export default function CreditScore({
           <div className="px-6 pb-6 space-y-6">
             {/* Score Breakdown Table */}
             <div>
-              <h4 className="text-sm font-semibold text-brand-muted uppercase tracking-wider mb-3">
+              <h4 className="text-sm font-semibold text-[var(--muted)] uppercase tracking-wider mb-3">
                 Current Stats vs. Recommendations
               </h4>
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b border-brand-border">
-                      <th className="text-left text-brand-muted py-2 px-2">Factor</th>
-                      <th className="text-left text-brand-muted py-2 px-2">Your Stats</th>
-                      <th className="text-left text-brand-muted py-2 px-2">Impact</th>
-                      <th className="text-left text-brand-muted py-2 px-2">Tip</th>
+                    <tr className="border-b border-[var(--border)]">
+                      <th className="text-left text-[var(--muted)] py-2 px-2">Factor</th>
+                      <th className="text-left text-[var(--muted)] py-2 px-2">Your Stats</th>
+                      <th className="text-left text-[var(--muted)] py-2 px-2">Impact</th>
+                      <th className="text-left text-[var(--muted)] py-2 px-2">Tip</th>
                     </tr>
                   </thead>
                   <tbody>
                     {recommendations.map((rec, i) => (
-                      <tr key={i} className="border-b border-brand-border/50">
+                      <tr key={i} className="border-b border-[var(--border)]/50">
                         <td className="py-3 px-2 font-medium">{rec.factor}</td>
-                        <td className="py-3 px-2 text-brand-muted">{rec.stat}</td>
+                        <td className="py-3 px-2 text-[var(--muted)]">{rec.stat}</td>
                         <td className="py-3 px-2">
                           <span
                             className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
@@ -344,7 +344,7 @@ export default function CreditScore({
                             {rec.impact}
                           </span>
                         </td>
-                        <td className="py-3 px-2 text-brand-muted text-xs">{rec.tip}</td>
+                        <td className="py-3 px-2 text-[var(--muted)] text-xs">{rec.tip}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -358,9 +358,9 @@ export default function CreditScore({
                 <h4 className="text-sm font-semibold mb-2">Next Milestone: {nextTier.name}</h4>
                 <div className="flex items-center gap-3 mb-3">
                   <div className="text-2xl font-bold">{nextTier.min}</div>
-                  <div className="text-xs text-brand-muted">{pointsToNext} points away</div>
+                  <div className="text-xs text-[var(--muted)]">{pointsToNext} points away</div>
                 </div>
-                <p className="text-sm text-brand-muted">
+                <p className="text-sm text-[var(--muted)]">
                   {TIER_BENEFITS[nextTier.name] || 'Unlock new benefits at this tier'}
                 </p>
                 {pointsToNext <= PTS_PAID_ON_TIME * 2 && (
@@ -379,23 +379,23 @@ export default function CreditScore({
 
       {/* Payment History Table */}
       {paymentHistory.length > 0 && (
-        <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
+        <div className="p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl">
           <h3 className="text-lg font-semibold mb-4">Payment History</h3>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-brand-border">
-                  <th className="text-left text-brand-muted py-3 px-2">Invoice</th>
-                  <th className="text-right text-brand-muted py-3 px-2">Amount</th>
-                  <th className="text-left text-brand-muted py-3 px-2">Status</th>
-                  <th className="text-right text-brand-muted py-3 px-2">Days Late</th>
+                <tr className="border-b border-[var(--border)]">
+                  <th className="text-left text-[var(--muted)] py-3 px-2">Invoice</th>
+                  <th className="text-right text-[var(--muted)] py-3 px-2">Amount</th>
+                  <th className="text-left text-[var(--muted)] py-3 px-2">Status</th>
+                  <th className="text-right text-[var(--muted)] py-3 px-2">Days Late</th>
                 </tr>
               </thead>
               <tbody>
                 {paymentHistory.slice(0, 10).map((record) => (
                   <tr
                     key={record.invoiceId}
-                    className="border-b border-brand-border hover:bg-brand-border/30 transition"
+                    className="border-b border-[var(--border)] hover:bg-brand-border/30 transition"
                   >
                     <td className="py-3 px-2 font-medium">#{record.invoiceId}</td>
                     <td className="text-right py-3 px-2">
@@ -443,7 +443,7 @@ function ScoreRow({
   return (
     <div>
       <div className="flex justify-between text-sm mb-1">
-        <span className="text-brand-muted">{label}</span>
+        <span className="text-[var(--muted)]">{label}</span>
         <span className="font-medium">{count}</span>
       </div>
       <div className="h-1.5 bg-brand-border rounded-full overflow-hidden">
@@ -458,7 +458,7 @@ function ScoreRow({
 
 export function CreditScoreSkeleton() {
   return (
-    <div className="p-6 bg-brand-card border border-brand-border rounded-2xl animate-pulse">
+    <div className="p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl animate-pulse">
       <Skeleton className="h-5 w-44 mb-6" />
 
       <div className="text-center mb-8">
@@ -481,7 +481,7 @@ export function CreditScoreSkeleton() {
         ))}
       </div>
 
-      <div className="mt-6 pt-6 border-t border-brand-border grid grid-cols-2 gap-4">
+      <div className="mt-6 pt-6 border-t border-[var(--border)] grid grid-cols-2 gap-4">
         <div>
           <Skeleton className="h-3 w-20 mb-1" />
           <Skeleton className="h-6 w-14" />

--- a/frontend/components/InvoiceCard.tsx
+++ b/frontend/components/InvoiceCard.tsx
@@ -50,7 +50,7 @@ export default function InvoiceCard({ id, metadata, fundedAmount }: Props) {
   return (
     <Link
       href={`/invoice/${id}`}
-      className="block p-5 bg-brand-card border border-brand-border rounded-2xl hover:border-brand-gold/30 transition-colors group"
+      className="block p-5 bg-[var(--card)] border border-[var(--border)] rounded-2xl hover:border-brand-gold/30 transition-colors group"
     >
       <div className="flex items-start justify-between gap-3 mb-4">
         <div className="flex gap-3 min-w-0 flex-1">
@@ -59,17 +59,17 @@ export default function InvoiceCard({ id, metadata, fundedAmount }: Props) {
             <img
               src={metadata.image}
               alt=""
-              className="w-12 h-12 rounded-xl object-cover border border-brand-border flex-shrink-0 bg-brand-dark"
+              className="w-12 h-12 rounded-xl object-cover border border-[var(--border)] flex-shrink-0 bg-[var(--bg)]"
             />
           ) : null}
           <div className="min-w-0">
-            <p className="text-xs text-brand-muted mb-1">
+            <p className="text-xs text-[var(--muted)] mb-1">
               {metadata.symbol} · #{id}
             </p>
-            <h3 className="font-semibold text-lg group-hover:text-brand-gold transition-colors line-clamp-2">
+            <h3 className="font-semibold text-lg group-hover:text-brand-gold transition-colors line-clamp-2 text-[var(--text-primary)]">
               {metadata.name}
             </h3>
-            <p className="text-sm text-brand-muted truncate mt-0.5">{metadata.debtor}</p>
+            <p className="text-sm text-[var(--muted)] truncate mt-0.5">{metadata.debtor}</p>
           </div>
         </div>
         <span
@@ -82,11 +82,11 @@ export default function InvoiceCard({ id, metadata, fundedAmount }: Props) {
         </span>
       </div>
 
-      <div className="text-2xl font-bold mb-4">{formatUSDC(metadata.amount)}</div>
+      <div className="text-2xl font-bold mb-4 text-[var(--text-primary)]">{formatUSDC(metadata.amount)}</div>
 
-      <div className="flex items-center justify-between text-sm text-brand-muted">
+      <div className="flex items-center justify-between text-sm text-[var(--muted)]">
         <div>
-          Due <span className="text-white">{formatDate(metadata.dueDate)}</span>
+          Due <span className="text-[var(--text-primary)]">{formatDate(metadata.dueDate)}</span>
         </div>
         <div
           className={
@@ -96,7 +96,7 @@ export default function InvoiceCard({ id, metadata, fundedAmount }: Props) {
                 ? 'text-orange-400'
                 : days <= 30
                   ? 'text-yellow-400'
-                  : 'text-brand-muted'
+                  : 'text-[var(--muted)]'
           }
         >
           {isOverdue ? `${Math.abs(days)}d overdue` : `${days}d left`}
@@ -104,20 +104,20 @@ export default function InvoiceCard({ id, metadata, fundedAmount }: Props) {
       </div>
 
       {showProgress && (
-        <div className="mt-4 border-t border-brand-border pt-4">
-          <div className="flex items-center justify-between text-xs text-brand-muted mb-1.5">
+        <div className="mt-4 border-t border-[var(--border)] pt-4">
+          <div className="flex items-center justify-between text-xs text-[var(--muted)] mb-1.5">
             <span>Co-funding progress</span>
-            <span className="text-white font-medium">{fundedPercent.toFixed(1)}%</span>
+            <span className="text-[var(--text-primary)] font-medium">{fundedPercent.toFixed(1)}%</span>
           </div>
-          <div className="h-1.5 bg-brand-border rounded-full overflow-hidden">
+          <div className="h-1.5 bg-[var(--border)] rounded-full overflow-hidden">
             <div
               className="h-full bg-brand-gold rounded-full transition-all duration-300"
               style={{ width: `${Math.min(100, fundedPercent)}%` }}
             />
           </div>
           <div className="flex items-center justify-between text-xs mt-1.5">
-            <span className="text-brand-muted">{formatUSDC(fundedAmount!)} committed</span>
-            <span className="text-brand-muted">
+            <span className="text-[var(--muted)]">{formatUSDC(fundedAmount!)} committed</span>
+            <span className="text-[var(--muted)]">
               {formatUSDC(metadata.amount - fundedAmount!)} remaining
             </span>
           </div>
@@ -125,7 +125,7 @@ export default function InvoiceCard({ id, metadata, fundedAmount }: Props) {
       )}
 
       {metadata.description && (
-        <p className="mt-3 text-xs text-brand-muted line-clamp-2 border-t border-brand-border pt-3">
+        <p className="mt-3 text-xs text-[var(--muted)] line-clamp-2 border-t border-[var(--border)] pt-3">
           {metadata.description}
         </p>
       )}

--- a/frontend/components/PoolStats.tsx
+++ b/frontend/components/PoolStats.tsx
@@ -21,9 +21,9 @@ export default function PoolStats({ config, tokenTotals, tokenLabel }: Props) {
   const factoringFee = (config.factoringFeeBps / 100).toFixed(2);
 
   return (
-    <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
-      <h2 className="text-lg font-semibold mb-1">Pool Overview</h2>
-      <p className="text-xs text-brand-muted mb-6">Showing {tokenLabel} liquidity</p>
+    <div className="p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl">
+      <h2 className="text-lg font-semibold mb-1 text-[var(--text-primary)]">Pool Overview</h2>
+      <p className="text-xs text-[var(--muted)] mb-6">Showing {tokenLabel} liquidity</p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
         <Stat label="Total Deposited" value={formatUSDC(deposited)} />
@@ -35,10 +35,10 @@ export default function PoolStats({ config, tokenTotals, tokenLabel }: Props) {
 
       <div className="mb-4">
         <div className="flex justify-between text-sm mb-2">
-          <span className="text-brand-muted">Utilization</span>
-          <span className="font-medium">{utilizationRate}%</span>
+          <span className="text-[var(--muted)]">Utilization</span>
+          <span className="font-medium text-[var(--text-primary)]">{utilizationRate}%</span>
         </div>
-        <div className="h-2 bg-brand-border rounded-full overflow-hidden">
+        <div className="h-2 bg-[var(--border)] rounded-full overflow-hidden">
           <div
             className="h-full bg-brand-gold rounded-full transition-all"
             style={{ width: `${Math.min(utilizationRate, 100)}%` }}
@@ -47,13 +47,13 @@ export default function PoolStats({ config, tokenTotals, tokenLabel }: Props) {
       </div>
 
       <div className="flex items-center justify-between p-3 bg-brand-gold/10 border border-brand-gold/20 rounded-xl">
-        <span className="text-sm text-brand-muted">Target APY</span>
+        <span className="text-sm text-[var(--muted)]">Target APY</span>
         <span className="text-brand-gold font-bold text-lg">{apy}%</span>
       </div>
 
-      <div className="flex items-center justify-between p-3 mt-3 bg-brand-dark rounded-xl border border-brand-border">
-        <span className="text-sm text-brand-muted">Factoring Fee</span>
-        <span className="text-white font-bold text-lg">{factoringFee}%</span>
+      <div className="flex items-center justify-between p-3 mt-3 bg-[var(--bg)] rounded-xl border border-[var(--border)]">
+        <span className="text-sm text-[var(--muted)]">Factoring Fee</span>
+        <span className="text-[var(--text-primary)] font-bold text-lg">{factoringFee}%</span>
       </div>
     </div>
   );
@@ -61,9 +61,9 @@ export default function PoolStats({ config, tokenTotals, tokenLabel }: Props) {
 
 function Stat({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
   return (
-    <div className="p-3 bg-brand-dark rounded-xl border border-brand-border">
-      <p className="text-xs text-brand-muted mb-1">{label}</p>
-      <p className={`font-semibold text-sm ${highlight ? 'text-brand-gold' : 'text-white'}`}>
+    <div className="p-3 bg-[var(--bg)] rounded-xl border border-[var(--border)]">
+      <p className="text-xs text-[var(--muted)] mb-1">{label}</p>
+      <p className={`font-semibold text-sm ${highlight ? 'text-brand-gold' : 'text-[var(--text-primary)]'}`}>
         {value}
       </p>
     </div>
@@ -72,7 +72,7 @@ function Stat({ label, value, highlight }: { label: string; value: string; highl
 
 export function PoolStatsSkeleton() {
   return (
-    <div className="p-6 bg-brand-card border border-brand-border rounded-2xl animate-pulse">
+    <div className="p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl animate-pulse">
       <Skeleton className="h-5 w-32 mb-1" />
       <Skeleton className="h-3 w-48 mb-6" />
 


### PR DESCRIPTION
## Summary

- **#531** — `fund_invoice_request` in the pool contract now rejects funding if `now >= due_date`, returning the new `PoolError::InvoiceExpired` (code 58). Lenders can no longer accidentally fund overdue invoices that would be immediately defaultable.
- **#536** — `repay_invoice_request` now verifies that the `payer == record.sme` (the recorded borrower), returning `PoolError::Unauthorized` for any third-party repayment attempt. Prevents griefing and credit-score manipulation attacks.
- **#534** — Added `record_funding()` to the credit score contract so borrowers who attract lender capital receive a positive demand signal in their score. The pool contract now calls this cross-contract method after every successful `fund_invoice`; the call is non-fatal so a credit-score contract failure never reverts a valid funding.
- **#535** — Dark mode support hardened across the frontend. Added an anti-flash inline script in `<html>` head that applies the `light` class before first paint (respects `prefers-color-scheme` and `localStorage`). Added `:root.light` overrides in `globals.css` for all hardcoded Tailwind brand-color classes. Updated `InvoiceCard`, `APYCalculator`, `PoolStats`, and `CreditScore` to use CSS variable equivalents (`var(--card)`, `var(--bg)`, `var(--border)`, `var(--muted)`, `var(--text-primary)`).

## Test plan

- [ ] `fund_invoice` with `due_date` in the past → `PoolError::InvoiceExpired`
- [ ] `fund_invoice` with `due_date` 1 second in the future → succeeds
- [ ] `repay_invoice` called by a non-borrower → `PoolError::Unauthorized`
- [ ] `repay_invoice` called by the SME borrower → succeeds
- [ ] `credit_score.record_funding()` increments `total_volume` for the borrower
- [ ] `fund_invoice` with credit score contract not set → funding still succeeds (non-fatal path)
- [ ] Toggle theme to light mode → all updated components render correctly with light backgrounds and dark text
- [ ] Refresh in light mode → no dark flash before the theme loads

closes #531     closes #534       closes #535       closes #536