### PR TITLE
feat(pool): replace static yield with utilization-driven kinked rate model

### DIFF
--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -151,6 +151,11 @@ pub enum PoolError {
     InvalidCoFundingParams = 77,
     // #865: global withdrawal-queue depth cap reached for this token
     WithdrawalQueueFull = 78,
+    // #863: utilization-driven rate model errors
+    InvalidRateModelConfig = 79,
+    RateModelNotConfigured = 80,
+    RateModelProposalNotFound = 81,
+    RateModelChangeNotReady = 82,
 }
 
 type PoolResult<T> = Result<T, PoolError>;
@@ -197,6 +202,16 @@ const DEFAULT_MAX_WITHDRAWAL_QUEUE_DEPTH: u32 = 500;
 // estimate_withdrawal_wait/get_liquidity_forecast, mirroring the credit_score contract's
 // PaymentHistory rolling-window pattern.
 const MAX_INFLOW_HISTORY: u32 = 50;
+// #863: fixed-size ring buffer capacity for the per-token rate history
+// ((timestamp, utilization_bps, rate_bps) samples) charted by the frontend.
+// 720 samples ≈ 30 days at hourly granularity; oldest entry is evicted on
+// overflow so storage never grows unbounded.
+const MAX_RATE_HISTORY: u32 = 720;
+// #863: absolute protocol ceiling for any rate the curve can produce or an
+// admin can configure — matches the existing 5_000 bps cap in set_yield /
+// propose_yield_change so the dynamic model can never price beyond what the
+// manual override already allows.
+const MAX_RATE_BPS_CAP: u32 = 5_000;
 // #865: clamp bounds for the predictive wait estimate so a sparse/empty inflow history
 // or a huge queue never produces a nonsensical (zero or unbounded) estimate.
 const MIN_WAIT_ESTIMATE_SECS: u64 = 3_600; // 1 hour
@@ -271,6 +286,43 @@ pub struct LiquidityForecastPoint {
 pub struct InflowEvent {
     pub amount: i128,
     pub timestamp: u64,
+}
+
+/// #863: utilization-driven kinked interest-rate model parameters, per token.
+/// The realized rate for *new* fundings moves automatically with utilization;
+/// only these curve parameters are admin-governed (via the timelocked
+/// propose/execute machinery, same pattern as `propose_yield_change`).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RateModelConfig {
+    /// Rate (bps) at 0% utilization.
+    pub base_rate_bps: u32,
+    /// The "kink" point in bps (e.g. 8_000 = 80% utilization).
+    pub optimal_utilization_bps: u32,
+    /// Rate increase (bps) spread across the 0..optimal utilization span.
+    pub slope1_bps: u32,
+    /// Rate increase (bps) spread across the optimal..100% span — steeper,
+    /// this is what disincentivizes over-draining the pool.
+    pub slope2_bps: u32,
+    /// Hard ceiling on the computed rate.
+    pub max_rate_bps: u32,
+}
+
+/// #863: one recorded rate sample for the frontend's rate-history chart.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RateSnapshot {
+    pub timestamp: u64,
+    pub utilization_bps: u32,
+    pub rate_bps: u32,
+}
+
+/// #863: a pending timelocked rate-model parameter change for one token.
+#[contracttype]
+#[derive(Clone)]
+pub struct RateModelProposal {
+    pub config: RateModelConfig,
+    pub proposed_at: u64,
 }
 
 #[contracttype]
@@ -389,6 +441,12 @@ pub struct FundedInvoice {
     /// interest directly to that round's `CoFundShare` holders instead of
     /// the pool-wide `reward_per_share` accumulator.
     pub co_funding_round_id: Option<u64>,
+    /// #863: interest rate locked in at funding time. When the token has a
+    /// `RateModelConfig` this is the curve's output at funding-time
+    /// utilization; otherwise it is the static `PoolConfig.yield_bps`.
+    /// Locked for the life of the invoice — later utilization/curve changes
+    /// never retroactively reprice already-funded invoices.
+    pub locked_yield_bps: u32,
 }
 
 // #860: multi-investor co-funding rounds — every co-funder ranks pari passu
@@ -625,6 +683,19 @@ pub enum DataKey {
     InflowHistoryStart(Address),
     // #865: individual ring-buffer slot: (token, slot_index) -> InflowEvent.
     InflowRecord(Address, u32),
+    // #863: per-token kinked interest-rate model parameters.
+    RateModel(Address),
+    // #863: pending timelocked rate-model change per token.
+    PendingRateModel(Address),
+    // #863: timestamp of the last executed rate-model change per token —
+    // enforces the same cooldown pattern as yield changes.
+    RateModelChangedAt(Address),
+    // #863: rate-history ring buffer bookkeeping (token -> length / start),
+    // mirroring the InflowHistory pattern above.
+    RateHistoryLen(Address),
+    RateHistoryStart(Address),
+    // #863: individual rate-history ring-buffer slot: (token, slot_index) -> RateSnapshot.
+    RateRecord(Address, u32),
 }
 
 const EVT: Symbol = symbol_short!("POOL");
@@ -767,6 +838,162 @@ fn calculate_interest(
     div_round_half_up(interest_numerator, denominator)
 }
 
