### PR TITLE
fix: add TruncatedAddress component with copy-to-clipboard (#786)

### DIFF
--- a/frontend/app/admin/defaults/page.tsx
+++ b/frontend/app/admin/defaults/page.tsx
@@ -6,7 +6,8 @@ import { useStore } from '@/lib/store';
 import { TableRowSkeleton } from '@/components/Skeleton';
 import ConfirmActionModal from '@/components/ConfirmActionModal';
 import { getInvoice, getInvoiceCount, buildMarkDefaultedTx, submitTx } from '@/lib/contracts';
-import { formatUSDC, truncateAddress, formatDate } from '@/lib/stellar';
+import { formatUSDC, formatDate } from '@/lib/stellar';
+import { TruncatedAddress } from '@/components/TruncatedAddress';
 import type { Invoice } from '@/lib/types';
 
 export default function AdminDefaultsPage() {
@@ -141,7 +142,7 @@ export default function AdminDefaultsPage() {
                         <div className="flex flex-col">
                           <span className="font-semibold text-white">{inv.debtor}</span>
                           <span className="text-xs text-brand-muted">
-                            {truncateAddress(inv.owner)}
+                            <TruncatedAddress address={inv.owner} />
                           </span>
                         </div>
                       </td>

--- a/frontend/app/admin/invoices/page.tsx
+++ b/frontend/app/admin/invoices/page.tsx
@@ -12,7 +12,8 @@ import {
   buildInitCoFundingTx,
   submitTx,
 } from '@/lib/contracts';
-import { formatUSDC, truncateAddress, formatDate } from '@/lib/stellar';
+import { formatUSDC, formatDate } from '@/lib/stellar';
+import { TruncatedAddress } from '@/components/TruncatedAddress';
 import type { Invoice } from '@/lib/types';
 
 /** Number of invoices to scan per batch */
@@ -440,7 +441,7 @@ export default function AdminInvoicesPage() {
                       <div className="flex flex-col">
                         <span className="font-medium text-white">{inv.debtor}</span>
                         <span className="text-xs text-brand-muted">
-                          {truncateAddress(inv.owner)}
+                          <TruncatedAddress address={inv.owner} />
                         </span>
                       </div>
                     </td>

--- a/frontend/components/TruncatedAddress.tsx
+++ b/frontend/components/TruncatedAddress.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import { truncateAddress } from '@/lib/stellar';
+
+interface TruncatedAddressProps {
+  /** Full Stellar wallet address */
+  address: string;
+  /** Number of characters to show on each side (default: 6) */
+  chars?: number;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * TruncatedAddress — renders a shortened Stellar address with
+ * click-to-copy functionality.
+ *
+ * Shows a checkmark icon for 2 seconds after copying.
+ * Displays the full address in a tooltip on hover.
+ */
+export function TruncatedAddress({
+  address,
+  chars = 6,
+  className = '',
+}: TruncatedAddressProps) {
+  const [copied, setCopied] = useState(false);
+
+  if (!address) return null;
+
+  const truncated = truncateAddress(address, chars);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard write failed silently
+    }
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 font-mono text-xs ${className}`}
+      title={address}
+    >
+      <span>{truncated}</span>
+      <button
+        onClick={handleCopy}
+        aria-label={copied ? 'Address copied' : 'Copy address to clipboard'}
+        className="inline-flex items-center justify-center w-4 h-4 text-[var(--muted)] hover:text-[var(--text-primary)] transition-colors"
+      >
+        {copied ? (
+          /* Checkmark icon */
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className="w-3.5 h-3.5 text-green-500"
+          >
+            <path
+              fillRule="evenodd"
+              d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207z"
+              clipRule="evenodd"
+            />
+          </svg>
+        ) : (
+          /* Copy icon */
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className="w-3.5 h-3.5"
+          >
+            <path d="M5.5 3.5A1.5 1.5 0 0 1 7 2h5a1.5 1.5 0 0 1 1.5 1.5v5A1.5 1.5 0 0 1 12 10H7a1.5 1.5 0 0 1-1.5-1.5v-5z" />
+            <path d="M3.5 5A1.5 1.5 0 0 0 2 6.5v5A1.5 1.5 0 0 0 3.5 13h5a1.5 1.5 0 0 0 1.5-1.5V10H8.5v1.5a.5.5 0 0 1-.5.5h-5a.5.5 0 0 1-.5-.5v-5a.5.5 0 0 1 .5-.5H5V5h-1.5z" />
+          </svg>
+        )}
+      </button>
+    </span>
+  );
+}

--- a/frontend/components/analytics/TopSmesTable.tsx
+++ b/frontend/components/analytics/TopSmesTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { TopSme } from '@/lib/analytics';
-import { truncateAddress } from '@/lib/analytics';
+import { TruncatedAddress } from '@/components/TruncatedAddress';
 
 interface TopSmesTableProps {
   data: TopSme[];
@@ -66,7 +66,7 @@ export function TopSmesTable({ data, isLoading }: TopSmesTableProps) {
                 <tr key={sme.address} className="hover:bg-white/5 transition-colors">
                   <td className="px-4 py-3 text-sm text-brand-muted font-mono">{index + 1}</td>
                   <td className="px-4 py-3 text-sm text-white font-mono">
-                    {truncateAddress(sme.address)}
+                    <TruncatedAddress address={sme.address} />
                   </td>
                   <td className="px-4 py-3 text-sm text-white text-right">{sme.invoiceCount}</td>
                   <td className="px-4 py-3 text-sm text-brand-gold text-right font-medium">


### PR DESCRIPTION
## What

Adds a reusable `TruncatedAddress` component that renders truncated Stellar wallet addresses (e.g., `GBXX...XXXX`) with a one-click copy-to-clipboard button. Replaces bare `truncateAddress()` calls in three locations with the new component:

- **Admin Invoices** (`admin/invoices/page.tsx`) — owner address column gets copy support
- **Admin Defaults** (`admin/defaults/page.tsx`) — owner address column gets copy support
- **Analytics Top SMEs Table** — SME address cell gets copy support

## Why

Full 56-character Stellar addresses displayed inline break layouts and provide poor UX compared to standard Web3 conventions. The component:
- Truncates to configurable length (default: `GBXX...XXXX`)
- Shows a checkmark icon for 2 seconds on successful copy
- Displays the full address in a `title` tooltip on hover
- Handles missing/null addresses gracefully

## Testing

- Component accepts `chars` prop to customize truncation length
- Copy uses `navigator.clipboard.writeText` with a 2-second checkmark state
- All three replaced locations verified:
  - `{truncateAddress(inv.owner)}` → `<TruncatedAddress address={inv.owner} />`
  - `{truncateAddress(sme.address)}` → `<TruncatedAddress address={sme.address} />`
- No regressions — component delegates truncation to the existing `truncateAddress` utility

Closes #786