+/// #863: pure two-slope kinked interest-rate curve (Aave/Compound family),
+/// independently unit-testable with no storage/env dependency.
+///
+/// ```text
+/// util <= optimal: rate = base + util * slope1 / optimal
+/// util >  optimal: rate = base + slope1 + (util - optimal) * slope2 / (10_000 - optimal)
+/// ```
+///
+/// The result is always clamped to `config.max_rate_bps`. All arithmetic is
+/// done in `u128` with checked ops; on any overflow the rate saturates to the
+/// ceiling rather than panicking. Monotonically non-decreasing in utilization
+/// for any valid config.
+pub fn compute_current_rate(utilization_bps: u32, config: &RateModelConfig) -> u32 {
+    let util = utilization_bps.min(BPS_DENOM) as u128;
+    let optimal = config.optimal_utilization_bps as u128;
+    let base = config.base_rate_bps as u128;
+    let ceiling = config.max_rate_bps as u128;
+
+    let mul_div = |a: u128, b: u128, denom: u128| -> u128 {
+        a.checked_mul(b)
+            .and_then(|v| v.checked_div(denom))
+            .unwrap_or(u128::MAX)
+    };
+
+    // Below (and at) the kink: base plus the pro-rata share of slope1.
+    // `checked_div(0)` on a zero kink yields None -> saturates to the ceiling.
+    let mut rate = base.saturating_add(mul_div(
+        util.min(optimal),
+        config.slope1_bps as u128,
+        optimal,
+    ));
+
+    // Above the kink: add the pro-rata share of slope2 over the remaining span.
+    // `util > optimal` implies span > 0 here, but checked_div keeps it total.
+    if util > optimal {
+        let span = (BPS_DENOM as u128).saturating_sub(optimal);
+        rate = rate.saturating_add(mul_div(util - optimal, config.slope2_bps as u128, span));
+    }
+
+    rate.min(ceiling).min(u32::MAX as u128) as u32
+}
+
+/// #863: curve-config sanity bounds checked before a rate model is stored.
+fn validate_rate_model_config(config: &RateModelConfig) -> PoolResult<()> {
+    // Kink must be inside (0%, 100%] — 0 would make the slope1 pro-ration
+    // meaningless (and the below-kink division undefined).
+    if config.optimal_utilization_bps == 0 || config.optimal_utilization_bps > BPS_DENOM {
+        return Err(PoolError::InvalidRateModelConfig);
+    }
+    if config.max_rate_bps == 0 || config.max_rate_bps > MAX_RATE_BPS_CAP {
+        return Err(PoolError::InvalidRateModelConfig);
+    }
+    if config.base_rate_bps > config.max_rate_bps {
+        return Err(PoolError::InvalidRateModelConfig);
+    }
+    if config.slope1_bps > MAX_RATE_BPS_CAP || config.slope2_bps > MAX_RATE_BPS_CAP {
+        return Err(PoolError::InvalidRateModelConfig);
+    }
+    Ok(())
+}
+
+/// #863: current utilization of a token in bps (0..10_000), 0 for an empty pool.
+fn utilization_bps(tt: &PoolTokenTotals) -> u32 {
+    if tt.pool_value <= 0 {
+        return 0;
+    }
+    ((tt.total_deployed as u128 * 10_000u128) / tt.pool_value as u128) as u32
+}
+
+/// #863: the rate a *new* funding for `token` would lock right now — the
+/// curve's output at current utilization when a rate model is configured,
+/// otherwise the static `config.yield_bps` fallback. Once a token has a
+/// `RateModelConfig`, the flat `yield_bps` is inert for that token's new
+/// fundings (the dynamic curve is the single source of truth); `set_yield` /
+/// `propose_yield_change` remain as the manual override for tokens without a
+/// configured model.
+fn current_rate_for_token(env: &Env, config: &PoolConfig, token: &Address) -> u32 {
+    let tt: PoolTokenTotals = env
+        .storage()
+        .instance()
+        .get(&DataKey::TokenTotals(token.clone()))
+        .unwrap_or_default();
+    match env
+        .storage()
+        .instance()
+        .get::<DataKey, RateModelConfig>(&DataKey::RateModel(token.clone()))
+    {
+        Some(model) => compute_current_rate(utilization_bps(&tt), &model),
+        None => config.yield_bps,
+    }
+}
+
+/// #863: append one (timestamp, utilization, rate) sample to the token's
+/// fixed-size rate-history ring buffer (capacity `MAX_RATE_HISTORY`; oldest
+/// entry evicted on overflow so storage stays bounded). No-op for tokens
+/// without a configured rate model, and consecutive duplicate samples (same
+/// utilization and rate) are collapsed so quiet periods don't flush real
+/// history out of the buffer.
+fn record_rate_snapshot(env: &Env, token: &Address) {
+    let model: Option<RateModelConfig> = env
+        .storage()
+        .instance()
+        .get(&DataKey::RateModel(token.clone()));
+    let Some(model) = model else { return };
+    let tt: PoolTokenTotals = env
+        .storage()
+        .instance()
+        .get(&DataKey::TokenTotals(token.clone()))
+        .unwrap_or_default();
+    let util = utilization_bps(&tt);
+    let rate = compute_current_rate(util, &model);
+
+    let len_key = DataKey::RateHistoryLen(token.clone());
+    let start_key = DataKey::RateHistoryStart(token.clone());
+    let len: u32 = env.storage().instance().get(&len_key).unwrap_or(0);
+    let start: u32 = env.storage().instance().get(&start_key).unwrap_or(0);
+
+    // Collapse consecutive duplicates: read the newest slot if any.
+    if len > 0 {
+        let newest_idx = (start + len - 1) % MAX_RATE_HISTORY;
+        if let Some(last) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, RateSnapshot>(&DataKey::RateRecord(token.clone(), newest_idx))
+        {
+            if last.utilization_bps == util && last.rate_bps == rate {
+                return;
+            }
+        }
+    }
+
+    let snapshot = RateSnapshot {
+        timestamp: env.ledger().timestamp(),
+        utilization_bps: util,
+        rate_bps: rate,
+    };
+    if len < MAX_RATE_HISTORY {
+        env.storage()
+            .persistent()
+            .set(&DataKey::RateRecord(token.clone(), len), &snapshot);
+        env.storage().instance().set(&len_key, &(len + 1));
+    } else {
+        env.storage()
+            .persistent()
+            .set(&DataKey::RateRecord(token.clone(), start), &snapshot);
+        let new_start = (start + 1) % MAX_RATE_HISTORY;
+        env.storage().instance().set(&start_key, &new_start);
+    }
+
+    // Indexed off-chain into a time-series table for the rate-history API.
+    env.events().publish(
+        (EVT, symbol_short!("rate_snap")),
+        (token.clone(), snapshot.timestamp, util, rate),
+    );
+}
+
 fn u128_to_i128(value: u128) -> PoolResult<i128> {
     if value > i128::MAX as u128 {
         return Err(PoolError::AmountOverflow);
@@ -798,9 +1025,12 @@ fn calculate_total_due(
     let elapsed_secs = accrual_end
         .checked_sub(record.funded_at)
         .ok_or(PoolError::AmountOverflow)?;
+    // #863: interest accrues at the rate locked in when the invoice was
+    // funded (curve output at funding-time utilization, or the static
+    // yield_bps fallback) — never the current live rate.
     let total_interest = calculate_interest(
         record.principal as u128,
-        config.yield_bps,
+        record.locked_yield_bps,
         elapsed_secs,
         config.compound_interest,
     )?;
@@ -1224,6 +1454,25 @@ fn fund_invoice_request(
         request.sme.clone(),
         &request.token,
     )?;
+    let prev_deployed = tt.total_deployed;
+    tt.total_deployed = tt
+        .total_deployed
+        .checked_add(request.principal)
+        .ok_or(PoolError::AmountOverflow)?;
+    // #863: lock in the rate live at funding time. With a configured rate
+    // model this prices the invoice off post-deployment utilization (the
+    // liquidity this funding consumes is reflected in its own rate);
+    // otherwise it falls back to the static `config.yield_bps`.
+    let locked_yield_bps = {
+        let model: Option<RateModelConfig> = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateModel(request.token.clone()));
+        match model {
+            Some(m) => compute_current_rate(utilization_bps(&tt), &m),
+            None => config.yield_bps,
+        }
+    };
     let funded = FundedInvoice {
         invoice_id: request.invoice_id,
         sme: request.sme.clone(),
@@ -1234,6 +1483,7 @@ fn fund_invoice_request(
         due_date: request.due_date,
         repaid_amount: 0i128,
         co_funding_round_id: None,
+        locked_yield_bps,
     };
 
     // Persist invoice record and update totals/stats.
@@ -1244,11 +1494,6 @@ fn fund_invoice_request(
     // #865: index this invoice_id so liquidity forecasting can enumerate open invoices.
     record_funded_invoice_id(env, &request.token, request.invoice_id);
 
-    let prev_deployed = tt.total_deployed;
-    tt.total_deployed = tt
-        .total_deployed
-        .checked_add(request.principal)
-        .ok_or(PoolError::AmountOverflow)?;
     env.storage().instance().set(&token_totals_key, &tt);
 
     // #275: check utilization after deployment
@@ -1313,6 +1558,9 @@ fn fund_invoice_request(
             env.ledger().timestamp(),
         ),
     );
+
+    // #863: utilization moved with this funding — record a rate sample.
+    record_rate_snapshot(env, &request.token);
 
     // #534: notify the credit score contract that this borrower secured funding.
     // Non-fatal — a cross-contract failure must not revert a successful funding.
@@ -3065,6 +3313,10 @@ impl FundingPool {
         Self::non_reentrant_end(env);
         let (fully_repaid, token, principal, repaid_amount, available_amount) = guarded_result?;
 
+        // #863: a repayment changes utilization (deployed capital and/or pool
+        // value) — record a rate sample for the history chart.
+        record_rate_snapshot(env, &token);
+
         if fully_repaid {
             // #217: Process withdrawal queue after repayment
             if let Err(e) = Self::process_withdrawal_queue(env, token.clone(), available_amount) {
@@ -3548,6 +3800,179 @@ impl FundingPool {
             (admin, cooldown_secs, max_change_bps, timelock_secs),
         );
         Ok(())
+    }
+
+    // #863: utilization-driven rate model governance — the curve's *parameters*
+    // move through the same cooldown + 48h-timelock pattern as yield changes;
+    // the realized rate itself moves automatically with utilization.
+
+    /// Admin proposes new rate-model parameters for `token`. The proposal
+    /// becomes executable after `yield_timelock_secs` (48h default) via
+    /// `execute_rate_model_change`; a fresh proposal replaces any pending one.
+    /// Proposals respect the yield-change cooldown between executed changes.
+    pub fn propose_rate_model_change(
+        env: Env,
+        admin: Address,
+        token: Address,
+        new_config: RateModelConfig,
+    ) -> Result<(), PoolError> {
+        admin.require_auth();
+        bump_instance(&env);
+        let config: PoolConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(PoolError::NotInitialized)?;
+        Self::require_admin(&env, &admin)?;
+        validate_rate_model_config(&new_config)?;
+
+        // Same cooldown pattern as propose_yield_change, tracked per token.
+        let now = env.ledger().timestamp();
+        let last_change: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateModelChangedAt(token.clone()))
+            .unwrap_or(0);
+        if now < last_change.saturating_add(config.yield_change_cooldown_secs) {
+            return Err(PoolError::InvalidAmount);
+        }
+
+        let proposal = RateModelProposal {
+            config: new_config,
+            proposed_at: now,
+        };
+        let effective_at = now + config.yield_timelock_secs;
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingRateModel(token.clone()), &proposal);
+        env.events().publish(
+            (EVT, symbol_short!("rm_prop")),
+            (admin, token, effective_at),
+        );
+        Ok(())
+    }
+
+    /// Anyone can execute once the timelock has elapsed; the new curve applies
+    /// to *new* fundings only — already-funded invoices keep their locked rate.
+    pub fn execute_rate_model_change(env: Env, token: Address) -> Result<(), PoolError> {
+        bump_instance(&env);
+        let config: PoolConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(PoolError::NotInitialized)?;
+        let proposal: RateModelProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingRateModel(token.clone()))
+            .ok_or(PoolError::RateModelProposalNotFound)?;
+
+        let now = env.ledger().timestamp();
+        let effective_at = proposal
+            .proposed_at
+            .saturating_add(config.yield_timelock_secs);
+        if now < effective_at {
+            return Err(PoolError::RateModelChangeNotReady);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::RateModel(token.clone()), &proposal.config);
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingRateModel(token.clone()));
+        env.storage()
+            .instance()
+            .set(&DataKey::RateModelChangedAt(token.clone()), &now);
+
+        // Record a sample so history reflects the new curve immediately.
+        record_rate_snapshot(&env, &token);
+        env.events()
+            .publish((EVT, symbol_short!("rm_exec")), (token, now));
+        Ok(())
+    }
+
+    /// Admin cancels a pending rate-model proposal before execution.
+    pub fn cancel_rate_model_change(
+        env: Env,
+        admin: Address,
+        token: Address,
+    ) -> Result<(), PoolError> {
+        admin.require_auth();
+        bump_instance(&env);
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingRateModel(token.clone()));
+        env.events()
+            .publish((EVT, symbol_short!("rm_cncl")), (admin, token));
+        Ok(())
+    }
+
+    /// #863: the rate a new funding for `token` would lock right now.
+    /// Errors with `RateModelNotConfigured` when the token has no curve —
+    /// callers can then fall back to `get_config().yield_bps`.
+    pub fn get_current_rate(env: Env, token: Address) -> Result<u32, PoolError> {
+        let model: RateModelConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateModel(token.clone()))
+            .ok_or(PoolError::RateModelNotConfigured)?;
+        let tt = Self::get_token_totals(env, token);
+        Ok(compute_current_rate(utilization_bps(&tt), &model))
+    }
+
+    /// #863: the token's current curve parameters, if any.
+    pub fn get_rate_model_config(env: Env, token: Address) -> Option<RateModelConfig> {
+        env.storage().instance().get(&DataKey::RateModel(token))
+    }
+
+    /// #863: up to `limit` most recent rate samples for `token`, returned in
+    /// chronological (oldest-first) order — ready for the frontend chart.
+    pub fn get_rate_history(env: Env, token: Address, limit: u32) -> Vec<RateSnapshot> {
+        let mut out = Vec::new(&env);
+        let len: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateHistoryLen(token.clone()))
+            .unwrap_or(0);
+        if len == 0 || limit == 0 {
+            return out;
+        }
+        let start: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateHistoryStart(token.clone()))
+            .unwrap_or(0);
+        let take = len.min(limit);
+        // Skip the oldest `len - take` samples so the most recent `take` remain.
+        let skip = len - take;
+        for offset in skip..len {
+            let idx = (start + offset) % MAX_RATE_HISTORY;
+            if let Some(snapshot) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, RateSnapshot>(&DataKey::RateRecord(token.clone(), idx))
+            {
+                out.push_back(snapshot);
+            }
+        }
+        out
+    }
+
+    /// #863: what the rate would be at a hypothetical utilization — powers the
+    /// frontend's "what if I deposit/withdraw X" scenario preview.
+    pub fn preview_rate_at_utilization(
+        env: Env,
+        token: Address,
+        hypothetical_util_bps: u32,
+    ) -> Result<u32, PoolError> {
+        let model: RateModelConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateModel(token))
+            .ok_or(PoolError::RateModelNotConfigured)?;
+        Ok(compute_current_rate(hypothetical_util_bps, &model))
     }
 
     pub fn set_factoring_fee(
@@ -4370,6 +4795,10 @@ impl FundingPool {
                     .instance()
                     .get(&DataKey::StorageStats)
                     .unwrap_or_default();
+                // #863: co-funded invoices lock the live rate at finalization
+                // too, so their repayment interest is computed from the same
+                // single source of truth as pool-funded invoices.
+                let config = get_config_cached(&env)?;
                 let funded = FundedInvoice {
                     invoice_id,
                     sme: round.sme.clone(),
@@ -4380,6 +4809,7 @@ impl FundingPool {
                     due_date: round.due_date,
                     repaid_amount: 0,
                     co_funding_round_id: Some(invoice_id),
+                    locked_yield_bps: current_rate_for_token(&env, &config, &round.token),
                 };
                 env.storage()
                     .persistent()
@@ -7373,6 +7803,9 @@ mod test {
             due_date: u64::MAX,
             repaid_amount: 0,
             co_funding_round_id: None,
+            // #863: interest now accrues at the locked rate, so the extreme
+            // value lives here to keep exercising the overflow path.
+            locked_yield_bps: u32::MAX,
         };
         let config = PoolConfig {
             invoice_contract: Address::generate(&env),

--- a/contracts/pool/tests/fuzz_tests.rs
+++ b/contracts/pool/tests/fuzz_tests.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
     Address, Env, IntoVal, Symbol,
 };
 
-use pool::{FundingPool, FundingPoolClient};
+use pool::{compute_current_rate, FundingPool, FundingPoolClient, RateModelConfig};
 
 #[contract]
 pub struct DummyShare;
@@ -89,6 +89,42 @@ fn mint(env: &Env, token_id: &Address, to: &Address, amount: i128) {
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(100))]
+
+    // ---- #863: kinked rate curve is monotonically non-decreasing ----
+
+    /// For any valid curve config, higher utilization never lowers the rate,
+    /// and the rate never exceeds the configured ceiling.
+    #[test]
+    fn prop_rate_curve_monotonic_in_utilization(
+        base in 0u32..=5_000,
+        optimal in 1u32..=10_000,
+        slope1 in 0u32..=5_000,
+        slope2 in 0u32..=5_000,
+        max_rate in 1u32..=5_000,
+        util_a in 0u32..=10_000,
+        util_b in 0u32..=10_000,
+    ) {
+        let config = RateModelConfig {
+            base_rate_bps: base.min(max_rate),
+            optimal_utilization_bps: optimal,
+            slope1_bps: slope1,
+            slope2_bps: slope2,
+            max_rate_bps: max_rate,
+        };
+        let (lo, hi) = if util_a <= util_b { (util_a, util_b) } else { (util_b, util_a) };
+        let rate_lo = compute_current_rate(lo, &config);
+        let rate_hi = compute_current_rate(hi, &config);
+        prop_assert!(
+            rate_lo <= rate_hi,
+            "monotonicity violated: rate({})={} > rate({})={}",
+            lo, rate_lo, hi, rate_hi
+        );
+        prop_assert!(
+            rate_hi <= max_rate,
+            "ceiling violated: rate({})={} > max_rate={}",
+            hi, rate_hi, max_rate
+        );
+    }
 
     // ---- #110: Pool invariant – pool_value >= total_deployed ----
 

--- a/contracts/pool/tests/rate_model_tests.rs
+++ b/contracts/pool/tests/rate_model_tests.rs
@@ -1,0 +1,597 @@
+#![cfg(test)]
+
+//! #863: utilization-driven kinked interest-rate model.
+//!
+//! Covers the pure `compute_current_rate` curve across every distinguishing
+//! utilization band, the timelocked propose/execute/cancel governance
+//! lifecycle, per-invoice rate locking at funding time, rate-history ring
+//! buffer behavior, and backward compatibility for tokens without a
+//! configured model.
+
+use pool::{compute_current_rate, FundingPool, FundingPoolClient, PoolError, RateModelConfig};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::{Address as _, Ledger},
+    token, Address, Env, Symbol,
+};
+
+#[contract]
+pub struct DummyShare;
+
+#[contractimpl]
+impl DummyShare {
+    pub fn total_supply(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, "tot"))
+            .unwrap_or(0)
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage().persistent().get(&id).unwrap_or(0)
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let total = Self::total_supply(env.clone());
+        let balance = Self::balance(env.clone(), to.clone());
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "tot"), &(total + amount));
+        env.storage().persistent().set(&to, &(balance + amount));
+    }
+
+    pub fn burn(env: Env, from: Address, amount: i128) {
+        let total = Self::total_supply(env.clone());
+        let balance = Self::balance(env.clone(), from.clone());
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "tot"), &(total - amount));
+        env.storage().persistent().set(&from, &(balance - amount));
+    }
+}
+
+#[contract]
+pub struct DummyInvoice;
+
+#[contractimpl]
+impl DummyInvoice {
+    pub fn get_authorized_pool(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, "pool"))
+            .expect("not initialized")
+    }
+
+    pub fn set_pool(env: Env, pool: Address) {
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "pool"), &pool);
+    }
+}
+
+const INIT_AT: u64 = 100_000;
+const YIELD_TIMELOCK_SECS: u64 = 172_800; // 48h default
+const YIELD_CHANGE_COOLDOWN_SECS: u64 = 86_400; // 24h default
+
+fn setup(env: &Env) -> (FundingPoolClient<'_>, Address, Address) {
+    env.ledger().with_mut(|l| l.timestamp = INIT_AT);
+    let contract_id = env.register(FundingPool, ());
+    let client = FundingPoolClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let invoice_contract = env.register(DummyInvoice, ());
+    DummyInvoiceClient::new(env, &invoice_contract).set_pool(&contract_id);
+    let share_token = env.register(DummyShare, ());
+
+    client.initialize(&admin, &usdc_id, &share_token, &invoice_contract);
+    client.set_max_investor_concentration(&admin, &10_000u32);
+    (client, admin, usdc_id)
+}
+
+fn mint(env: &Env, token_id: &Address, to: &Address, amount: i128) {
+    token::StellarAssetClient::new(env, token_id).mint(to, &amount);
+}
+
+/// Standard curve used across the integration tests:
+/// 2% base, kink at 80%, +6% across the gentle slope, +24% across the steep
+/// slope, 50% ceiling.
+fn standard_model() -> RateModelConfig {
+    RateModelConfig {
+        base_rate_bps: 200,
+        optimal_utilization_bps: 8_000,
+        slope1_bps: 600,
+        slope2_bps: 2_400,
+        max_rate_bps: 5_000,
+    }
+}
+
+/// Push a rate model through the full propose -> timelock -> execute cycle.
+fn enact_rate_model(client: &FundingPoolClient, admin: &Address, token: &Address, env: &Env) {
+    client.propose_rate_model_change(admin, token, &standard_model());
+    env.ledger()
+        .with_mut(|l| l.timestamp += YIELD_TIMELOCK_SECS);
+    client.execute_rate_model_change(token);
+}
+
+// ── pure-function curve tests ───────────────────────────────────────────────
+
+#[test]
+fn test_rate_at_zero_utilization_is_base() {
+    assert_eq!(compute_current_rate(0, &standard_model()), 200);
+}
+
+#[test]
+fn test_rate_just_below_kink() {
+    // 200 + 7999 * 600 / 8000 = 200 + 599.925 -> 799 (integer truncation)
+    assert_eq!(compute_current_rate(7_999, &standard_model()), 799);
+}
+
+#[test]
+fn test_rate_exactly_at_kink() {
+    // base + full slope1, no slope2 contribution
+    assert_eq!(compute_current_rate(8_000, &standard_model()), 800);
+}
+
+#[test]
+fn test_rate_just_above_kink() {
+    // 800 + 1 * 2400 / 2000 = 801
+    assert_eq!(compute_current_rate(8_001, &standard_model()), 801);
+}
+
+#[test]
+fn test_rate_at_full_utilization() {
+    // base + slope1 + slope2
+    assert_eq!(compute_current_rate(10_000, &standard_model()), 3_200);
+}
+
+#[test]
+fn test_rate_clamps_to_max_rate() {
+    let model = RateModelConfig {
+        max_rate_bps: 1_000,
+        ..standard_model()
+    };
+    // Unc clamped value at 100% would be 3_200.
+    assert_eq!(compute_current_rate(10_000, &model), 1_000);
+    // Just below the ceiling the curve is unaffected: at the kink, 800 < 1_000.
+    assert_eq!(compute_current_rate(8_000, &model), 800);
+}
+
+#[test]
+fn test_rate_clamps_utilization_above_100_percent() {
+    assert_eq!(
+        compute_current_rate(12_345, &standard_model()),
+        compute_current_rate(10_000, &standard_model())
+    );
+}
+
+#[test]
+fn test_rate_kink_at_100_percent_has_no_steep_region() {
+    let model = RateModelConfig {
+        optimal_utilization_bps: 10_000,
+        ..standard_model()
+    };
+    // Entire span uses slope1; nothing can exceed the kink.
+    assert_eq!(compute_current_rate(10_000, &model), 800);
+    assert_eq!(compute_current_rate(5_000, &model), 500);
+}
+
+#[test]
+fn test_rate_zero_slopes_give_flat_base() {
+    let model = RateModelConfig {
+        slope1_bps: 0,
+        slope2_bps: 0,
+        ..standard_model()
+    };
+    assert_eq!(compute_current_rate(0, &model), 200);
+    assert_eq!(compute_current_rate(10_000, &model), 200);
+}
+
+#[test]
+fn test_rate_never_panics_on_degenerate_config() {
+    // A zero kink is rejected by validate_rate_model_config before storage,
+    // but the pure function itself must stay total (saturates to ceiling).
+    let degenerate = RateModelConfig {
+        optimal_utilization_bps: 0,
+        ..standard_model()
+    };
+    assert_eq!(compute_current_rate(5_000, &degenerate), 5_000);
+}
+
+// ── governance lifecycle ────────────────────────────────────────────────────
+
+#[test]
+fn test_propose_rejects_invalid_configs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    let cases = [
+        // kink out of bounds
+        RateModelConfig {
+            optimal_utilization_bps: 0,
+            ..standard_model()
+        },
+        RateModelConfig {
+            optimal_utilization_bps: 10_001,
+            ..standard_model()
+        },
+        // zero / excessive ceiling
+        RateModelConfig {
+            max_rate_bps: 0,
+            ..standard_model()
+        },
+        RateModelConfig {
+            max_rate_bps: 5_001,
+            ..standard_model()
+        },
+        // base above ceiling
+        RateModelConfig {
+            base_rate_bps: 4_000,
+            max_rate_bps: 3_000,
+            ..standard_model()
+        },
+        // slopes out of bounds
+        RateModelConfig {
+            slope1_bps: 5_001,
+            ..standard_model()
+        },
+        RateModelConfig {
+            slope2_bps: 5_001,
+            ..standard_model()
+        },
+    ];
+    for bad in cases {
+        let result = client.try_propose_rate_model_change(&admin, &usdc_id, &bad);
+        assert_eq!(result, Err(Ok(PoolError::InvalidRateModelConfig)));
+    }
+}
+
+#[test]
+fn test_execute_rejected_before_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    client.propose_rate_model_change(&admin, &usdc_id, &standard_model());
+
+    env.ledger().with_mut(|l| l.timestamp += 86_400); // +24h < 48h
+    let result = client.try_execute_rate_model_change(&usdc_id);
+    assert_eq!(result, Err(Ok(PoolError::RateModelChangeNotReady)));
+}
+
+#[test]
+fn test_execute_without_proposal_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, usdc_id) = setup(&env);
+
+    let result = client.try_execute_rate_model_change(&usdc_id);
+    assert_eq!(result, Err(Ok(PoolError::RateModelProposalNotFound)));
+}
+
+#[test]
+fn test_execute_at_timelock_boundary_sets_model() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    client.propose_rate_model_change(&admin, &usdc_id, &standard_model());
+    env.ledger()
+        .with_mut(|l| l.timestamp += YIELD_TIMELOCK_SECS);
+    client.execute_rate_model_change(&usdc_id);
+
+    assert_eq!(
+        client.get_rate_model_config(&usdc_id),
+        Some(standard_model())
+    );
+}
+
+#[test]
+fn test_cancel_proposal_blocks_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    client.propose_rate_model_change(&admin, &usdc_id, &standard_model());
+    client.cancel_rate_model_change(&admin, &usdc_id);
+
+    env.ledger()
+        .with_mut(|l| l.timestamp += YIELD_TIMELOCK_SECS);
+    let result = client.try_execute_rate_model_change(&usdc_id);
+    assert_eq!(result, Err(Ok(PoolError::RateModelProposalNotFound)));
+}
+
+#[test]
+fn test_cooldown_enforced_between_executed_changes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    enact_rate_model(&client, &admin, &usdc_id, &env);
+
+    // Immediately after execution the cooldown window is still open.
+    let result = client.try_propose_rate_model_change(&admin, &usdc_id, &standard_model());
+    assert_eq!(result, Err(Ok(PoolError::InvalidAmount)));
+
+    // After the cooldown a fresh proposal is accepted again.
+    env.ledger()
+        .with_mut(|l| l.timestamp += YIELD_CHANGE_COOLDOWN_SECS);
+    client.propose_rate_model_change(&admin, &usdc_id, &standard_model());
+}
+
+#[test]
+fn test_views_error_when_model_not_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, usdc_id) = setup(&env);
+
+    assert_eq!(
+        client.try_get_current_rate(&usdc_id),
+        Err(Ok(PoolError::RateModelNotConfigured))
+    );
+    assert_eq!(
+        client.try_preview_rate_at_utilization(&usdc_id, &5_000u32),
+        Err(Ok(PoolError::RateModelNotConfigured))
+    );
+    assert_eq!(client.get_rate_model_config(&usdc_id), None);
+    assert_eq!(client.get_rate_history(&usdc_id, &10u32).len(), 0);
+}
+
+// ── rate locking at funding time ────────────────────────────────────────────
+
+#[test]
+fn test_invoices_lock_curve_rate_at_funding_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    let investor = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    mint(&env, &usdc_id, &investor, 100_000);
+    client.deposit(&investor, &usdc_id, &100_000);
+
+    enact_rate_model(&client, &admin, &usdc_id, &env);
+
+    let due_date = env.ledger().timestamp() + 1_000_000;
+
+    // 10% utilization: 200 + 1000 * 600 / 8000 = 275 bps.
+    client.fund_invoice(&admin, &1u64, &10_000i128, &borrower, &due_date, &usdc_id);
+    // 80% utilization (exactly at kink): 200 + 600 = 800 bps.
+    client.fund_invoice(&admin, &2u64, &70_000i128, &borrower, &due_date, &usdc_id);
+    // 95% utilization (above kink): 800 + 1500 * 2400 / 2000 = 2_600 bps.
+    client.fund_invoice(&admin, &3u64, &15_000i128, &borrower, &due_date, &usdc_id);
+
+    assert_eq!(
+        client.get_funded_invoice(&1u64).unwrap().locked_yield_bps,
+        275
+    );
+    assert_eq!(
+        client.get_funded_invoice(&2u64).unwrap().locked_yield_bps,
+        800
+    );
+    assert_eq!(
+        client.get_funded_invoice(&3u64).unwrap().locked_yield_bps,
+        2_600
+    );
+
+    // Live rate view agrees with the last funding's snapshot.
+    assert_eq!(client.get_current_rate(&usdc_id), 2_600);
+    assert_eq!(client.preview_rate_at_utilization(&usdc_id, &0u32), 200);
+    assert_eq!(
+        client.preview_rate_at_utilization(&usdc_id, &10_000u32),
+        3_200
+    );
+}
+
+#[test]
+fn test_repayment_uses_locked_rate_after_utilization_changes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    let investor = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    mint(&env, &usdc_id, &investor, 100_000);
+    client.deposit(&investor, &usdc_id, &100_000);
+
+    enact_rate_model(&client, &admin, &usdc_id, &env);
+
+    let due_date = env.ledger().timestamp() + 1_000_000;
+
+    // Invoice 1 funds at 10% utilization and locks 275 bps.
+    client.fund_invoice(&admin, &1u64, &10_000i128, &borrower, &due_date, &usdc_id);
+    // Invoice 2 then pushes utilization to 80% — the live rate is now 800 bps.
+    client.fund_invoice(&admin, &2u64, &70_000i128, &borrower, &due_date, &usdc_id);
+
+    env.ledger().with_mut(|l| l.timestamp += 100_000);
+
+    // Simple interest at the locked 275 bps for 100_000s on 10_000 principal:
+    // 10_000 * 275 * 100_000 / (10_000 * 31_536_000) = 0.87 -> 1 (round half
+    // up). The live 800 bps would charge 3 stroops instead — so this
+    // assertion only holds if the originally-locked rate is used.
+    assert_eq!(client.estimate_repayment(&1u64, &None), 10_001);
+    // Invoice 2 at its locked 800 bps: 70_000 * 800 * 100_000 /
+    // (10_000 * 31_536_000) = 17.76 -> 18 (round half up).
+    assert_eq!(client.estimate_repayment(&2u64, &None), 70_018);
+
+    mint(&env, &usdc_id, &borrower, 10_001);
+    client.repay_invoice(&1u64, &borrower, &10_001i128);
+
+    let record = client.get_funded_invoice(&1u64).unwrap();
+    assert_eq!(record.repaid_amount, 10_001);
+    assert_eq!(record.locked_yield_bps, 275);
+}
+
+#[test]
+fn test_funding_without_model_locks_static_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    let investor = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    mint(&env, &usdc_id, &investor, 100_000);
+    client.deposit(&investor, &usdc_id, &100_000);
+
+    let due_date = env.ledger().timestamp() + 1_000_000;
+    client.fund_invoice(&admin, &1u64, &10_000i128, &borrower, &due_date, &usdc_id);
+
+    // DEFAULT_YIELD_BPS = 800 locked verbatim — no curve configured.
+    assert_eq!(
+        client.get_funded_invoice(&1u64).unwrap().locked_yield_bps,
+        800
+    );
+
+    // The manual override still drives new fundings for model-less tokens.
+    env.ledger()
+        .with_mut(|l| l.timestamp += YIELD_CHANGE_COOLDOWN_SECS + 1);
+    client.set_yield(&admin, &900u32);
+    client.fund_invoice(&admin, &2u64, &10_000i128, &borrower, &due_date, &usdc_id);
+    assert_eq!(
+        client.get_funded_invoice(&2u64).unwrap().locked_yield_bps,
+        900
+    );
+}
+
+#[test]
+fn test_curve_takes_precedence_over_static_yield_once_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    let investor = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    mint(&env, &usdc_id, &investor, 100_000);
+    client.deposit(&investor, &usdc_id, &100_000);
+
+    enact_rate_model(&client, &admin, &usdc_id, &env);
+
+    // Manual override down to 700 bps (within the 200 bps max step) — must
+    // NOT affect new fundings now that the token has a curve; the flat yield
+    // is inert for this token.
+    env.ledger()
+        .with_mut(|l| l.timestamp += YIELD_CHANGE_COOLDOWN_SECS + 1);
+    client.set_yield(&admin, &700u32);
+
+    let due_date = env.ledger().timestamp() + 1_000_000;
+    client.fund_invoice(&admin, &1u64, &10_000i128, &borrower, &due_date, &usdc_id);
+    assert_eq!(
+        client.get_funded_invoice(&1u64).unwrap().locked_yield_bps,
+        275
+    );
+}
+
+// ── rate-history ring buffer ────────────────────────────────────────────────
+
+#[test]
+fn test_rate_history_records_on_fund_and_repay_in_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    let investor = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    mint(&env, &usdc_id, &investor, 100_000);
+    client.deposit(&investor, &usdc_id, &100_000);
+
+    enact_rate_model(&client, &admin, &usdc_id, &env);
+
+    let due_date = env.ledger().timestamp() + 1_000_000;
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.fund_invoice(&admin, &1u64, &10_000i128, &borrower, &due_date, &usdc_id);
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.fund_invoice(&admin, &2u64, &70_000i128, &borrower, &due_date, &usdc_id);
+    env.ledger().with_mut(|l| l.timestamp += 100);
+
+    // Repay invoice 2 in full — utilization drops back, another sample lands.
+    let due = client.estimate_repayment(&2u64, &None);
+    mint(&env, &usdc_id, &borrower, due);
+    client.repay_invoice(&2u64, &borrower, &due);
+
+    let history = client.get_rate_history(&usdc_id, &100u32);
+    // 1 sample on execute + 2 fundings + 1 repayment.
+    assert_eq!(history.len(), 4);
+    // Chronological (oldest-first), strictly non-decreasing timestamps.
+    for i in 1..history.len() {
+        assert!(
+            history.get(i - 1).unwrap().timestamp <= history.get(i).unwrap().timestamp,
+            "history out of order at index {i}"
+        );
+    }
+    // Funding raised utilization; repayment brought it back down.
+    assert_eq!(history.get(1).unwrap().utilization_bps, 1_000);
+    assert_eq!(history.get(2).unwrap().utilization_bps, 8_000);
+    assert!(history.get(3).unwrap().utilization_bps < 8_000);
+    // Rates track the curve at those utilization levels.
+    assert_eq!(history.get(1).unwrap().rate_bps, 275);
+    assert_eq!(history.get(2).unwrap().rate_bps, 800);
+
+    // The limit keeps only the most recent samples.
+    let limited = client.get_rate_history(&usdc_id, &2u32);
+    assert_eq!(limited.len(), 2);
+    assert_eq!(limited.get(0), history.get(2));
+    assert_eq!(limited.get(1), history.get(3));
+}
+
+#[test]
+fn test_rate_history_collapses_consecutive_duplicates() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    enact_rate_model(&client, &admin, &usdc_id, &env);
+
+    // A second snapshot at unchanged utilization/rate is a no-op: repaying
+    // nothing changed nothing, so no funding happens here at all — instead,
+    // simply confirm only the execute-time sample exists.
+    let history = client.get_rate_history(&usdc_id, &100u32);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().utilization_bps, 0);
+    assert_eq!(history.get(0).unwrap().rate_bps, 200);
+}
+
+#[test]
+fn test_rate_history_ring_buffer_evicts_oldest_on_overflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, usdc_id) = setup(&env);
+
+    // Push MAX_RATE_HISTORY + 5 (725) distinct samples by cycling
+    // propose -> execute with a different base rate each round (consecutive
+    // duplicates would collapse, so each round must differ from the last).
+    let total_rounds = 725u32;
+    for i in 0..total_rounds {
+        let model = RateModelConfig {
+            base_rate_bps: (i % 50) + 1,
+            optimal_utilization_bps: 8_000,
+            slope1_bps: 0,
+            slope2_bps: 0,
+            max_rate_bps: 5_000,
+        };
+        client.propose_rate_model_change(&admin, &usdc_id, &model);
+        env.ledger()
+            .with_mut(|l| l.timestamp += YIELD_TIMELOCK_SECS);
+        client.execute_rate_model_change(&usdc_id);
+        // Move past the cooldown before the next proposal.
+        env.ledger()
+            .with_mut(|l| l.timestamp += YIELD_CHANGE_COOLDOWN_SECS);
+    }
+
+    let history = client.get_rate_history(&usdc_id, &1_000u32);
+    // Capacity is 720 — the oldest 5 samples were evicted.
+    assert_eq!(history.len(), 720);
+    // Empty pool => utilization 0 => rate == base_rate_bps of that round.
+    // Round i contributes rate (i % 50) + 1; retained rounds are 5..=724.
+    assert_eq!(history.get(0).unwrap().rate_bps, 6); // round 5
+    assert_eq!(history.get(719).unwrap().rate_bps, 25); // round 724: 724 % 50 = 24 -> 25
+                                                        // Chronological order is preserved across the wraparound.
+    for i in 1..history.len() {
+        assert!(
+            history.get(i - 1).unwrap().timestamp <= history.get(i).unwrap().timestamp,
+            "history out of order at index {i}"
+        );
+    }
+}

--- a/frontend/__tests__/lib/rate-model.test.ts
+++ b/frontend/__tests__/lib/rate-model.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #863: the client-side curve port must produce exactly the same values as
+ * the on-chain `compute_current_rate` — these vectors mirror the Rust unit
+ * tests in contracts/pool/tests/rate_model_tests.rs.
+ */
+
+import {
+  computeCurrentRateBps,
+  sampleRateCurve,
+  validateRateModelConfig,
+} from '@/lib/rate-model';
+import type { RateModelConfig } from '@/lib/types';
+
+const standardModel: RateModelConfig = {
+  baseRateBps: 200,
+  optimalUtilizationBps: 8_000,
+  slope1Bps: 600,
+  slope2Bps: 2_400,
+  maxRateBps: 5_000,
+};
+
+describe('computeCurrentRateBps', () => {
+  it('returns the base rate at 0% utilization', () => {
+    expect(computeCurrentRateBps(0, standardModel)).toBe(200);
+  });
+
+  it('prorates slope1 just below the kink', () => {
+    expect(computeCurrentRateBps(7_999, standardModel)).toBe(799);
+  });
+
+  it('returns base + slope1 exactly at the kink', () => {
+    expect(computeCurrentRateBps(8_000, standardModel)).toBe(800);
+  });
+
+  it('adds slope2 pro-rata just above the kink', () => {
+    expect(computeCurrentRateBps(8_001, standardModel)).toBe(801);
+  });
+
+  it('returns base + slope1 + slope2 at 100% utilization', () => {
+    expect(computeCurrentRateBps(10_000, standardModel)).toBe(3_200);
+  });
+
+  it('clamps to the configured max rate', () => {
+    const model = { ...standardModel, maxRateBps: 1_000 };
+    expect(computeCurrentRateBps(10_000, model)).toBe(1_000);
+    expect(computeCurrentRateBps(8_000, model)).toBe(800);
+  });
+
+  it('clamps utilization above 100%', () => {
+    expect(computeCurrentRateBps(12_345, standardModel)).toBe(
+      computeCurrentRateBps(10_000, standardModel),
+    );
+  });
+
+  it('has no steep region when the kink is at 100%', () => {
+    const model = { ...standardModel, optimalUtilizationBps: 10_000 };
+    expect(computeCurrentRateBps(10_000, model)).toBe(800);
+    expect(computeCurrentRateBps(5_000, model)).toBe(500);
+  });
+
+  it('is flat when both slopes are zero', () => {
+    const model = { ...standardModel, slope1Bps: 0, slope2Bps: 0 };
+    expect(computeCurrentRateBps(0, model)).toBe(200);
+    expect(computeCurrentRateBps(10_000, model)).toBe(200);
+  });
+
+  it('is monotonically non-decreasing across the full range', () => {
+    let prev = -1;
+    for (let util = 0; util <= 10_000; util++) {
+      const rate = computeCurrentRateBps(util, standardModel);
+      expect(rate).toBeGreaterThanOrEqual(prev);
+      prev = rate;
+    }
+  });
+});
+
+describe('sampleRateCurve', () => {
+  it('returns endpoints matching the curve', () => {
+    const points = sampleRateCurve(standardModel);
+    expect(points[0]).toEqual({ utilizationBps: 0, rateBps: 200 });
+    expect(points[points.length - 1]).toEqual({ utilizationBps: 10_000, rateBps: 3_200 });
+  });
+});
+
+describe('validateRateModelConfig', () => {
+  it('accepts the standard model', () => {
+    expect(validateRateModelConfig(standardModel)).toBeNull();
+  });
+
+  it.each([
+    [{ optimalUtilizationBps: 0 }, 'kink at 0'],
+    [{ optimalUtilizationBps: 10_001 }, 'kink above 100%'],
+    [{ maxRateBps: 0 }, 'zero ceiling'],
+    [{ maxRateBps: 5_001 }, 'ceiling above protocol cap'],
+    [{ baseRateBps: 4_000, maxRateBps: 3_000 }, 'base above ceiling'],
+    [{ slope1Bps: 5_001 }, 'slope1 above cap'],
+    [{ slope2Bps: 5_001 }, 'slope2 above cap'],
+  ])('rejects %s', (patch, _label) => {
+    expect(validateRateModelConfig({ ...standardModel, ...patch })).not.toBeNull();
+  });
+});

--- a/frontend/app/admin/yield/page.tsx
+++ b/frontend/app/admin/yield/page.tsx
@@ -1,14 +1,21 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useStore } from '@/lib/store';
 import { Skeleton } from '@/components/Skeleton';
+import { RateCurveChart } from '@/components/analytics';
+import { validateRateModelConfig } from '@/lib/rate-model';
+import { stablecoinLabel } from '@/lib/stellar';
+import type { RateModelConfig } from '@/lib/types';
 import {
   getPoolConfig,
   buildSetYieldTx,
   buildSetFactoringFeeTx,
   submitTx,
+  getAcceptedTokens,
+  getRateModelConfig,
+  buildProposeRateModelTx,
 } from '@/lib/contracts';
 
 export default function AdminYieldPage() {
@@ -18,6 +25,17 @@ export default function AdminYieldPage() {
   const [loading, setLoading] = useState(false);
   const [txLoading, setTxLoading] = useState(false);
 
+  // #863: rate-model curve editor state (values stored as percent strings,
+  // converted to bps on submit).
+  const [rateTokens, setRateTokens] = useState<string[]>([]);
+  const [rateToken, setRateToken] = useState('');
+  const [currentModel, setCurrentModel] = useState<RateModelConfig | null>(null);
+  const [baseRate, setBaseRate] = useState('2');
+  const [kinkUtil, setKinkUtil] = useState('80');
+  const [slope1, setSlope1] = useState('6');
+  const [slope2, setSlope2] = useState('24');
+  const [maxRate, setMaxRate] = useState('50');
+
   useEffect(() => {
     async function load() {
       setLoading(true);
@@ -26,6 +44,9 @@ export default function AdminYieldPage() {
         setPoolConfig(config);
         setNewYield((config.yieldBps / 100).toString());
         setNewFactoringFee((config.factoringFeeBps / 100).toString());
+        const tokens = await getAcceptedTokens();
+        setRateTokens(tokens);
+        if (tokens.length > 0) setRateToken((prev) => prev || tokens[0] || '');
       } catch (e) {
         console.error(e);
       } finally {
@@ -34,6 +55,43 @@ export default function AdminYieldPage() {
     }
     load();
   }, [setPoolConfig]);
+
+  // Load the selected token's current curve (if any) into the editor.
+  useEffect(() => {
+    if (!rateToken) return;
+    let cancelled = false;
+    getRateModelConfig(rateToken)
+      .then((model) => {
+        if (cancelled) return;
+        setCurrentModel(model);
+        if (model) {
+          setBaseRate((model.baseRateBps / 100).toString());
+          setKinkUtil((model.optimalUtilizationBps / 100).toString());
+          setSlope1((model.slope1Bps / 100).toString());
+          setSlope2((model.slope2Bps / 100).toString());
+          setMaxRate((model.maxRateBps / 100).toString());
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setCurrentModel(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [rateToken]);
+
+  // Live preview of the draft curve before submitting the timelocked proposal.
+  const draftModel = useMemo<RateModelConfig>(
+    () => ({
+      baseRateBps: Math.round(parseFloat(baseRate || '0') * 100),
+      optimalUtilizationBps: Math.round(parseFloat(kinkUtil || '0') * 100),
+      slope1Bps: Math.round(parseFloat(slope1 || '0') * 100),
+      slope2Bps: Math.round(parseFloat(slope2 || '0') * 100),
+      maxRateBps: Math.round(parseFloat(maxRate || '0') * 100),
+    }),
+    [baseRate, kinkUtil, slope1, slope2, maxRate],
+  );
+  const draftError = useMemo(() => validateRateModelConfig(draftModel), [draftModel]);
 
   if (loading) {
     return (
@@ -114,8 +172,40 @@ export default function AdminYieldPage() {
     }
   }
 
+  // #863: propose new curve parameters — takes effect only after the
+  // on-chain timelock (48h default) via execute_rate_model_change.
+  async function handleRateModelSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!wallet.address || !rateToken) return;
+
+    if (draftError) {
+      toast.error(draftError);
+      return;
+    }
+
+    setTxLoading(true);
+
+    try {
+      const xdr = await buildProposeRateModelTx(wallet.address, rateToken, draftModel);
+      await signAndSubmit(xdr);
+      toast.success(
+        `Rate model proposal submitted for ${stablecoinLabel(rateToken)}. ` +
+          'It becomes executable after the timelock elapses.',
+      );
+
+      const model = await getRateModelConfig(rateToken);
+      setCurrentModel(model);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Failed to propose rate model change.';
+      toast.error(msg);
+      console.error(e);
+    } finally {
+      setTxLoading(false);
+    }
+  }
+
   return (
-    <div className="max-w-2xl space-y-8">
+    <div className="max-w-4xl space-y-8">
       <div>
         <h1 className="text-3xl font-bold mb-2">Pool Fee Management</h1>
         <p className="text-brand-muted text-sm">
@@ -216,12 +306,98 @@ export default function AdminYieldPage() {
         </form>
       </div>
 
+      {/* #863: utilization-driven rate model editor */}
+      <div className="p-8 bg-brand-card border border-brand-border rounded-2xl shadow-sm">
+        <div className="mb-6">
+          <h2 className="text-xl font-bold text-white mb-1">Interest Rate Curve</h2>
+          <p className="text-brand-muted text-sm">
+            Utilization-driven pricing per token. New parameters go through the standard
+            timelocked proposal flow; already-funded invoices keep their locked rate.
+          </p>
+        </div>
+
+        {rateTokens.length === 0 ? (
+          <p className="text-brand-muted text-sm">No accepted tokens configured.</p>
+        ) : (
+          <form onSubmit={handleRateModelSubmit} className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-white mb-2">Token</label>
+              <select
+                value={rateToken}
+                onChange={(e) => setRateToken(e.target.value)}
+                className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-3 text-white focus:outline-none focus:border-brand-gold"
+              >
+                {rateTokens.map((tok) => (
+                  <option key={tok} value={tok}>
+                    {stablecoinLabel(tok)}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-2 text-xs text-brand-muted">
+                {currentModel
+                  ? 'This token has an active curve — the flat yield rate is inert for its new fundings.'
+                  : 'No curve configured yet — new fundings use the flat yield rate above.'}
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {(
+                [
+                  ['Base rate (%)', baseRate, setBaseRate, 'Rate at 0% utilization'],
+                  ['Kink utilization (%)', kinkUtil, setKinkUtil, 'Optimal utilization point'],
+                  ['Slope 1 (%)', slope1, setSlope1, 'Rate added from 0% to the kink'],
+                  ['Slope 2 (%)', slope2, setSlope2, 'Rate added from kink to 100%'],
+                  ['Max rate (%)', maxRate, setMaxRate, 'Hard ceiling on the curve'],
+                ] as const
+              ).map(([label, value, setter, hint]) => (
+                <div key={label}>
+                  <label className="block text-sm font-medium text-white mb-2">{label}</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={value}
+                    onChange={(e) => setter(e.target.value)}
+                    className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-3 text-white placeholder-brand-muted focus:outline-none focus:border-brand-gold"
+                    required
+                  />
+                  <p className="mt-1 text-xs text-brand-muted">{hint}</p>
+                </div>
+              ))}
+            </div>
+
+            {draftError ? (
+              <p className="text-sm text-red-400">{draftError}</p>
+            ) : (
+              <RateCurveChart config={draftModel} title="Proposal preview" />
+            )}
+
+            <button
+              type="submit"
+              disabled={txLoading || loading || !rateToken || Boolean(draftError)}
+              className="w-full py-4 bg-brand-gold text-brand-dark font-bold rounded-xl hover:bg-brand-amber transition-all shadow-lg active:scale-[0.98] disabled:opacity-50"
+            >
+              {txLoading ? 'Submitting Proposal...' : 'Propose Rate Model Change'}
+            </button>
+            <p className="text-xs text-brand-muted">
+              The proposal becomes executable after the on-chain timelock (48h default). Anyone
+              can execute it once the timelock elapses.
+            </p>
+          </form>
+        )}
+      </div>
+
       <div className="p-6 bg-brand-dark border border-brand-border rounded-2xl text-xs text-brand-muted space-y-2">
         <p className="font-bold text-white mb-1 uppercase tracking-tighter">Safety Controls:</p>
         <p>• The contract enforces a maximum yield of 50.00% (5000 bps).</p>
         <p>• The contract enforces a maximum factoring fee of 100.00% (10000 bps).</p>
+        <p>• Curve parameters are capped at a 50.00% (5000 bps) max rate.</p>
         <p>• Yield changes apply to active and new funded invoices at repayment time.</p>
         <p>• Factoring fees are locked when an invoice becomes fully funded.</p>
+        <p>
+          • Once a token has a rate curve, the curve prices its new fundings and the flat yield
+          rate is inert for that token (it remains the fallback for tokens without a curve).
+        </p>
       </div>
     </div>
   );

--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -8,21 +8,36 @@ import {
   YieldPerformanceChart,
   InvoiceFunnelChart,
   RecentEventsFeed,
+  RateCurveChart,
 } from '@/components/analytics';
-import { getPoolConfig, getAcceptedTokens, getPoolTokenTotals } from '@/lib/contracts';
+import {
+  getPoolConfig,
+  getAcceptedTokens,
+  getPoolTokenTotals,
+  getRateModelConfig,
+  getCurrentRate,
+} from '@/lib/contracts';
 import {
   fetchAnalyticsData,
   clearAnalyticsCache,
   type AnalyticsDashboardData,
 } from '@/lib/analytics';
 import { formatUSDC, stablecoinLabel } from '@/lib/stellar';
-import type { PoolConfig, PoolTokenTotals } from '@/lib/types';
+import type { PoolConfig, PoolTokenTotals, RateModelConfig } from '@/lib/types';
 
 const POOL_CONFIGURED = Boolean(process.env.NEXT_PUBLIC_POOL_CONTRACT_ID);
 
 interface TokenData {
   token: string;
   totals: PoolTokenTotals;
+}
+
+/** #863: per-token rate model state for the curve chart. */
+interface TokenRateModel {
+  token: string;
+  config: RateModelConfig;
+  currentRateBps: number | null;
+  utilizationBps: number;
 }
 
 function StatCard({
@@ -70,6 +85,7 @@ function UtilizationBar({ deployed, total }: { deployed: bigint; total: bigint }
 export default function AnalyticsPage() {
   const [config, setConfig] = useState<PoolConfig | null>(null);
   const [tokens, setTokens] = useState<TokenData[]>([]);
+  const [rateModels, setRateModels] = useState<TokenRateModel[]>([]);
   const [statsLoading, setStatsLoading] = useState(true);
   const [statsError, setStatsError] = useState<string | null>(null);
 
@@ -124,6 +140,21 @@ export default function AnalyticsPage() {
         })),
       );
       setTokens(tokenData);
+
+      // #863: load each token's rate model (if any) for the curve charts.
+      const models = await Promise.all(
+        tokenData.map(async ({ token, totals }) => {
+          const modelConfig = await getRateModelConfig(token);
+          if (!modelConfig) return null;
+          const currentRateBps = await getCurrentRate(token);
+          const utilizationBps =
+            totals.totalDeposited > 0n
+              ? Number((totals.totalDeployed * 10_000n) / totals.totalDeposited)
+              : 0;
+          return { token, config: modelConfig, currentRateBps, utilizationBps };
+        }),
+      );
+      setRateModels(models.filter((m): m is TokenRateModel => m !== null));
     } catch (e) {
       setStatsError(e instanceof Error ? e.message : 'Failed to load analytics data.');
     } finally {
@@ -253,6 +284,21 @@ export default function AnalyticsPage() {
                     </div>
                   ))}
                 </div>
+              </div>
+            )}
+
+            {/* #863: utilization-driven rate curves (one per configured token) */}
+            {!statsLoading && !statsError && rateModels.length > 0 && (
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+                {rateModels.map((m) => (
+                  <RateCurveChart
+                    key={m.token}
+                    config={m.config}
+                    currentUtilizationBps={m.utilizationBps}
+                    currentRateBps={m.currentRateBps ?? undefined}
+                    title={`Rate Curve — ${stablecoinLabel(m.token)}`}
+                  />
+                ))}
               </div>
             )}
           </>

--- a/frontend/app/invest/page.tsx
+++ b/frontend/app/invest/page.tsx
@@ -20,10 +20,13 @@ import {
   submitTx,
   getKycRequired,
   getInvestorKyc,
+  getRateModelConfig,
+  getCurrentRate,
 } from '@/lib/contracts';
 import { parseStellarAddress } from '@/lib/types';
 import { toStroops, formatUSDC, stablecoinLabel, USDC_TOKEN_ID } from '@/lib/stellar';
-import type { PoolTokenTotals } from '@/lib/types';
+import type { PoolTokenTotals, RateModelConfig } from '@/lib/types';
+import { RateCurveChart } from '@/components/analytics';
 import { useTranslations } from 'next-intl';
 
 export default function InvestPage() {
@@ -42,6 +45,11 @@ export default function InvestPage() {
   const [tokenTotals, setTokenTotals] = useState<PoolTokenTotals | null>(null);
   const [tokenDepositCap, setTokenDepositCap] = useState<bigint>(0n);
 
+  // #863: utilization-driven rate model for the selected token (null when
+  // the token has no curve configured — the static yield_bps applies).
+  const [rateModel, setRateModel] = useState<RateModelConfig | null>(null);
+  const [liveRateBps, setLiveRateBps] = useState<number | null>(null);
+
   // #109: KYC status
   const [kycRequired, setKycRequired] = useState(false);
   const [kycApproved, setKycApproved] = useState(false);
@@ -53,6 +61,7 @@ export default function InvestPage() {
   useEffect(() => {
     if (!selectedToken) return;
     loadTokenTotals(selectedToken);
+    loadRateModel(selectedToken);
   }, [selectedToken, poolConfig]);
 
   useEffect(() => {
@@ -112,6 +121,20 @@ export default function InvestPage() {
     } catch {
       setTokenTotals(null);
       setTokenDepositCap(0n);
+    }
+  }
+
+  // #863: live curve for the selected token; falls back to the static yield
+  // when no rate model is configured for it.
+  async function loadRateModel(token: string) {
+    if (!POOL_CONFIGURED) return;
+    try {
+      const model = await getRateModelConfig(token);
+      setRateModel(model);
+      setLiveRateBps(model ? await getCurrentRate(token) : null);
+    } catch {
+      setRateModel(null);
+      setLiveRateBps(null);
     }
   }
 
@@ -227,8 +250,23 @@ export default function InvestPage() {
               </div>
             )}
 
-            {/* Earnings calculator */}
-            <APYCalculator />
+            {/* Earnings calculator — uses the live curve rate when the
+                selected token has a rate model configured (#863). */}
+            <APYCalculator token={selectedToken || undefined} />
+
+            {/* #863: live utilization-driven rate curve for the selected token */}
+            {rateModel && (
+              <RateCurveChart
+                config={rateModel}
+                currentUtilizationBps={
+                  tokenTotals && tokenTotals.totalDeposited > 0n
+                    ? Number((tokenTotals.totalDeployed * 10_000n) / tokenTotals.totalDeposited)
+                    : 0
+                }
+                currentRateBps={liveRateBps ?? undefined}
+                title={`Rate Curve — ${stablecoinLabel(selectedToken)}`}
+              />
+            )}
 
             {wallet.connected && position && selectedToken && (
               <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
@@ -473,7 +511,10 @@ export default function InvestPage() {
               assumptions before you invest.
             </p>
           </div>
-          <ScenarioModeler yieldBps={poolConfig?.yieldBps ?? null} loading={loading} />
+          <ScenarioModeler
+            yieldBps={liveRateBps ?? poolConfig?.yieldBps ?? null}
+            loading={loading}
+          />
         </section>
       </div>
     </div>

--- a/frontend/components/APYCalculator.tsx
+++ b/frontend/components/APYCalculator.tsx
@@ -2,10 +2,11 @@
 
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { usePoolConfig } from '@/lib/cache';
 import { formatApyPercent, projectedInterestStroops } from '@/lib/apy';
 import { formatUSDC, toStroops } from '@/lib/stellar';
+import { getCurrentRate } from '@/lib/contracts';
 import { Skeleton } from '@/components/Skeleton';
 
 const DEFAULT_LOCK_DAYS = '30';
@@ -17,15 +18,44 @@ const DEFAULT_YIELD_BPS = 800;
  * Fetches the live `yield_bps` from the pool contract’s `get_config()` on mount
  * (via SWR-backed `usePoolConfig`). Falls back to {@link DEFAULT_YIELD_BPS} when
  * the contract read fails, and shows a loading skeleton during initial fetch.
+ *
+ * #863: when `token` is provided and that token has a utilization-driven rate
+ * model configured, the live curve rate (`get_current_rate`) is used instead of
+ * the flat `yield_bps`, so projections track real-time supply/demand.
  */
-export function APYCalculator({ className = '' }: { className?: string }) {
+export function APYCalculator({
+  className = '',
+  token,
+}: {
+  className?: string;
+  token?: string;
+}) {
   const [depositInput, setDepositInput] = useState('');
   const [lockDaysInput, setLockDaysInput] = useState(DEFAULT_LOCK_DAYS);
   const { data: poolConfig, isLoading } = usePoolConfig();
+  const [liveCurveRate, setLiveCurveRate] = useState<number | null>(null);
 
-  const yieldBps = poolConfig?.yieldBps ?? DEFAULT_YIELD_BPS;
+  useEffect(() => {
+    let cancelled = false;
+    if (!token) {
+      setLiveCurveRate(null);
+      return;
+    }
+    getCurrentRate(token)
+      .then((rate) => {
+        if (!cancelled) setLiveCurveRate(rate);
+      })
+      .catch(() => {
+        if (!cancelled) setLiveCurveRate(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const yieldBps = liveCurveRate ?? poolConfig?.yieldBps ?? DEFAULT_YIELD_BPS;
   const hasValidPoolRate = yieldBps >= 0;
-  const isFallbackRate = !poolConfig;
+  const isFallbackRate = !poolConfig && liveCurveRate === null;
 
   const { interestStroops, totalStroops } = useMemo(() => {
     if (yieldBps === null || yieldBps < 0) {
@@ -58,7 +88,8 @@ export function APYCalculator({ className = '' }: { className?: string }) {
     <div className={`p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl ${className}`.trim()}>
       <h2 className="text-lg font-semibold mb-1 text-[var(--text-primary)]">Earnings calculator</h2>
       <p className="text-xs text-[var(--muted)] mb-4">
-        Model projected returns using the pool&apos;s current rate (
+        Model projected returns using the pool&apos;s{' '}
+        {liveCurveRate !== null ? 'live utilization-driven rate' : 'current rate'} (
         {hasValidPoolRate ? `${formatApyPercent(yieldBps!)}% APY` : 'rate unavailable'}
         ).
       </p>
@@ -129,7 +160,7 @@ export function APYCalculator({ className = '' }: { className?: string }) {
 
       <p className="mt-4 text-xs text-[var(--muted)] leading-relaxed border-t border-[var(--border)] pt-4">
         <strong className="text-[var(--muted)]">Disclaimer:</strong> This projection uses the
-        pool&apos;s configured yield rate and assumes continuous linear accrual like on-chain
+        pool&apos;s {liveCurveRate !== null ? 'live curve rate at current utilization' : 'configured yield rate'} and assumes continuous linear accrual like on-chain
         invoice interest. Actual returns depend on invoice repayment timing, utilization, and pool
         parameters -- nothing is guaranteed.
       </p>

--- a/frontend/components/analytics/RateCurveChart.tsx
+++ b/frontend/components/analytics/RateCurveChart.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+/**
+ * #863: kinked interest-rate curve chart — utilization on the x-axis, rate
+ * (APY) on the y-axis, with the pool's current operating point highlighted.
+ * The curve itself is computed client-side from the on-chain
+ * `RateModelConfig` via the shared `computeCurrentRateBps` port, so rendering
+ * costs zero RPC round-trips.
+ */
+
+import { useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceDot,
+  ReferenceLine,
+} from 'recharts';
+import type { RateModelConfig } from '@/lib/types';
+import { computeCurrentRateBps, sampleRateCurve } from '@/lib/rate-model';
+
+interface RateCurveChartProps {
+  config: RateModelConfig;
+  /** Current pool utilization in bps; the marker is omitted when undefined. */
+  currentUtilizationBps?: number;
+  /** Current live rate in bps; falls back to the curve value at the marker. */
+  currentRateBps?: number;
+  title?: string;
+}
+
+export function RateCurveChart({
+  config,
+  currentUtilizationBps,
+  currentRateBps,
+  title = 'Interest Rate Curve',
+}: RateCurveChartProps) {
+  const data = useMemo(
+    () =>
+      sampleRateCurve(config).map((p) => ({
+        utilization: p.utilizationBps / 100, // percent
+        rate: p.rateBps / 100, // percent APY
+      })),
+    [config],
+  );
+
+  const hasMarker = currentUtilizationBps !== undefined;
+  const markerUtilization = hasMarker ? currentUtilizationBps / 100 : 0;
+  // The marker's y comes from the live rate when provided, otherwise the
+  // curve evaluated at the exact current utilization.
+  const markerRate = hasMarker
+    ? (currentRateBps ?? computeCurrentRateBps(currentUtilizationBps, config)) / 100
+    : 0;
+
+  return (
+    <div className="p-6 bg-brand-card border border-brand-border rounded-2xl">
+      <div className="flex items-center justify-between mb-1">
+        <h3 className="text-lg font-bold text-white flex items-center gap-2">
+          <span className="w-2 h-6 bg-brand-gold rounded-full" />
+          {title}
+        </h3>
+        {hasMarker && (
+          <p className="text-xs text-brand-muted">
+            now: {markerUtilization.toFixed(1)}% util → {markerRate.toFixed(2)}% APY
+          </p>
+        )}
+      </div>
+      <p className="text-xs text-brand-muted mb-4">
+        Kink at {(config.optimalUtilizationBps / 100).toFixed(0)}% utilization — rates rise
+        steeply beyond it to attract deposits and slow draw-downs.
+      </p>
+      <div className="h-72 overflow-x-hidden">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" />
+            <XAxis
+              dataKey="utilization"
+              type="number"
+              domain={[0, 100]}
+              tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 11 }}
+              tickFormatter={(val: number) => `${val}%`}
+            />
+            <YAxis
+              dataKey="rate"
+              type="number"
+              domain={[0, 'auto']}
+              tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 11 }}
+              tickFormatter={(val: number) => `${val}%`}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: '#1a1a2e',
+                border: '1px solid rgba(255,255,255,0.1)',
+                borderRadius: '8px',
+                color: '#fff',
+              }}
+              formatter={(value) => [`${Number(value ?? 0).toFixed(2)}%`, 'APY']}
+              labelFormatter={(label) => `Utilization: ${Number(label).toFixed(1)}%`}
+            />
+            <ReferenceLine
+              x={config.optimalUtilizationBps / 100}
+              stroke="rgba(255,255,255,0.25)"
+              strokeDasharray="4 4"
+              label={{
+                value: 'kink',
+                fill: 'rgba(255,255,255,0.4)',
+                fontSize: 10,
+                position: 'top',
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="rate"
+              stroke="#C9A84C"
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+            {hasMarker && (
+              <ReferenceDot
+                x={markerUtilization}
+                y={markerRate}
+                r={6}
+                fill="#C9A84C"
+                stroke="#fff"
+                strokeWidth={2}
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/analytics/index.ts
+++ b/frontend/components/analytics/index.ts
@@ -4,3 +4,4 @@ export { InvoiceFunnelChart } from './InvoiceFunnelChart';
 export { CreditScoreDistributionChart } from './CreditScoreDistributionChart';
 export { TopSmesTable } from './TopSmesTable';
 export { RecentEventsFeed } from './RecentEventsFeed';
+export { RateCurveChart } from './RateCurveChart';

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -42,6 +42,8 @@ import type {
   AttestorInfo,
   Attestation,
   FullCreditScore,
+  RateModelConfig,
+  RateSnapshot,
 } from './types';
 // Auto-generated contract bindings (single source of truth for the on-chain
 // ABI — methods, struct shapes and error codes). Regenerate with
@@ -946,6 +948,188 @@ export async function buildSetYieldTx(admin: string, yieldBps: number): Promise<
         'set_yield',
         new Address(admin).toScVal(),
         nativeToScVal(yieldBps, { type: 'u32' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await simulateRpcTransaction(tx);
+  if (StellarRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Simulation failed: ${sim.error}`);
+  }
+
+  const prepared = StellarRpc.assembleTransaction(tx, sim).build();
+  return prepared.toXDR();
+}
+
+// ── #863: utilization-driven kinked interest-rate model ─────────────────────
+
+// Soroban encodes named-field structs as an ScMap keyed by field-name Symbols
+// in alphabetical order: (base_rate_bps, max_rate_bps,
+// optimal_utilization_bps, slope1_bps, slope2_bps).
+function rateModelConfigToScVal(config: RateModelConfig): xdr.ScVal {
+  const entry = (key: string, val: xdr.ScVal) =>
+    new xdr.ScMapEntry({ key: nativeToScVal(key, { type: 'symbol' }), val });
+  return xdr.ScVal.scvMap([
+    entry('base_rate_bps', nativeToScVal(config.baseRateBps, { type: 'u32' })),
+    entry('max_rate_bps', nativeToScVal(config.maxRateBps, { type: 'u32' })),
+    entry(
+      'optimal_utilization_bps',
+      nativeToScVal(config.optimalUtilizationBps, { type: 'u32' }),
+    ),
+    entry('slope1_bps', nativeToScVal(config.slope1Bps, { type: 'u32' })),
+    entry('slope2_bps', nativeToScVal(config.slope2Bps, { type: 'u32' })),
+  ]);
+}
+
+function rateModelConfigFromRaw(raw: Record<string, unknown>): RateModelConfig {
+  return {
+    baseRateBps: Number(raw.base_rate_bps ?? 0),
+    optimalUtilizationBps: Number(raw.optimal_utilization_bps ?? 0),
+    slope1Bps: Number(raw.slope1_bps ?? 0),
+    slope2Bps: Number(raw.slope2_bps ?? 0),
+    maxRateBps: Number(raw.max_rate_bps ?? 0),
+  };
+}
+
+/** Rate (bps) a new funding for `token` would lock right now, or null when
+ * the token has no rate model configured (caller falls back to the static
+ * `PoolConfig.yieldBps`). */
+export async function getCurrentRate(token: string): Promise<number | null> {
+  const sim = await simulateTx(
+    POOL_CONTRACT_ID,
+    'get_current_rate',
+    [new Address(token).toScVal()],
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  );
+  if (StellarRpc.Api.isSimulationError(sim)) {
+    // RateModelNotConfigured (80) — treated as "no curve" by callers.
+    return null;
+  }
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  return Number(scValToNative(result!.retval));
+}
+
+/** The token's curve parameters, or null when no rate model is configured. */
+export async function getRateModelConfig(token: string): Promise<RateModelConfig | null> {
+  const sim = await simulateTx(
+    POOL_CONTRACT_ID,
+    'get_rate_model_config',
+    [new Address(token).toScVal()],
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  );
+  if (StellarRpc.Api.isSimulationError(sim)) return null;
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  const raw = scValToNative(result!.retval);
+  if (!raw) return null;
+  return rateModelConfigFromRaw(raw as Record<string, unknown>);
+}
+
+/** Up to `limit` most recent rate samples, chronological (oldest-first). */
+export async function getRateHistory(token: string, limit: number): Promise<RateSnapshot[]> {
+  const sim = await simulateTx(
+    POOL_CONTRACT_ID,
+    'get_rate_history',
+    [new Address(token).toScVal(), nativeToScVal(limit, { type: 'u32' })],
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  );
+  if (StellarRpc.Api.isSimulationError(sim)) return [];
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  const raw = scValToNative(result!.retval) as Record<string, unknown>[];
+  if (!Array.isArray(raw)) return [];
+  return raw.map((r) => ({
+    timestamp: Number(r.timestamp ?? 0),
+    utilizationBps: Number(r.utilization_bps ?? 0),
+    rateBps: Number(r.rate_bps ?? 0),
+  }));
+}
+
+/** What the rate would be at a hypothetical utilization, or null when the
+ * token has no rate model configured. */
+export async function previewRateAtUtilization(
+  token: string,
+  utilizationBps: number,
+): Promise<number | null> {
+  const sim = await simulateTx(
+    POOL_CONTRACT_ID,
+    'preview_rate_at_utilization',
+    [new Address(token).toScVal(), nativeToScVal(utilizationBps, { type: 'u32' })],
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  );
+  if (StellarRpc.Api.isSimulationError(sim)) return null;
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  return Number(scValToNative(result!.retval));
+}
+
+/** Admin: propose new curve parameters; executable after the yield timelock. */
+export async function buildProposeRateModelTx(
+  admin: string,
+  token: string,
+  config: RateModelConfig,
+): Promise<string> {
+  const account = await getRpcAccount(admin);
+  const contract = new Contract(POOL_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK,
+  })
+    .addOperation(
+      contract.call(
+        'propose_rate_model_change',
+        new Address(admin).toScVal(),
+        new Address(token).toScVal(),
+        rateModelConfigToScVal(config),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await simulateRpcTransaction(tx);
+  if (StellarRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Simulation failed: ${sim.error}`);
+  }
+
+  const prepared = StellarRpc.assembleTransaction(tx, sim).build();
+  return prepared.toXDR();
+}
+
+/** Anyone: execute a rate-model proposal once its timelock has elapsed. */
+export async function buildExecuteRateModelTx(caller: string, token: string): Promise<string> {
+  const account = await getRpcAccount(caller);
+  const contract = new Contract(POOL_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK,
+  })
+    .addOperation(contract.call('execute_rate_model_change', new Address(token).toScVal()))
+    .setTimeout(30)
+    .build();
+
+  const sim = await simulateRpcTransaction(tx);
+  if (StellarRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Simulation failed: ${sim.error}`);
+  }
+
+  const prepared = StellarRpc.assembleTransaction(tx, sim).build();
+  return prepared.toXDR();
+}
+
+/** Admin: cancel a pending rate-model proposal. */
+export async function buildCancelRateModelTx(admin: string, token: string): Promise<string> {
+  const account = await getRpcAccount(admin);
+  const contract = new Contract(POOL_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK,
+  })
+    .addOperation(
+      contract.call(
+        'cancel_rate_model_change',
+        new Address(admin).toScVal(),
+        new Address(token).toScVal(),
       ),
     )
     .setTimeout(30)

--- a/frontend/lib/rate-model.ts
+++ b/frontend/lib/rate-model.ts
@@ -1,0 +1,81 @@
+/**
+ * #863: client-side port of the pool contract's kinked interest-rate curve
+ * (`compute_current_rate` in contracts/pool/src/lib.rs).
+ *
+ * Kept deliberately pure and dependency-free so chart components and the
+ * admin curve editor can render/preview the curve without one RPC round-trip
+ * per point. The math must stay in lockstep with the on-chain version:
+ *
+ *   util <= optimal: rate = base + util * slope1 / optimal
+ *   util >  optimal: rate = base + slope1 + (util - optimal) * slope2 / (10_000 - optimal)
+ *
+ * clamped to `maxRateBps`. Integer truncation mirrors the Rust integer math.
+ */
+
+import type { RateModelConfig } from './types';
+
+export const BPS_DENOM = 10_000;
+
+export function computeCurrentRateBps(utilizationBps: number, config: RateModelConfig): number {
+  const util = Math.min(Math.max(0, Math.floor(utilizationBps)), BPS_DENOM);
+  const optimal = config.optimalUtilizationBps;
+  if (optimal <= 0 || optimal > BPS_DENOM) return config.maxRateBps;
+
+  const below = Math.min(util, optimal);
+  let rate = config.baseRateBps + Math.floor((below * config.slope1Bps) / optimal);
+
+  if (util > optimal) {
+    const span = BPS_DENOM - optimal;
+    rate += Math.floor(((util - optimal) * config.slope2Bps) / span);
+  }
+
+  return Math.min(rate, config.maxRateBps);
+}
+
+/** Sample the curve at evenly-spaced utilization points for charting. */
+export function sampleRateCurve(
+  config: RateModelConfig,
+  points = 101,
+): { utilizationBps: number; rateBps: number }[] {
+  const samples: { utilizationBps: number; rateBps: number }[] = [];
+  const step = BPS_DENOM / (points - 1);
+  for (let i = 0; i < points; i++) {
+    const utilizationBps = Math.round(i * step);
+    samples.push({ utilizationBps, rateBps: computeCurrentRateBps(utilizationBps, config) });
+  }
+  return samples;
+}
+
+/** Client-side mirror of the contract's `validate_rate_model_config`. */
+export function validateRateModelConfig(config: RateModelConfig): string | null {
+  const MAX_RATE_BPS_CAP = 5_000;
+  if (
+    !Number.isInteger(config.optimalUtilizationBps) ||
+    config.optimalUtilizationBps <= 0 ||
+    config.optimalUtilizationBps > BPS_DENOM
+  ) {
+    return 'Optimal utilization must be between 1 and 10000 bps (0.01%–100%).';
+  }
+  if (
+    !Number.isInteger(config.maxRateBps) ||
+    config.maxRateBps <= 0 ||
+    config.maxRateBps > MAX_RATE_BPS_CAP
+  ) {
+    return `Max rate must be between 1 and ${MAX_RATE_BPS_CAP} bps.`;
+  }
+  if (!Number.isInteger(config.baseRateBps) || config.baseRateBps < 0) {
+    return 'Base rate must be a non-negative integer (bps).';
+  }
+  if (config.baseRateBps > config.maxRateBps) {
+    return 'Base rate cannot exceed the max rate.';
+  }
+  for (const [name, slope] of [
+    ['Slope 1', config.slope1Bps],
+    ['Slope 2', config.slope2Bps],
+  ] as const) {
+    if (!Number.isInteger(slope) || slope < 0 || slope > MAX_RATE_BPS_CAP) {
+      return `${name} must be between 0 and ${MAX_RATE_BPS_CAP} bps.`;
+    }
+  }
+  return null;
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -98,6 +98,29 @@ export interface LiquidityForecastPoint {
   projectedAvailable: bigint;
 }
 
+// ── #863: utilization-driven kinked interest-rate model ─────────────────────
+
+/** Curve parameters for one token, as returned by `get_rate_model_config`. */
+export interface RateModelConfig {
+  /** Rate (bps) at 0% utilization. */
+  baseRateBps: number;
+  /** The "kink" point in bps (e.g. 8000 = 80%). */
+  optimalUtilizationBps: number;
+  /** Rate increase (bps) spread across the 0..optimal span. */
+  slope1Bps: number;
+  /** Rate increase (bps) spread across the optimal..100% span (steeper). */
+  slope2Bps: number;
+  /** Hard ceiling on the computed rate. */
+  maxRateBps: number;
+}
+
+/** One sample from the on-chain rate-history ring buffer. */
+export interface RateSnapshot {
+  timestamp: number;
+  utilizationBps: number;
+  rateBps: number;
+}
+
 export type ProposalStatus = 'Active' | 'Passed' | 'Rejected' | 'Executed' | 'Cancelled';
 
 export interface GovernanceProposal {

--- a/indexer/src/api.ts
+++ b/indexer/src/api.ts
@@ -414,6 +414,52 @@ export function startApiServer(db: Database.Database, port: number): void {
     }
   });
 
+  // #863: utilization-driven rate model — the pool contract emits a
+  // `rate_snap` event with value (token, timestamp, utilization_bps, rate_bps)
+  // whenever a new sample lands in its on-chain ring buffer (on funding,
+  // repayment, and rate-model execution). This endpoint reconstructs the
+  // time series for one token from those events; `from`/`to` are optional
+  // unix-second bounds applied to the contract-side sample timestamp.
+  app.get('/pool/:token/rate-history', (req, res) => {
+    try {
+      const { token } = req.params;
+      if (!token) {
+        return res.status(400).json({ error: 'token path param is required' });
+      }
+      const from = typeof req.query.from === 'string' ? Number(req.query.from) : undefined;
+      const to = typeof req.query.to === 'string' ? Number(req.query.to) : undefined;
+      if ((from !== undefined && Number.isNaN(from)) || (to !== undefined && Number.isNaN(to))) {
+        return res.status(400).json({ error: 'from/to must be unix timestamps in seconds' });
+      }
+
+      const events = getEvents(db, {
+        contractType: 'pool',
+        eventType: 'rate_snap',
+        limit: 10_000,
+        offset: 0,
+      });
+
+      const samples = events
+        .filter((evt) => Array.isArray(evt.value) && evt.value[0] === token)
+        .map((evt) => {
+          const value = evt.value as any[];
+          return {
+            timestamp: Number(value[1]),
+            utilizationBps: Number(value[2]),
+            rateBps: Number(value[3]),
+            ledgerSequence: evt.ledgerSequence,
+            txHash: evt.txHash,
+          };
+        })
+        .filter((s) => (from === undefined || s.timestamp >= from) && (to === undefined || s.timestamp <= to))
+        .sort((a, b) => a.timestamp - b.timestamp);
+
+      return res.json({ token, samples, count: samples.length });
+    } catch (err: any) {
+      return res.status(500).json({ error: err.message });
+    }
+  });
+
   // Get latest ledger
   app.get('/ledger/latest', (_req, res) => {
     try {

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -14,6 +14,9 @@ import type {
   PoolTokenTotals,
   FundedInvoice,
   TransactionProgress,
+  WithdrawalRequest,
+  WaitEstimate,
+  LiquidityForecastPoint,
   CoFundingRound,
   OracleInfo,
   VerificationRound,
@@ -21,6 +24,8 @@ import type {
   AttestorInfo,
   Attestation,
   CreditScoreResponse,
+  RateModelConfig,
+  RateSnapshot,
 } from './types';
 
 const SIMULATION_SOURCE_ACCOUNT = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
@@ -68,6 +73,34 @@ function coFundingRoundFromScVal(raw: Record<string, unknown>): CoFundingRound {
     minCommitment: BigInt(String(raw.min_commitment)),
     maxInvestorBps: Number(raw.max_investor_bps),
     participants: (raw.participants as string[]) ?? [],
+  };
+}
+
+// #863: RateModelConfig struct -> ScVal. Soroban encodes named-field structs
+// as an ScMap keyed by field-name Symbols in alphabetical order:
+// (base_rate_bps, max_rate_bps, optimal_utilization_bps, slope1_bps, slope2_bps).
+function rateModelConfigToScVal(config: RateModelConfig): xdr.ScVal {
+  const entry = (key: string, val: xdr.ScVal) =>
+    new xdr.ScMapEntry({ key: nativeToScVal(key, { type: 'symbol' }), val });
+  return xdr.ScVal.scvMap([
+    entry('base_rate_bps', nativeToScVal(config.baseRateBps, { type: 'u32' })),
+    entry('max_rate_bps', nativeToScVal(config.maxRateBps, { type: 'u32' })),
+    entry(
+      'optimal_utilization_bps',
+      nativeToScVal(config.optimalUtilizationBps, { type: 'u32' }),
+    ),
+    entry('slope1_bps', nativeToScVal(config.slope1Bps, { type: 'u32' })),
+    entry('slope2_bps', nativeToScVal(config.slope2Bps, { type: 'u32' })),
+  ]);
+}
+
+function rateModelConfigFromScVal(raw: Record<string, unknown>): RateModelConfig {
+  return {
+    baseRateBps: Number(raw.base_rate_bps),
+    optimalUtilizationBps: Number(raw.optimal_utilization_bps),
+    slope1Bps: Number(raw.slope1_bps),
+    slope2Bps: Number(raw.slope2_bps),
+    maxRateBps: Number(raw.max_rate_bps),
   };
 }
 
@@ -715,6 +748,184 @@ export class AsteraClient {
         day: Number(r.day),
         projectedAvailable: BigInt(String(r.projected_available)),
       }));
+    },
+
+    // #863: utilization-driven kinked interest-rate model
+
+    /** Rate (bps) a new funding for `token` would lock right now. Throws when
+     * the token has no rate model configured — fall back to
+     * `getConfig().yieldBps` in that case. */
+    getCurrentRate: async (token: string): Promise<number> => {
+      const sim = await simulateTx(
+        this.server,
+        this.config.network,
+        this.config.poolContractId,
+        'get_current_rate',
+        [new Address(token).toScVal()],
+        SIMULATION_SOURCE_ACCOUNT,
+      );
+      if (StellarRpc.Api.isSimulationError(sim)) {
+        throw new Error(`Simulation failed: ${sim.error}`);
+      }
+      return Number(scValToNative(sim.result!.retval));
+    },
+
+    /** The token's curve parameters, or null when no rate model is configured. */
+    getRateModelConfig: async (token: string): Promise<RateModelConfig | null> => {
+      const sim = await simulateTx(
+        this.server,
+        this.config.network,
+        this.config.poolContractId,
+        'get_rate_model_config',
+        [new Address(token).toScVal()],
+        SIMULATION_SOURCE_ACCOUNT,
+      );
+      if (StellarRpc.Api.isSimulationError(sim)) {
+        throw new Error(`Simulation failed: ${sim.error}`);
+      }
+      const raw = scValToNative(sim.result!.retval);
+      if (!raw) return null;
+      return rateModelConfigFromScVal(raw as Record<string, unknown>);
+    },
+
+    /** Up to `limit` most recent rate samples, chronological (oldest-first). */
+    getRateHistory: async (token: string, limit: number): Promise<RateSnapshot[]> => {
+      const sim = await simulateTx(
+        this.server,
+        this.config.network,
+        this.config.poolContractId,
+        'get_rate_history',
+        [new Address(token).toScVal(), nativeToScVal(limit, { type: 'u32' })],
+        SIMULATION_SOURCE_ACCOUNT,
+      );
+      if (StellarRpc.Api.isSimulationError(sim)) {
+        throw new Error(`Simulation failed: ${sim.error}`);
+      }
+      const raw = scValToNative(sim.result!.retval) as Record<string, unknown>[];
+      return (raw ?? []).map((r) => ({
+        timestamp: Number(r.timestamp),
+        utilizationBps: Number(r.utilization_bps),
+        rateBps: Number(r.rate_bps),
+      }));
+    },
+
+    /** What the rate would be at a hypothetical utilization (bps). */
+    previewRateAtUtilization: async (token: string, utilizationBps: number): Promise<number> => {
+      const sim = await simulateTx(
+        this.server,
+        this.config.network,
+        this.config.poolContractId,
+        'preview_rate_at_utilization',
+        [new Address(token).toScVal(), nativeToScVal(utilizationBps, { type: 'u32' })],
+        SIMULATION_SOURCE_ACCOUNT,
+      );
+      if (StellarRpc.Api.isSimulationError(sim)) {
+        throw new Error(`Simulation failed: ${sim.error}`);
+      }
+      return Number(scValToNative(sim.result!.retval));
+    },
+
+    /** Admin: propose new curve parameters (executable after the yield timelock). */
+    proposeRateModelChange: async (params: {
+      signer: (txXdr: string) => Promise<string>;
+      admin: string;
+      token: string;
+      config: RateModelConfig;
+      onProgress?: (progress: TransactionProgress) => void;
+    }): Promise<string> => {
+      const account = await this.server.getAccount(params.admin);
+      const contract = new Contract(this.config.poolContractId);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.config.network,
+      })
+        .addOperation(
+          contract.call(
+            'propose_rate_model_change',
+            new Address(params.admin).toScVal(),
+            new Address(params.token).toScVal(),
+            rateModelConfigToScVal(params.config),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (StellarRpc.Api.isSimulationError(sim)) {
+        throw new Error(`Simulation failed: ${sim.error}`);
+      }
+
+      const prepared = StellarRpc.assembleTransaction(tx, sim).build();
+      const signedXdr = await params.signer(prepared.toXDR());
+      const result = await this.submitTx(signedXdr, params.onProgress);
+      return result.hash;
+    },
+
+    /** Anyone: execute a rate-model proposal once its timelock has elapsed. */
+    executeRateModelChange: async (params: {
+      signer: (txXdr: string) => Promise<string>;
+      caller: string;
+      token: string;
+      onProgress?: (progress: TransactionProgress) => void;
+    }): Promise<string> => {
+      const account = await this.server.getAccount(params.caller);
+      const contract = new Contract(this.config.poolContractId);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.config.network,
+      })
+        .addOperation(
+          contract.call('execute_rate_model_change', new Address(params.token).toScVal()),
+        )
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (StellarRpc.Api.isSimulationError(sim)) {
+        throw new Error(`Simulation failed: ${sim.error}`);
+      }
+
+      const prepared = StellarRpc.assembleTransaction(tx, sim).build();
+      const signedXdr = await params.signer(prepared.toXDR());
+      const result = await this.submitTx(signedXdr, params.onProgress);
+      return result.hash;
+    },
+
+    /** Admin: cancel a pending rate-model proposal. */
+    cancelRateModelChange: async (params: {
+      signer: (txXdr: string) => Promise<string>;
+      admin: string;
+      token: string;
+      onProgress?: (progress: TransactionProgress) => void;
+    }): Promise<string> => {
+      const account = await this.server.getAccount(params.admin);
+      const contract = new Contract(this.config.poolContractId);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.config.network,
+      })
+        .addOperation(
+          contract.call(
+            'cancel_rate_model_change',
+            new Address(params.admin).toScVal(),
+            new Address(params.token).toScVal(),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (StellarRpc.Api.isSimulationError(sim)) {
+        throw new Error(`Simulation failed: ${sim.error}`);
+      }
+
+      const prepared = StellarRpc.assembleTransaction(tx, sim).build();
+      const signedXdr = await params.signer(prepared.toXDR());
+      const result = await this.submitTx(signedXdr, params.onProgress);
+      return result.hash;
     },
 
     requestWithdrawal: async (params: {

--- a/sdk/src/generated/pool.ts
+++ b/sdk/src/generated/pool.ts
@@ -78,6 +78,11 @@ export const Errors = {
   75: { message: 'CoFundingRoundNotFilled' },
   76: { message: 'CoFundingTooManyParticipants' },
   77: { message: 'InvalidCoFundingParams' },
+  78: { message: 'WithdrawalQueueFull' },
+  79: { message: 'InvalidRateModelConfig' },
+  80: { message: 'RateModelNotConfigured' },
+  81: { message: 'RateModelProposalNotFound' },
+  82: { message: 'RateModelChangeNotReady' },
 } as const;
 
 export type PoolErrorCode = keyof typeof Errors;

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -52,6 +52,27 @@ export interface PoolConfig {
   compoundInterest: boolean;
 }
 
+// #863: utilization-driven kinked interest-rate model
+
+export interface RateModelConfig {
+  /** Rate (bps) at 0% utilization. */
+  baseRateBps: number;
+  /** The "kink" point in bps (e.g. 8000 = 80%). */
+  optimalUtilizationBps: number;
+  /** Rate increase (bps) spread across the 0..optimal span. */
+  slope1Bps: number;
+  /** Rate increase (bps) spread across the optimal..100% span (steeper). */
+  slope2Bps: number;
+  /** Hard ceiling on the computed rate. */
+  maxRateBps: number;
+}
+
+export interface RateSnapshot {
+  timestamp: number;
+  utilizationBps: number;
+  rateBps: number;
+}
+
 // #865: withdrawal-queue completion + liquidity forecasting
 
 export interface WithdrawalRequest {


### PR DESCRIPTION
## Summary

Closes #863. Replaces the pool's flat admin-set `yield_bps` with an Aave/Compound-style **utilization-driven kinked interest rate model**, so new invoice fundings reprice with real-time supply/demand while already-funded invoices keep rate certainty.

### Contract (`contracts/pool`)
- New per-token `RateModelConfig` (`base_rate_bps`, `optimal_utilization_bps`, `slope1_bps`, `slope2_bps`, `max_rate_bps`)
- Pure `compute_current_rate` two-slope curve (overflow-safe, unit-testable, no env dependency)
- `FundedInvoice.locked_yield_bps` snapshots the live rate **at funding time**; `calculate_total_due` / repay / estimate all use the locked rate (never retroactive reprice)
- Timelocked governance: `propose_rate_model_change` / `execute_rate_model_change` / `cancel_rate_model_change` (reuses yield cooldown + 48h timelock pattern)
- Bounded rate-history ring buffer (720 samples) + `rate_snap` events
- Views: `get_current_rate`, `get_rate_model_config`, `get_rate_history`, `preview_rate_at_utilization`
- Static `set_yield` / `propose_yield_change` kept as emergency fallback for tokens **without** a configured model; once a curve is set it takes sole precedence for that token's new fundings

### Tests
- `contracts/pool/tests/rate_model_tests.rs` — pure curve vectors (0%, kink±1, 100%, clamp), locked-rate repayment across utilization changes, ring-buffer eviction + chronological order, timelock lifecycle, invalid config, backward compatibility
- Monotonicity property test in `fuzz_tests.rs`

### SDK / Indexer / Frontend
- SDK: `getCurrentRate`, `getRateModelConfig`, `getRateHistory`, `previewRateAtUtilization`, `proposeRateModelChange` / `executeRateModelChange` / `cancelRateModelChange`
- Indexer: `GET /pool/:token/rate-history?from=&to=` from `rate_snap` events
- Frontend: `RateCurveChart` on analytics + invest; APY calculator + scenario modeler pull the live curve rate; admin yield page gains a curve-parameter editor with live preview before the timelocked proposal

## Test plan

- [x] `cd contracts/pool && cargo fmt && cargo clippy -p pool -- -D warnings && cargo test`
- [x] `cargo test --test rate_model_tests` (24/24)
- [x] `cargo test --test fuzz_tests prop_rate_curve_monotonic_in_utilization`
- [x] Existing yield timelock + integration tests still pass (backward compat)
- [x] SDK `tsc` / `tsup` build
- [x] Indexer `tsc` build
- [x] Frontend `tsc`, `jest` (243 tests incl. new rate-model vectors), `next build`
- [ ] Manual: propose → wait timelock → execute rate model on a testnet token; fund two invoices at different utilizations and confirm distinct `locked_yield_bps`; repay first after utilization moves and confirm interest uses the original lock

## Notes
- Adding `locked_yield_bps` to `FundedInvoice` is a storage-layout change. Fresh deploys / test envs are fine; a mainnet upgrade should bump `CURRENT_MIGRATION_VERSION` and backfill existing funded invoices (e.g. with then-current `yield_bps`) before reading the new field.