### PR TITLE
Feat/referral keeper and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,7 @@ version = "0.1.0"
 dependencies = [
  "compliance",
  "proptest",
+ "referral",
  "soroban-sdk",
 ]
 
@@ -1236,6 +1237,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "referral"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "contracts/governance",
     "contracts/oracle_registry",
     "contracts/compliance",
+    "contracts/referral",
     "contracts/tests",
     "benchmarks",
 ]

--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -5,6 +5,7 @@
 // - Admin: initialize(), admin-only setters
 // - Pool contract: mark_funded(), mark_paid(), mark_defaulted()
 // - Oracle: mark_verified(), mark_disputed()
+// - Keeper (#801): mark_defaulted() only — no other admin/pool privileges
 // - Anyone: cleanup_expired_storage(), read-only view functions (e.g., get_invoice)
 
 use soroban_sdk::{
@@ -159,6 +160,9 @@ pub enum InvoiceError {
     ComplianceNotCleared = 38,
     ComplianceCheckFailed = 39,
     ComplianceRegistryNotConfigured = 40,
+    // #798: create_invoice() input validation
+    InvalidAmount = 41,
+    InvalidDueDate = 42,
 }
 
 #[contracttype]
@@ -315,6 +319,10 @@ pub enum DataKey {
     // #867: optional compliance registry + opt-in gate
     ComplianceRegistry,
     RequireComplianceCheck,
+    // #801: keeper allowlist — addresses permitted to call mark_defaulted()
+    // on behalf of an automated monitor (e.g. Stellar Turrets), in addition
+    // to the pool contract.
+    KeeperIds,
 }
 
 const EVT: Symbol = symbol_short!("INVOICE");
@@ -628,6 +636,17 @@ fn resolve_invoice_grace_period_days(env: &Env, invoice: &Invoice) -> u32 {
         .get(&DataKey::GracePeriodDays)
         .unwrap_or(DEFAULT_GRACE_PERIOD_DAYS);
     invoice.grace_period_override.unwrap_or(global_grace)
+}
+
+/// #801: whether `address` is a whitelisted keeper allowed to call
+/// `mark_defaulted()` on behalf of an automated monitor.
+fn is_keeper(env: &Env, address: &Address) -> bool {
+    let keepers: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKey::KeeperIds)
+        .unwrap_or_else(|| Vec::new(env));
+    keepers.contains(address)
 }
 
 fn validate_due_date(env: &Env, due_date: u64) {
@@ -1107,6 +1126,75 @@ impl InvoiceContract {
             .unwrap_or(false)
     }
 
+    /// #801: whitelist `keeper` as an address permitted to call
+    /// `mark_defaulted()`. Admin-only; a keeper cannot call any other
+    /// admin- or pool-gated function.
+    pub fn add_keeper(env: Env, admin: Address, keeper: Address) {
+        admin.require_auth();
+        require_not_paused(&env);
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic_with_error!(&env, InvoiceError::Unauthorized);
+        }
+        let mut keepers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::KeeperIds)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !keepers.contains(&keeper) {
+            keepers.push_back(keeper.clone());
+            env.storage().instance().set(&DataKey::KeeperIds, &keepers);
+        }
+        bump_instance(&env);
+        env.events()
+            .publish((EVT, Symbol::new(&env, "keeper_added")), (admin, keeper));
+    }
+
+    /// #801: revoke a previously whitelisted keeper. Admin-only.
+    pub fn remove_keeper(env: Env, admin: Address, keeper: Address) {
+        admin.require_auth();
+        require_not_paused(&env);
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic_with_error!(&env, InvoiceError::Unauthorized);
+        }
+        let keepers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::KeeperIds)
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut remaining: Vec<Address> = Vec::new(&env);
+        for i in 0..keepers.len() {
+            let k = keepers.get(i).unwrap();
+            if k != keeper {
+                remaining.push_back(k);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::KeeperIds, &remaining);
+        bump_instance(&env);
+        env.events()
+            .publish((EVT, Symbol::new(&env, "keeper_removed")), (admin, keeper));
+    }
+
+    /// #801: list all whitelisted keeper addresses.
+    pub fn list_keepers(env: Env) -> Vec<Address> {
+        bump_instance(&env);
+        env.storage()
+            .instance()
+            .get(&DataKey::KeeperIds)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
     pub fn get_metadata_image_uri(env: Env) -> String {
         env.storage()
             .persistent()
@@ -1186,7 +1274,7 @@ impl InvoiceContract {
             }
         }
         if amount <= 0 {
-            panic!("amount must be positive");
+            panic_with_error!(&env, InvoiceError::InvalidAmount);
         }
         let max_invoice_amount: i128 = env
             .storage()
@@ -1195,6 +1283,11 @@ impl InvoiceContract {
             .expect("max invoice amount not set");
         if amount > max_invoice_amount {
             panic!("invoice amount exceeds maximum");
+        }
+        // #798: due_date must lie in the future regardless of the
+        // admin-configurable min-due-date window (which may be set to 0).
+        if due_date <= env.ledger().timestamp() {
+            panic_with_error!(&env, InvoiceError::InvalidDueDate);
         }
         validate_min_due_date_window(&env, due_date);
         validate_due_date(&env, due_date);
@@ -1778,6 +1871,10 @@ impl InvoiceContract {
         );
     }
 
+    /// #801: callable by the pool contract (existing flow) or by a
+    /// whitelisted keeper — e.g. an automated Turret/cron monitor that
+    /// triggers defaults once the grace period has expired. Keepers may
+    /// only call this function; they hold no other admin privileges.
     pub fn mark_defaulted(env: Env, id: u64, pool: Address) {
         pool.require_auth();
         require_not_paused(&env);
@@ -1787,8 +1884,8 @@ impl InvoiceContract {
             .instance()
             .get(&DataKey::Pool)
             .expect("not initialized");
-        if pool != authorized_pool {
-            panic!("unauthorized pool");
+        if pool != authorized_pool && !is_keeper(&env, &pool) {
+            panic_with_error!(&env, InvoiceError::Unauthorized);
         }
         let mut invoice: Invoice = env
             .storage()
@@ -3255,13 +3352,13 @@ mod test {
         assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Paid);
     }
 
+    // #798: create_invoice() input validation — amount and due_date
     #[test]
-    #[should_panic(expected = "amount must be positive")]
-    fn test_create_invoice_zero_amount_panics() {
+    fn test_create_invoice_zero_amount_returns_invalid_amount() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, _admin, _pool, sme) = setup(&env);
-        client.create_invoice(
+        let result = client.try_create_invoice(
             &sme,
             &String::from_str(&env, "X"),
             &0i128,
@@ -3270,16 +3367,43 @@ mod test {
             &String::from_str(&env, "h"),
             &String::from_str(&env, "https://example.com/meta"),
         );
+        assert_eq!(
+            result,
+            Err(Ok::<soroban_sdk::Error, _>(
+                InvoiceError::InvalidAmount.into()
+            ))
+        );
     }
 
     #[test]
-    #[should_panic(expected = "Error(Contract, #23)")]
-    fn test_create_invoice_past_due_date_panics() {
+    fn test_create_invoice_negative_amount_returns_invalid_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _pool, sme) = setup(&env);
+        let result = client.try_create_invoice(
+            &sme,
+            &String::from_str(&env, "X"),
+            &-1i128,
+            &(env.ledger().timestamp() + 1),
+            &String::from_str(&env, "d"),
+            &String::from_str(&env, "h"),
+            &String::from_str(&env, "https://example.com/meta"),
+        );
+        assert_eq!(
+            result,
+            Err(Ok::<soroban_sdk::Error, _>(
+                InvoiceError::InvalidAmount.into()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_create_invoice_past_due_date_returns_invalid_due_date() {
         let env = Env::default();
         env.mock_all_auths();
         env.ledger().with_mut(|l| l.timestamp = 1_000_000);
         let (client, _admin, _pool, sme) = setup(&env);
-        client.create_invoice(
+        let result = client.try_create_invoice(
             &sme,
             &String::from_str(&env, "X"),
             &100i128,
@@ -3287,6 +3411,12 @@ mod test {
             &String::from_str(&env, "d"),
             &String::from_str(&env, "h"),
             &String::from_str(&env, "https://example.com/meta"),
+        );
+        assert_eq!(
+            result,
+            Err(Ok::<soroban_sdk::Error, _>(
+                InvoiceError::InvalidDueDate.into()
+            ))
         );
     }
 
@@ -3869,6 +3999,80 @@ mod test {
             .with_mut(|l| l.timestamp = due + (15 * SECS_PER_DAY));
         client.mark_defaulted(&id, &pool);
         assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Defaulted);
+    }
+
+    // #801: keeper role
+    #[test]
+    fn test_keeper_can_mark_defaulted_after_grace_period() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _pool, _owner) = setup_funded_invoice(&env);
+        let keeper = Address::generate(&env);
+        client.add_keeper(&admin, &keeper);
+        assert_eq!(client.list_keepers(), soroban_sdk::vec![&env, keeper.clone()]);
+
+        let id = 1u64;
+        let due = client.get_invoice(&id).due_date;
+        env.ledger()
+            .with_mut(|l| l.timestamp = due + (DEFAULT_GRACE_PERIOD_DAYS as u64 + 1) * SECS_PER_DAY);
+
+        client.mark_defaulted(&id, &keeper);
+        assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Defaulted);
+    }
+
+    #[test]
+    fn test_non_keeper_cannot_mark_defaulted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _pool, _owner) = setup_funded_invoice(&env);
+        let stranger = Address::generate(&env);
+
+        let id = 1u64;
+        let due = client.get_invoice(&id).due_date;
+        env.ledger()
+            .with_mut(|l| l.timestamp = due + (DEFAULT_GRACE_PERIOD_DAYS as u64 + 1) * SECS_PER_DAY);
+
+        let result = client.try_mark_defaulted(&id, &stranger);
+        assert_eq!(
+            result,
+            Err(Ok::<soroban_sdk::Error, _>(InvoiceError::Unauthorized.into()))
+        );
+    }
+
+    #[test]
+    fn test_removed_keeper_cannot_mark_defaulted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _pool, _owner) = setup_funded_invoice(&env);
+        let keeper = Address::generate(&env);
+        client.add_keeper(&admin, &keeper);
+        client.remove_keeper(&admin, &keeper);
+        assert_eq!(client.list_keepers().len(), 0);
+
+        let id = 1u64;
+        let due = client.get_invoice(&id).due_date;
+        env.ledger()
+            .with_mut(|l| l.timestamp = due + (DEFAULT_GRACE_PERIOD_DAYS as u64 + 1) * SECS_PER_DAY);
+
+        let result = client.try_mark_defaulted(&id, &keeper);
+        assert_eq!(
+            result,
+            Err(Ok::<soroban_sdk::Error, _>(InvoiceError::Unauthorized.into()))
+        );
+    }
+
+    #[test]
+    fn test_add_keeper_non_admin_returns_typed_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _pool, _sme) = setup(&env);
+        let attacker = Address::generate(&env);
+        let keeper = Address::generate(&env);
+        let result = client.try_add_keeper(&attacker, &keeper);
+        assert_eq!(
+            result,
+            Err(Ok::<soroban_sdk::Error, _>(InvoiceError::Unauthorized.into()))
+        );
     }
 
     #[test]

--- a/contracts/pool/Cargo.toml
+++ b/contracts/pool/Cargo.toml
@@ -13,6 +13,7 @@ soroban-sdk = { workspace = true }
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
 proptest = "1.4"
 compliance = { path = "../compliance" }
+referral = { path = "../referral" }
 
 [[test]]
 name = "fuzz_tests"

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -713,6 +713,9 @@ const EVT: Symbol = symbol_short!("POOL");
 // #867: stored under a Symbol key (not DataKey) — pool DataKey is already at
 // the Soroban 50-variant ceiling after #863.
 const COMPLIANCE_CFG: Symbol = symbol_short!("cmp_cfg");
+// #799: referral registry address — also stored under a Symbol key rather
+// than a DataKey variant, for the same reason as COMPLIANCE_CFG above.
+const REFERRAL_CFG: Symbol = symbol_short!("ref_cfg");
 
 #[contractclient(name = "CreditScoreClient")]
 pub trait CreditScoreContract {
@@ -731,6 +734,22 @@ pub trait InvoiceContract {
 #[contractclient(name = "ComplianceClient")]
 pub trait ComplianceContract {
     fn is_cleared(env: Env, address: Address) -> bool;
+}
+
+/// #799: cross-contract interface to the referral program. `kind` is
+/// `"borrow"` or `"deposit"`; returns the reward amount (if any) credited
+/// to the referee's referrer, which the pool must then transfer to the
+/// referral contract.
+#[contractclient(name = "ReferralClient")]
+pub trait ReferralContract {
+    fn record_activity(
+        env: Env,
+        caller: Address,
+        referee: Address,
+        kind: Symbol,
+        fee_amount: i128,
+        token: Address,
+    ) -> i128;
 }
 
 // Cache for config to reduce storage reads
@@ -2112,6 +2131,11 @@ impl FundingPool {
         // has arrived — don't wait solely for the next repayment (mirrors the same
         // best-effort, non-blocking pattern used in repay_invoice_request).
         record_inflow_event(&env, &token, usdc_received);
+        // #799: activates the referral on this investor's first deposit.
+        // The pool has no separate yield fee to share yet, so fee_amount is
+        // 0 here — record_referral_activity is a no-op reward-wise but
+        // still records the qualifying activity / referral count.
+        Self::record_referral_activity(&env, &investor, symbol_short!("deposit"), 0, &token);
         let post_deposit_liquidity = available_liquidity(&tt).unwrap_or(0);
         if let Err(e) = Self::process_withdrawal_queue(&env, token, post_deposit_liquidity) {
             let _ = e;
@@ -3357,6 +3381,16 @@ impl FundingPool {
                 let _ = e;
                 env.logs().add("Failed to process withdrawal queue", &[]);
             }
+
+            // #799: pay the referrer (if any) their cut of the
+            // factoring fee just realized above.
+            Self::record_referral_activity(
+                env,
+                &record.sme,
+                symbol_short!("borrow"),
+                record.factoring_fee,
+                &token,
+            );
 
             env.events().publish(
                 (EVT, symbol_short!("repaid")),
@@ -5348,6 +5382,49 @@ impl FundingPool {
         }
     }
 
+    /// #799: best-effort referral hook. If a referral registry is
+    /// configured, records `kind` ("borrow" or "deposit") activity for
+    /// `referee` and — if a reward was credited — moves that amount of
+    /// `token` from the pool's own balance to the referral contract so
+    /// `claim_rewards()` can pay it out, debiting the same amount from
+    /// `protocol_revenue` (the reward is a redistributed slice of the fee
+    /// already credited there, not new inflation). Never fails the caller:
+    /// an unset registry or any cross-contract error is swallowed.
+    fn record_referral_activity(env: &Env, referee: &Address, kind: Symbol, fee_amount: i128, token: &Address) {
+        if fee_amount < 0 {
+            return;
+        }
+        let registry: Option<Address> = env.storage().instance().get(&REFERRAL_CFG);
+        let Some(registry) = registry else {
+            return;
+        };
+        let client = ReferralClient::new(env, &registry);
+        let reward = match client.try_record_activity(
+            &env.current_contract_address(),
+            referee,
+            &kind,
+            &fee_amount,
+            token,
+        ) {
+            Ok(Ok(amount)) if amount > 0 => amount,
+            _ => return,
+        };
+
+        let token_totals_key = DataKey::TokenTotals(token.clone());
+        let mut tt: PoolTokenTotals = env
+            .storage()
+            .instance()
+            .get(&token_totals_key)
+            .unwrap_or_default();
+        tt.protocol_revenue = tt.protocol_revenue.saturating_sub(reward);
+        env.storage().instance().set(&token_totals_key, &tt);
+
+        let token_client = token::Client::new(env, token);
+        token_client.transfer(&env.current_contract_address(), &registry, &reward);
+        env.events()
+            .publish((EVT, symbol_short!("ref_pay")), (referee.clone(), reward));
+    }
+
     fn require_not_paused(env: &Env) {
         require_not_paused(env);
     }
@@ -5516,6 +5593,27 @@ impl FundingPool {
             .get::<Symbol, ComplianceGateConfig>(&COMPLIANCE_CFG)
             .map(|g| g.required)
             .unwrap_or(false)
+    }
+
+    // ---- #799: Referral program integration ----
+
+    /// Set the referral contract address. When set, a referrer's cut of a
+    /// referee's factoring fee (on invoice repayment) or deposit is routed
+    /// there automatically. Unset by default — existing deployments and
+    /// tests are unaffected until an admin opts in.
+    pub fn set_referral_registry(env: Env, admin: Address, registry: Address) -> Result<(), PoolError> {
+        admin.require_auth();
+        bump_instance(&env);
+        Self::require_admin(&env, &admin)?;
+        env.storage().instance().set(&REFERRAL_CFG, &registry);
+        env.events()
+            .publish((EVT, symbol_short!("ref_set")), (admin, registry));
+        Ok(())
+    }
+
+    pub fn get_referral_registry(env: Env) -> Option<Address> {
+        bump_instance(&env);
+        env.storage().instance().get(&REFERRAL_CFG)
     }
 
     // ---- #109: Investor KYC / whitelist methods ----
@@ -6477,6 +6575,91 @@ mod test {
         assert_eq!(tt.total_paid_out, expected_total_due);
         // pool_value grew by the yield
         assert!(tt.pool_value >= principal);
+    }
+
+    // #799: referral program integration — the pool contract pays a
+    // referrer their configured cut of a referee's factoring fee.
+    #[test]
+    fn test_referral_reward_paid_on_invoice_repayment() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+        let referrer = Address::generate(&env);
+
+        let referral_id = env.register(referral::ReferralContract, ());
+        let referral_client = referral::ReferralContractClient::new(&env, &referral_id);
+        referral_client.initialize(&admin, &client.address);
+        referral_client.register(&sme, &referrer);
+        client.set_referral_registry(&admin, &referral_id);
+
+        let principal: i128 = 1_000_000_000;
+        mint(&env, &usdc_id, &investor, principal);
+        mint(&env, &usdc_id, &sme, principal * 2);
+
+        // 2.5% factoring fee; default referral borrow reward is 5% of that fee.
+        client.set_factoring_fee(&admin, &250);
+        client.deposit(&investor, &usdc_id, &principal);
+        client.fund_invoice(
+            &admin,
+            &1u64,
+            &principal,
+            &sme,
+            &(env.ledger().timestamp() + 30 * 86_400),
+            &usdc_id,
+        );
+
+        let expected_fee = principal * 250 / BPS_DENOM as i128;
+        let expected_reward = expected_fee * 500 / BPS_DENOM as i128;
+
+        env.ledger().with_mut(|l| l.timestamp += 30 * 86_400);
+        let total_due = client.estimate_repayment(&1u64, &None);
+        client.repay_invoice(&1u64, &sme, &total_due);
+
+        // Referrer's reward is credited and actually funded on the referral contract.
+        assert_eq!(
+            referral_client.get_pending_reward(&referrer, &usdc_id),
+            expected_reward
+        );
+        assert_eq!(referral_client.get_stats(&referrer).referral_count, 1);
+        let usdc_client = soroban_sdk::token::Client::new(&env, &usdc_id);
+        assert_eq!(usdc_client.balance(&referral_id), expected_reward);
+
+        // The reward is carved out of protocol_revenue, not paid on top of it.
+        let tt = client.get_token_totals(&usdc_id);
+        assert_eq!(tt.total_fee_revenue, expected_fee);
+        assert_eq!(tt.protocol_revenue, expected_fee - expected_reward);
+
+        // Referrer can claim it.
+        let claimed = referral_client.claim_rewards(&referrer, &usdc_id);
+        assert_eq!(claimed, expected_reward);
+        assert_eq!(usdc_client.balance(&referrer), expected_reward);
+    }
+
+    #[test]
+    fn test_referral_activates_on_first_deposit() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, admin, usdc_id, _share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let referrer = Address::generate(&env);
+
+        let referral_id = env.register(referral::ReferralContract, ());
+        let referral_client = referral::ReferralContractClient::new(&env, &referral_id);
+        referral_client.initialize(&admin, &client.address);
+        referral_client.register(&investor, &referrer);
+        client.set_referral_registry(&admin, &referral_id);
+
+        mint(&env, &usdc_id, &investor, 10_000);
+        client.deposit(&investor, &usdc_id, &1_000i128);
+
+        // No pool-level yield fee exists yet, so the deposit earns no
+        // reward — but the referral is still activated/counted.
+        assert_eq!(referral_client.get_stats(&referrer).referral_count, 1);
+        assert_eq!(referral_client.get_pending_reward(&referrer, &usdc_id), 0);
     }
 
     #[test]

--- a/contracts/referral/Cargo.toml
+++ b/contracts/referral/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "referral"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[[test]]
+name = "lifecycle_tests"
+path = "tests/lifecycle_tests.rs"

--- a/contracts/referral/src/lib.rs
+++ b/contracts/referral/src/lib.rs
@@ -1,0 +1,381 @@
+#![no_std]
+
+// === AUTHORIZED CALLERS ===
+// - Admin: initialize(), set_pool(), set_borrow_reward_bps(),
+//   set_deposit_reward_bps(), pause()/unpause()
+// - Referee (new user): register()
+// - Pool contract: record_activity()
+// - Referrer: claim_rewards()
+// - Anyone: read-only view functions (get_stats, get_referrer, get_pending_reward)
+//
+// #799: on-chain referral program. A referee names their referrer once via
+// register(). The pool contract calls record_activity() whenever it
+// realizes a fee attributable to a referred user (a repaid invoice's
+// factoring fee, or — once the pool has a yield fee to share — a deposit),
+// which both activates the referral (counted once) and credits the
+// referrer's pending reward. Referrers withdraw accrued rewards via
+// claim_rewards(); the pool contract is responsible for actually
+// transferring each reward amount to this contract at the moment it's
+// credited (see record_activity's return value).
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
+    Address, Env, Symbol,
+};
+
+const LEDGERS_PER_DAY: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = LEDGERS_PER_DAY * 30;
+const INSTANCE_LIFETIME_THRESHOLD: u32 = LEDGERS_PER_DAY * 7;
+const REGISTRY_TTL: u32 = LEDGERS_PER_DAY * 365;
+
+const BPS_DENOM: i128 = 10_000;
+const MAX_BPS: u32 = 10_000;
+/// Referee borrows: referrer earns 5% of factoring fees from their invoices.
+const DEFAULT_BORROW_REWARD_BPS: u32 = 500;
+/// Referee deposits: referrer earns 10% of the yield fee from their deposits.
+const DEFAULT_DEPOSIT_REWARD_BPS: u32 = 1_000;
+
+const EVT: Symbol = symbol_short!("REFERRAL");
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ReferralError {
+    AlreadyInitialized = 0,
+    Unauthorized = 1,
+    AlreadyRegistered = 2,
+    SelfReferral = 3,
+    InvalidBps = 4,
+    ContractPaused = 5,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReferralStats {
+    pub referrer: Address,
+    pub referral_count: u32,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Pool,
+    Initialized,
+    Paused,
+    BorrowRewardBps,
+    DepositRewardBps,
+    /// referee -> referrer
+    Referrer(Address),
+    /// referee -> has earned at least one reward yet (locks referrer, and
+    /// gates the one-time ReferralCount increment)
+    Activated(Address),
+    /// (referrer, token) -> unclaimed reward balance
+    PendingReward(Address, Address),
+    /// referrer -> number of referees who have completed a qualifying
+    /// activity
+    ReferralCount(Address),
+}
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+fn require_not_paused(env: &Env) {
+    if env
+        .storage()
+        .instance()
+        .get::<DataKey, bool>(&DataKey::Paused)
+        .unwrap_or(false)
+    {
+        panic_with_error!(env, ReferralError::ContractPaused);
+    }
+}
+
+fn require_admin(env: &Env, admin: &Address) {
+    let stored_admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .expect("not initialized");
+    if admin != &stored_admin {
+        panic_with_error!(env, ReferralError::Unauthorized);
+    }
+}
+
+#[contract]
+pub struct ReferralContract;
+
+#[contractimpl]
+impl ReferralContract {
+    pub fn initialize(env: Env, admin: Address, pool: Address) {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            panic_with_error!(&env, ReferralError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Pool, &pool);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::BorrowRewardBps, &DEFAULT_BORROW_REWARD_BPS);
+        env.storage()
+            .instance()
+            .set(&DataKey::DepositRewardBps, &DEFAULT_DEPOSIT_REWARD_BPS);
+        bump_instance(&env);
+    }
+
+    pub fn pause(env: Env, admin: Address) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+        env.storage().instance().set(&DataKey::Paused, &true);
+        bump_instance(&env);
+        env.events().publish((EVT, symbol_short!("paused")), admin);
+    }
+
+    pub fn unpause(env: Env, admin: Address) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        bump_instance(&env);
+        env.events()
+            .publish((EVT, symbol_short!("unpaused")), admin);
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get::<DataKey, bool>(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    /// Update the pool contract address authorized to call record_activity().
+    pub fn set_pool(env: Env, admin: Address, pool: Address) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+        env.storage().instance().set(&DataKey::Pool, &pool);
+        bump_instance(&env);
+        env.events()
+            .publish((EVT, symbol_short!("pool_set")), (admin, pool));
+    }
+
+    pub fn get_pool(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .expect("not initialized")
+    }
+
+    /// Admin-configurable share (bps) of the factoring fee a referrer earns
+    /// when their referee's invoice is repaid.
+    pub fn set_borrow_reward_bps(env: Env, admin: Address, bps: u32) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+        if bps > MAX_BPS {
+            panic_with_error!(&env, ReferralError::InvalidBps);
+        }
+        env.storage().instance().set(&DataKey::BorrowRewardBps, &bps);
+        bump_instance(&env);
+        env.events()
+            .publish((EVT, symbol_short!("brw_bps")), (admin, bps));
+    }
+
+    /// Admin-configurable share (bps) of the yield fee a referrer earns
+    /// from their referee's deposits.
+    pub fn set_deposit_reward_bps(env: Env, admin: Address, bps: u32) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+        if bps > MAX_BPS {
+            panic_with_error!(&env, ReferralError::InvalidBps);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::DepositRewardBps, &bps);
+        bump_instance(&env);
+        env.events()
+            .publish((EVT, symbol_short!("dep_bps")), (admin, bps));
+    }
+
+    pub fn get_borrow_reward_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::BorrowRewardBps)
+            .unwrap_or(DEFAULT_BORROW_REWARD_BPS)
+    }
+
+    pub fn get_deposit_reward_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::DepositRewardBps)
+            .unwrap_or(DEFAULT_DEPOSIT_REWARD_BPS)
+    }
+
+    /// Register `referrer` as the caller's referrer. Callable once per
+    /// referee — the referrer cannot be changed afterwards (#799).
+    pub fn register(env: Env, referee: Address, referrer: Address) {
+        referee.require_auth();
+        require_not_paused(&env);
+        if referee == referrer {
+            panic_with_error!(&env, ReferralError::SelfReferral);
+        }
+        let key = DataKey::Referrer(referee.clone());
+        if env.storage().persistent().has(&key) {
+            panic_with_error!(&env, ReferralError::AlreadyRegistered);
+        }
+        env.storage().persistent().set(&key, &referrer);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, REGISTRY_TTL, REGISTRY_TTL);
+        bump_instance(&env);
+        env.events()
+            .publish((EVT, symbol_short!("registerd")), (referee, referrer));
+    }
+
+    pub fn get_referrer(env: Env, referee: Address) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::Referrer(referee))
+    }
+
+    /// Records a qualifying activity (`kind` is `"borrow"` or `"deposit"`)
+    /// for `referee`. Callable only by the configured pool contract.
+    ///
+    /// On the referee's first qualifying activity this activates the
+    /// referral, incrementing the referrer's `ReferralCount` exactly once.
+    /// Every qualifying activity (including the first) credits the
+    /// referrer's pending balance with `fee_amount * bps / 10_000` of
+    /// `token`, using the borrow or deposit reward rate as appropriate.
+    /// Returns the reward amount credited (0 if the referee has no
+    /// referrer, or `fee_amount` is not positive) — the pool contract is
+    /// expected to transfer that exact amount of `token` to this contract.
+    pub fn record_activity(
+        env: Env,
+        caller: Address,
+        referee: Address,
+        kind: Symbol,
+        fee_amount: i128,
+        token: Address,
+    ) -> i128 {
+        caller.require_auth();
+        require_not_paused(&env);
+        let pool: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .expect("not initialized");
+        if caller != pool {
+            panic_with_error!(&env, ReferralError::Unauthorized);
+        }
+        let referrer: Address = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::Referrer(referee.clone()))
+        {
+            Some(r) => r,
+            None => return 0,
+        };
+
+        // #799: activation (first qualifying action, counted once) happens
+        // regardless of fee_amount — a $0-fee first deposit still "records
+        // the referral on-chain" per the program design. Only the reward
+        // accrual below is gated on there being a positive fee to share.
+        let activated_key = DataKey::Activated(referee.clone());
+        if !env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&activated_key)
+            .unwrap_or(false)
+        {
+            env.storage().persistent().set(&activated_key, &true);
+            env.storage()
+                .persistent()
+                .extend_ttl(&activated_key, REGISTRY_TTL, REGISTRY_TTL);
+            let count_key = DataKey::ReferralCount(referrer.clone());
+            let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+            env.storage().persistent().set(&count_key, &(count + 1));
+            env.storage()
+                .persistent()
+                .extend_ttl(&count_key, REGISTRY_TTL, REGISTRY_TTL);
+            env.events().publish(
+                (EVT, symbol_short!("activatd")),
+                (referee.clone(), referrer.clone()),
+            );
+        }
+
+        if fee_amount <= 0 {
+            return 0;
+        }
+
+        let bps: u32 = if kind == symbol_short!("borrow") {
+            Self::get_borrow_reward_bps(env.clone())
+        } else {
+            Self::get_deposit_reward_bps(env.clone())
+        };
+        // #799: floor (not ceiling) — this is a payout carved out of an
+        // already-collected fee, so rounding in the protocol's favor
+        // (never overpaying the referrer) is the safe direction.
+        let reward = fee_amount.saturating_mul(bps as i128) / BPS_DENOM;
+        if reward > 0 {
+            let reward_key = DataKey::PendingReward(referrer.clone(), token);
+            let pending: i128 = env.storage().persistent().get(&reward_key).unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&reward_key, &(pending + reward));
+            env.storage()
+                .persistent()
+                .extend_ttl(&reward_key, REGISTRY_TTL, REGISTRY_TTL);
+            bump_instance(&env);
+            env.events()
+                .publish((EVT, symbol_short!("accrued")), (referrer, reward));
+        }
+        reward
+    }
+
+    pub fn get_pending_reward(env: Env, referrer: Address, token: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PendingReward(referrer, token))
+            .unwrap_or(0)
+    }
+
+    /// Claim all pending rewards in `token`. Requires this contract to
+    /// actually hold the tokens — the pool contract transfers each
+    /// referrer's cut here at the moment `record_activity` credits it.
+    pub fn claim_rewards(env: Env, referrer: Address, token: Address) -> i128 {
+        referrer.require_auth();
+        require_not_paused(&env);
+        let reward_key = DataKey::PendingReward(referrer.clone(), token.clone());
+        let amount: i128 = env.storage().persistent().get(&reward_key).unwrap_or(0);
+        if amount <= 0 {
+            return 0;
+        }
+        env.storage().persistent().set(&reward_key, &0i128);
+        bump_instance(&env);
+
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(&env.current_contract_address(), &referrer, &amount);
+
+        env.events()
+            .publish((EVT, symbol_short!("claimed")), (referrer, token, amount));
+        amount
+    }
+
+    pub fn get_stats(env: Env, referrer: Address) -> ReferralStats {
+        let referral_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ReferralCount(referrer.clone()))
+            .unwrap_or(0);
+        ReferralStats {
+            referrer,
+            referral_count,
+        }
+    }
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod test {
+    // Unit tests live in tests/lifecycle_tests.rs.
+}

--- a/contracts/referral/tests/lifecycle_tests.rs
+++ b/contracts/referral/tests/lifecycle_tests.rs
@@ -1,0 +1,301 @@
+#![cfg(test)]
+
+use referral::{ReferralContract, ReferralContractClient, ReferralError};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env, Symbol,
+};
+
+fn setup(env: &Env) -> (ReferralContractClient<'_>, Address, Address) {
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    let contract_id = env.register(ReferralContract, ());
+    let client = ReferralContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let pool = Address::generate(env);
+    client.initialize(&admin, &pool);
+    (client, admin, pool)
+}
+
+fn setup_token(env: &Env) -> Address {
+    let token_admin = Address::generate(env);
+    env.register_stellar_asset_contract_v2(token_admin)
+        .address()
+}
+
+fn mint(env: &Env, token_id: &Address, to: &Address, amount: i128) {
+    token::StellarAssetClient::new(env, token_id).mint(to, &amount);
+}
+
+#[test]
+fn test_register_sets_referrer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer = Address::generate(&env);
+
+    client.register(&referee, &referrer);
+
+    assert_eq!(client.get_referrer(&referee), Some(referrer));
+}
+
+#[test]
+fn test_register_rejects_self_referral() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _pool) = setup(&env);
+    let referee = Address::generate(&env);
+
+    let result = client.try_register(&referee, &referee);
+    assert_eq!(
+        result,
+        Err(Ok::<soroban_sdk::Error, _>(ReferralError::SelfReferral.into()))
+    );
+}
+
+#[test]
+fn test_register_cannot_change_referrer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer_a = Address::generate(&env);
+    let referrer_b = Address::generate(&env);
+
+    client.register(&referee, &referrer_a);
+    let result = client.try_register(&referee, &referrer_b);
+
+    assert_eq!(
+        result,
+        Err(Ok::<soroban_sdk::Error, _>(
+            ReferralError::AlreadyRegistered.into()
+        ))
+    );
+    assert_eq!(client.get_referrer(&referee), Some(referrer_a));
+}
+
+#[test]
+fn test_record_activity_rejects_non_pool_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let token = setup_token(&env);
+    client.register(&referee, &referrer);
+
+    let attacker = Address::generate(&env);
+    let result = client.try_record_activity(
+        &attacker,
+        &referee,
+        &Symbol::new(&env, "borrow"),
+        &1_000i128,
+        &token,
+    );
+    assert_eq!(
+        result,
+        Err(Ok::<soroban_sdk::Error, _>(ReferralError::Unauthorized.into()))
+    );
+}
+
+#[test]
+fn test_record_activity_no_referrer_returns_zero_reward() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let token = setup_token(&env);
+
+    let reward = client.record_activity(
+        &pool,
+        &referee,
+        &Symbol::new(&env, "borrow"),
+        &1_000i128,
+        &token,
+    );
+    assert_eq!(reward, 0);
+}
+
+#[test]
+fn test_record_activity_activates_on_zero_fee_first_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let token = setup_token(&env);
+    client.register(&referee, &referrer);
+
+    // A $0-fee first deposit still activates (counts) the referral, even
+    // though it earns no reward (no yield fee to share yet).
+    let reward = client.record_activity(
+        &pool,
+        &referee,
+        &Symbol::new(&env, "deposit"),
+        &0i128,
+        &token,
+    );
+    assert_eq!(reward, 0);
+    assert_eq!(client.get_stats(&referrer).referral_count, 1);
+    assert_eq!(client.get_pending_reward(&referrer, &token), 0);
+}
+
+#[test]
+fn test_record_activity_credits_borrow_reward_and_activates_once() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let token = setup_token(&env);
+    client.register(&referee, &referrer);
+
+    // Default borrow bps is 500 (5%): 5% of 1_000_0000000 = 50_0000000.
+    let reward1 = client.record_activity(
+        &pool,
+        &referee,
+        &Symbol::new(&env, "borrow"),
+        &1_000_0000000i128,
+        &token,
+    );
+    assert_eq!(reward1, 50_0000000i128);
+    assert_eq!(client.get_stats(&referrer).referral_count, 1);
+    assert_eq!(
+        client.get_pending_reward(&referrer, &token),
+        50_0000000i128
+    );
+
+    // A second qualifying activity accrues more reward but does not bump
+    // referral_count again (activation is a one-time event).
+    let reward2 = client.record_activity(
+        &pool,
+        &referee,
+        &Symbol::new(&env, "borrow"),
+        &200_0000000i128,
+        &token,
+    );
+    assert_eq!(reward2, 10_0000000i128);
+    assert_eq!(client.get_stats(&referrer).referral_count, 1);
+    assert_eq!(
+        client.get_pending_reward(&referrer, &token),
+        60_0000000i128
+    );
+}
+
+#[test]
+fn test_record_activity_uses_deposit_bps_for_deposit_kind() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let token = setup_token(&env);
+    client.register(&referee, &referrer);
+
+    // Default deposit bps is 1_000 (10%): 10% of 500_0000000 = 50_0000000.
+    let reward = client.record_activity(
+        &pool,
+        &referee,
+        &Symbol::new(&env, "deposit"),
+        &500_0000000i128,
+        &token,
+    );
+    assert_eq!(reward, 50_0000000i128);
+}
+
+#[test]
+fn test_admin_can_configure_reward_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let token = setup_token(&env);
+    client.register(&referee, &referrer);
+
+    client.set_borrow_reward_bps(&admin, &1_000u32); // 10%
+    assert_eq!(client.get_borrow_reward_bps(), 1_000u32);
+
+    let reward = client.record_activity(
+        &pool,
+        &referee,
+        &Symbol::new(&env, "borrow"),
+        &1_000_0000000i128,
+        &token,
+    );
+    assert_eq!(reward, 100_0000000i128);
+}
+
+#[test]
+fn test_set_reward_bps_above_max_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _pool) = setup(&env);
+
+    let result = client.try_set_borrow_reward_bps(&admin, &10_001u32);
+    assert_eq!(
+        result,
+        Err(Ok::<soroban_sdk::Error, _>(ReferralError::InvalidBps.into()))
+    );
+}
+
+#[test]
+fn test_claim_rewards_transfers_token_and_resets_pending() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let token = setup_token(&env);
+    client.register(&referee, &referrer);
+
+    let reward = client.record_activity(
+        &pool,
+        &referee,
+        &Symbol::new(&env, "borrow"),
+        &1_000_0000000i128,
+        &token,
+    );
+    // The pool is responsible for funding this contract with the reward it
+    // just credited — mirror that here so claim_rewards has funds to pay out.
+    mint(&env, &token, &client.address, reward);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&referrer), 0);
+
+    let claimed = client.claim_rewards(&referrer, &token);
+    assert_eq!(claimed, reward);
+    assert_eq!(token_client.balance(&referrer), reward);
+    assert_eq!(client.get_pending_reward(&referrer, &token), 0);
+
+    // Claiming again with nothing pending is a harmless no-op.
+    assert_eq!(client.claim_rewards(&referrer, &token), 0);
+}
+
+#[test]
+fn test_pause_blocks_register_and_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _pool) = setup(&env);
+    let referee = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let token = setup_token(&env);
+
+    client.pause(&admin);
+
+    let result = client.try_register(&referee, &referrer);
+    assert_eq!(
+        result,
+        Err(Ok::<soroban_sdk::Error, _>(
+            ReferralError::ContractPaused.into()
+        ))
+    );
+
+    let claim_result = client.try_claim_rewards(&referrer, &token);
+    assert_eq!(
+        claim_result,
+        Err(Ok::<soroban_sdk::Error, _>(
+            ReferralError::ContractPaused.into()
+        ))
+    );
+}

--- a/docs/keeper-monitor.md
+++ b/docs/keeper-monitor.md
@@ -1,0 +1,91 @@
+# Invoice Default Keeper Monitor (#801)
+
+Invoice due-date monitoring and default triggering used to require an admin to
+manually call `mark_defaulted()` once an invoice's grace period expired. This
+document describes the `keeper` role that lets a restricted, automated
+off-chain monitor perform that call safely, and how to run it.
+
+## On-chain keeper role
+
+The invoice contract now recognizes a `keeper` allowlist in addition to the
+admin and the pool contract:
+
+| Function | Caller | Effect |
+| --- | --- | --- |
+| `add_keeper(admin, keeper)` | admin only | Whitelists `keeper` to call `mark_defaulted()`. |
+| `remove_keeper(admin, keeper)` | admin only | Revokes a keeper. |
+| `list_keepers()` | anyone (read-only) | Returns the current keeper allowlist. |
+| `mark_defaulted(id, caller)` | pool **or** a whitelisted keeper | Unchanged default logic; the grace-period check is not affected by who calls it. |
+
+A keeper address has **no other privileges** — it cannot call any other
+admin- or pool-gated function. Non-keeper, non-pool callers are rejected with
+`InvoiceError::Unauthorized`.
+
+Whitelist a keeper once, from the admin account:
+
+```bash
+soroban contract invoke \
+  --id "$INVOICE_CONTRACT_ID" \
+  --source admin \
+  --network testnet \
+  -- add_keeper --admin "$ADMIN_ADDRESS" --keeper "$KEEPER_ADDRESS"
+```
+
+## Off-chain monitor script
+
+`scripts/monitor_invoices.ts` polls the invoice contract for `Funded`
+invoices whose grace period (`due_date + grace_period_days`) has elapsed and
+submits `mark_defaulted(id, keeper)` for each, signed by the keeper key.
+
+### Setup
+
+```bash
+cd scripts
+npm install
+```
+
+### Configuration
+
+| Env var | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `INVOICE_CONTRACT_ID` | yes | — | Deployed invoice contract id. |
+| `KEEPER_SECRET_KEY` | yes | — | Secret key of the whitelisted keeper account. |
+| `RPC_URL` | no | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint. |
+| `NETWORK_PASSPHRASE` | no | `Test SDF Network ; September 2015` | Network passphrase. |
+| `POLL_INTERVAL_MS` | no | `60000` | Delay between sweeps when run continuously. |
+| `RUN_ONCE` | no | `false` | Set to `true` to perform a single sweep and exit. |
+
+### Running as a cron job
+
+Run one sweep per invocation and let cron handle scheduling:
+
+```bash
+# crontab -e
+*/15 * * * * cd /path/to/Astera/scripts && \
+  INVOICE_CONTRACT_ID=... KEEPER_SECRET_KEY=... RUN_ONCE=true \
+  npx tsx monitor_invoices.ts >> /var/log/astera-keeper.log 2>&1
+```
+
+### Running continuously (long-lived process)
+
+Omit `RUN_ONCE` and let the script poll on its own interval — suitable for a
+systemd service, Docker container, or a Stellar Turret task runner:
+
+```bash
+INVOICE_CONTRACT_ID=... KEEPER_SECRET_KEY=... npm run monitor:invoices
+```
+
+### Deploying to a Stellar Turret
+
+The script has no dependency on any specific runner — a Turret task simply
+needs to invoke `npx tsx monitor_invoices.ts` with `RUN_ONCE=true` on its own
+schedule, using the same environment variables as the cron setup above. The
+Turret's signing key must be whitelisted via `add_keeper()` beforehand.
+
+## Security notes
+
+- The keeper key should be a dedicated account funded only for transaction
+  fees — it cannot move funds or call any other contract function.
+- If a keeper key is compromised, call `remove_keeper()` from the admin
+  account immediately; this does not affect the pool contract's ability to
+  call `mark_defaulted()`.

--- a/frontend/__tests__/lib/swrConfig.test.tsx
+++ b/frontend/__tests__/lib/swrConfig.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import useSWR, { SWRConfig } from 'swr';
+import { swrConfig, MAX_RETRY_COUNT, RETRY_BASE_DELAY_MS } from '../../lib/swrConfig';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <SWRConfig value={swrConfig}>{children}</SWRConfig>;
+}
+
+// onErrorRetry doesn't read its `config` argument — a loosely-typed stand-in
+// avoids fabricating every required (but unused) PublicConfiguration field.
+const unusedConfig = swrConfig as Parameters<NonNullable<typeof swrConfig.onErrorRetry>>[2];
+
+describe('swrConfig.onErrorRetry (#800)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('schedules a retry with exponential backoff for a transient error', () => {
+    const revalidate = jest.fn();
+
+    swrConfig.onErrorRetry!(
+      new Error('network error, please retry'),
+      'some-key',
+      unusedConfig,
+      revalidate,
+      { retryCount: 0, dedupe: false },
+    );
+    expect(revalidate).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(RETRY_BASE_DELAY_MS - 1);
+    expect(revalidate).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(revalidate).toHaveBeenCalledWith({ retryCount: 0 });
+  });
+
+  it('doubles the delay on each successive retry', () => {
+    const revalidate = jest.fn();
+
+    swrConfig.onErrorRetry!(new Error('timeout'), 'key', unusedConfig, revalidate, {
+      retryCount: 2,
+      dedupe: false,
+    });
+
+    jest.advanceTimersByTime(RETRY_BASE_DELAY_MS * 2 ** 2 - 1);
+    expect(revalidate).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(revalidate).toHaveBeenCalledWith({ retryCount: 2 });
+  });
+
+  it('stops retrying once errorRetryCount is reached', () => {
+    const revalidate = jest.fn();
+
+    swrConfig.onErrorRetry!(new Error('timeout'), 'key', unusedConfig, revalidate, {
+      retryCount: MAX_RETRY_COUNT,
+      dedupe: false,
+    });
+
+    jest.advanceTimersByTime(60_000);
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a permanent "not found" error', () => {
+    const revalidate = jest.fn();
+
+    swrConfig.onErrorRetry!(new Error('invoice not found'), 'key', unusedConfig, revalidate, {
+      retryCount: 0,
+      dedupe: false,
+    });
+
+    jest.advanceTimersByTime(60_000);
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+});
+
+describe('SWR + swrConfig integration (#800)', () => {
+  // Real timers here — exercising the actual RETRY_BASE_DELAY_MS backoff
+  // through SWR's own retry engine end-to-end (not just our callback logic).
+  it('mock RPC fails twice then succeeds — data loads correctly', async () => {
+    let attempts = 0;
+    const fetcher = jest.fn(async () => {
+      attempts++;
+      if (attempts < 3) {
+        throw new Error('network error, please retry');
+      }
+      return 'ok';
+    });
+
+    const { result } = renderHook(() => useSWR('real-timer-retry-key', fetcher), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBe('ok'), { timeout: 10_000 });
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(result.current.error).toBeUndefined();
+  }, 15_000);
+});

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import CreditScore, { CreditScoreSkeleton } from '@/components/CreditScore';
 import OnboardingModal, { isFirstTimeUser } from '@/components/OnboardingModal';
 import SMEOnboardingChecklist from '@/components/SMEOnboardingChecklist';
 import TestnetFaucet from '@/components/TestnetFaucet';
+import InviteFriends from '@/components/InviteFriends';
 import PipelineBoard from '@/components/dashboard/PipelineBoard';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import {
@@ -415,6 +416,7 @@ function DashboardContent() {
             {wallet.address && (
               <div className="lg:col-span-3">
                 <TestnetFaucet address={wallet.address} />
+                <InviteFriends address={wallet.address} />
               </div>
             )}
             {/* Left column */}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import Navbar from '@/components/Navbar';
 import ThemeProvider from '@/components/ThemeProvider';
+import SWRProvider from '@/components/SWRProvider';
 import { Toaster } from 'react-hot-toast';
 import { assertEnvValid } from '@/lib/env';
 
@@ -57,13 +58,15 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           Skip to main content
         </a>
         <NextIntlClientProvider messages={messages}>
-          <ThemeProvider>
-            <Navbar />
-            <main id="main-content" role="main">
-              {children}
-            </main>
-            <Toaster position="top-right" toastOptions={{ duration: 5000 }} />
-          </ThemeProvider>
+          <SWRProvider>
+            <ThemeProvider>
+              <Navbar />
+              <main id="main-content" role="main">
+                {children}
+              </main>
+              <Toaster position="top-right" toastOptions={{ duration: 5000 }} />
+            </ThemeProvider>
+          </SWRProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/frontend/components/APYCalculator.tsx
+++ b/frontend/components/APYCalculator.tsx
@@ -8,6 +8,7 @@ import { formatApyPercent, projectedInterestStroops } from '@/lib/apy';
 import { formatUSDC, toStroops } from '@/lib/stellar';
 import { getCurrentRate } from '@/lib/contracts';
 import { Skeleton } from '@/components/Skeleton';
+import { RetryIndicator } from '@/components/RetryIndicator';
 
 const DEFAULT_LOCK_DAYS = '30';
 const DEFAULT_YIELD_BPS = 800;
@@ -23,16 +24,16 @@ const DEFAULT_YIELD_BPS = 800;
  * model configured, the live curve rate (`get_current_rate`) is used instead of
  * the flat `yield_bps`, so projections track real-time supply/demand.
  */
-export function APYCalculator({
-  className = '',
-  token,
-}: {
-  className?: string;
-  token?: string;
-}) {
+export function APYCalculator({ className = '', token }: { className?: string; token?: string }) {
   const [depositInput, setDepositInput] = useState('');
   const [lockDaysInput, setLockDaysInput] = useState(DEFAULT_LOCK_DAYS);
-  const { data: poolConfig, isLoading } = usePoolConfig();
+  const {
+    data: poolConfig,
+    isLoading,
+    error: poolConfigError,
+    isValidating: isPoolConfigValidating,
+    mutate: retryPoolConfig,
+  } = usePoolConfig();
   const [liveCurveRate, setLiveCurveRate] = useState<number | null>(null);
 
   useEffect(() => {
@@ -85,7 +86,9 @@ export function APYCalculator({
   }
 
   return (
-    <div className={`p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl ${className}`.trim()}>
+    <div
+      className={`p-6 bg-[var(--card)] border border-[var(--border)] rounded-2xl ${className}`.trim()}
+    >
       <h2 className="text-lg font-semibold mb-1 text-[var(--text-primary)]">Earnings calculator</h2>
       <p className="text-xs text-[var(--muted)] mb-4">
         Model projected returns using the pool&apos;s{' '}
@@ -157,12 +160,21 @@ export function APYCalculator({
           {formatApyPercent(DEFAULT_YIELD_BPS)}%.
         </p>
       )}
+      <RetryIndicator
+        error={poolConfigError}
+        isValidating={isPoolConfigValidating}
+        onRetry={() => retryPoolConfig?.()}
+        className="mt-2"
+      />
 
       <p className="mt-4 text-xs text-[var(--muted)] leading-relaxed border-t border-[var(--border)] pt-4">
         <strong className="text-[var(--muted)]">Disclaimer:</strong> This projection uses the
-        pool&apos;s {liveCurveRate !== null ? 'live curve rate at current utilization' : 'configured yield rate'} and assumes continuous linear accrual like on-chain
-        invoice interest. Actual returns depend on invoice repayment timing, utilization, and pool
-        parameters -- nothing is guaranteed.
+        pool&apos;s{' '}
+        {liveCurveRate !== null
+          ? 'live curve rate at current utilization'
+          : 'configured yield rate'}{' '}
+        and assumes continuous linear accrual like on-chain invoice interest. Actual returns depend
+        on invoice repayment timing, utilization, and pool parameters -- nothing is guaranteed.
       </p>
     </div>
   );

--- a/frontend/components/InviteFriends.tsx
+++ b/frontend/components/InviteFriends.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { getEnvConfig } from '@/lib/env';
+import { useReferralStats } from '@/lib/cache';
+import toast from 'react-hot-toast';
+
+interface Props {
+  address: string;
+}
+
+// #799: shareable referral link — the referral program only exists once a
+// referral contract is deployed and configured.
+export default function InviteFriends({ address }: Props) {
+  const { NEXT_PUBLIC_REFERRAL_CONTRACT_ID } = getEnvConfig();
+  const { data: stats } = useReferralStats(NEXT_PUBLIC_REFERRAL_CONTRACT_ID ? address : null);
+
+  if (!NEXT_PUBLIC_REFERRAL_CONTRACT_ID) return null;
+
+  const referralLink =
+    typeof window !== 'undefined' ? `${window.location.origin}/?ref=${address}` : '';
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(referralLink);
+      toast.success('Referral link copied!');
+    } catch {
+      toast.error('Could not copy link — copy it manually.');
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-brand-gold/30 bg-brand-gold/5 p-4 mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-brand-gold">Invite friends</p>
+          <p className="text-xs text-brand-muted mt-0.5">
+            Share your link — earn a share of the protocol fees from anyone you refer.
+            {stats && stats.referralCount > 0
+              ? ` ${stats.referralCount} referral${stats.referralCount === 1 ? '' : 's'} so far.`
+              : ''}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <code className="px-3 py-1.5 rounded-lg bg-brand-dark border border-brand-border text-xs text-brand-muted max-w-[220px] truncate">
+            {referralLink}
+          </code>
+          <button
+            onClick={copyLink}
+            className="px-3 py-1.5 rounded-lg bg-brand-gold text-brand-dark text-xs font-bold hover:bg-brand-gold-light transition-colors"
+          >
+            Copy link
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/RetryIndicator.tsx
+++ b/frontend/components/RetryIndicator.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+interface RetryIndicatorProps {
+  error: unknown;
+  isValidating?: boolean;
+  onRetry: () => void;
+  className?: string;
+}
+
+// #800: subtle "Retrying…" state while SWR's automatic backoff is in
+// flight, falling back to an explicit error + manual "Retry" button once
+// the automatic retries are exhausted. Renders nothing when there is no
+// error.
+export function RetryIndicator({
+  error,
+  isValidating,
+  onRetry,
+  className = '',
+}: RetryIndicatorProps) {
+  if (!error) return null;
+
+  if (isValidating) {
+    return (
+      <p className={`text-xs text-[var(--muted)] ${className}`.trim()} role="status">
+        Retrying…
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className={`flex items-center gap-2 text-xs text-yellow-600 dark:text-yellow-300 ${className}`.trim()}
+      role="alert"
+    >
+      <span>Failed to load data.</span>
+      <button type="button" onClick={onRetry} className="underline hover:no-underline">
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/SWRProvider.tsx
+++ b/frontend/components/SWRProvider.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { SWRConfig } from 'swr';
+import { swrConfig } from '@/lib/swrConfig';
+
+// #800: applies the app-wide retry/backoff policy to every SWR hook.
+export default function SWRProvider({ children }: { children: React.ReactNode }) {
+  return <SWRConfig value={swrConfig}>{children}</SWRConfig>;
+}

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -17,6 +17,9 @@ import {
   buildMarkDefaultedTx,
   buildSetYieldTx,
   submitTx,
+  getReferrer,
+  getReferralStats,
+  buildRegisterReferralTx,
 } from './contracts';
 import type {
   Invoice,
@@ -25,6 +28,7 @@ import type {
   PoolTokenTotals,
   FundedInvoice,
   InvoiceMetadata,
+  ReferralStats,
 } from './types';
 
 type SWRCacheEntry = {
@@ -85,6 +89,12 @@ export const CACHE_CONFIG: Record<string, SWRCacheEntry> = {
     revalidateOnFocus: true,
     revalidateOnReconnect: true,
     dedupingInterval: CACHE_TTL.invoiceStatus,
+  },
+  referral: {
+    refreshInterval: CACHE_TTL.creditScore,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.creditScore,
   },
 };
 
@@ -198,6 +208,50 @@ export function useFundedInvoice(invoiceId: number | null) {
     },
   );
 }
+
+// ---- #799: Referral Program Cache ----
+
+export function useReferrer(referee: string | null) {
+  return useSWR<string | null, ContractError>(
+    referee ? ['referrer', referee] : null,
+    () => fetcher(() => getReferrer(referee!)),
+    {
+      ...CACHE_CONFIG.referral,
+    },
+  );
+}
+
+export function useReferralStats(referrer: string | null) {
+  return useSWR<ReferralStats, ContractError>(
+    referrer ? ['referral-stats', referrer] : null,
+    () => fetcher(() => getReferralStats(referrer!)),
+    {
+      ...CACHE_CONFIG.referral,
+    },
+  );
+}
+
+async function registerReferralMutation(
+  _: string,
+  { arg }: { arg: { referee: string; referrer: string; signedXdr: string } },
+) {
+  return submitTx(arg.signedXdr);
+}
+
+export function useRegisterReferral(referee: string) {
+  return useSWRMutation<
+    unknown,
+    ContractError,
+    string,
+    { referee: string; referrer: string; signedXdr: string }
+  >('register-referral', registerReferralMutation, {
+    onSuccess: () => {
+      mutate(['referrer', referee]);
+    },
+  });
+}
+
+export { buildRegisterReferralTx };
 
 // ---- Mutations with Cache Invalidation ----
 
@@ -354,9 +408,3 @@ export function getPositionCacheKeys(investor?: string, token?: string) {
 
   return keys;
 }
-
-// Export SWR provider config for app setup
-export const swrConfig = {
-  provider: () => new Map(),
-  ...CACHE_CONFIG.invoice,
-};

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -8,6 +8,7 @@ import {
   GOVERNANCE_CONTRACT_ID,
   ORACLE_REGISTRY_CONTRACT_ID,
   COMPLIANCE_CONTRACT_ID,
+  REFERRAL_CONTRACT_ID,
   NETWORK,
   simulateTx,
   submitTx,
@@ -45,6 +46,7 @@ import type {
   FullCreditScore,
   RateModelConfig,
   RateSnapshot,
+  ReferralStats,
 } from './types';
 // Auto-generated contract bindings (single source of truth for the on-chain
 // ABI — methods, struct shapes and error codes). Regenerate with
@@ -85,6 +87,9 @@ if (ORACLE_REGISTRY_CONTRACT_ID) {
 }
 if (COMPLIANCE_CONTRACT_ID) {
   validateContractId(COMPLIANCE_CONTRACT_ID, 'compliance');
+}
+if (REFERRAL_CONTRACT_ID) {
+  validateContractId(REFERRAL_CONTRACT_ID, 'referral');
 }
 
 // ── Mock mode (#229) ─────────────────────────────────────────────────────────
@@ -909,10 +914,7 @@ export async function buildCancelWithdrawalRequestTx(
 }
 
 /** Permissionless: anyone can trigger a drain attempt against current liquidity. */
-export async function buildDrainWithdrawalQueueTx(
-  caller: string,
-  token: string,
-): Promise<string> {
+export async function buildDrainWithdrawalQueueTx(caller: string, token: string): Promise<string> {
   const account = await getRpcAccount(caller);
   const contract = new Contract(POOL_CONTRACT_ID);
 
@@ -977,10 +979,7 @@ function rateModelConfigToScVal(config: RateModelConfig): xdr.ScVal {
   return xdr.ScVal.scvMap([
     entry('base_rate_bps', nativeToScVal(config.baseRateBps, { type: 'u32' })),
     entry('max_rate_bps', nativeToScVal(config.maxRateBps, { type: 'u32' })),
-    entry(
-      'optimal_utilization_bps',
-      nativeToScVal(config.optimalUtilizationBps, { type: 'u32' }),
-    ),
+    entry('optimal_utilization_bps', nativeToScVal(config.optimalUtilizationBps, { type: 'u32' })),
     entry('slope1_bps', nativeToScVal(config.slope1Bps, { type: 'u32' })),
     entry('slope2_bps', nativeToScVal(config.slope2Bps, { type: 'u32' })),
   ]);
@@ -2321,12 +2320,7 @@ export async function buildSlashOracleTx(params: {
 
 // ---- #867: Compliance registry ----
 
-export type ComplianceStatusUi =
-  | 'Unscreened'
-  | 'Cleared'
-  | 'Flagged'
-  | 'Blocked'
-  | 'PendingReview';
+export type ComplianceStatusUi = 'Unscreened' | 'Cleared' | 'Flagged' | 'Blocked' | 'PendingReview';
 
 export type RiskTierUi = 'Low' | 'Medium' | 'High';
 
@@ -2387,9 +2381,7 @@ export async function getComplianceRecord(
   };
 }
 
-export async function getComplianceHistory(
-  address: StellarAddress,
-): Promise<ComplianceRecordUi[]> {
+export async function getComplianceHistory(address: StellarAddress): Promise<ComplianceRecordUi[]> {
   const sim = await simulateTx(
     requireComplianceContractId(),
     'get_screening_history',
@@ -2488,6 +2480,56 @@ export async function fetchComplianceServiceFlags(): Promise<
   } catch {
     return [];
   }
+}
+
+// ---- #799: Referral program ----
+
+export async function getReferrer(referee: string): Promise<string | null> {
+  const sim = await simulateTx(
+    REFERRAL_CONTRACT_ID,
+    'get_referrer',
+    [new Address(referee).toScVal()],
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  );
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  const raw = scValToNative(result!.retval);
+  return raw ? (raw as string) : null;
+}
+
+export async function getReferralStats(referrer: string): Promise<ReferralStats> {
+  const sim = await simulateTx(
+    REFERRAL_CONTRACT_ID,
+    'get_stats',
+    [new Address(referrer).toScVal()],
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  );
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  const raw = scValToNative(result!.retval) as Record<string, unknown>;
+  return {
+    referrer: raw.referrer as StellarAddress,
+    referralCount: Number(raw.referral_count ?? 0),
+  };
+}
+
+export async function buildRegisterReferralTx(referee: string, referrer: string): Promise<string> {
+  const account = await getRpcAccount(referee);
+  const contract = new Contract(REFERRAL_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK,
+  })
+    .addOperation(
+      contract.call('register', new Address(referee).toScVal(), new Address(referrer).toScVal()),
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await simulateRpcTransaction(tx);
+  if (StellarRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Simulation failed: ${sim.error}`);
+  }
+  return StellarRpc.assembleTransaction(tx, sim).build().toXDR();
 }
 
 export { submitTx };

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -3,6 +3,8 @@ type EnvConfig = {
   NEXT_PUBLIC_POOL_CONTRACT_ID: string;
   NEXT_PUBLIC_USDC_TOKEN_ID: string;
   NEXT_PUBLIC_EURC_TOKEN_ID?: string;
+  // #799: optional — the referral program is opt-in on the pool contract.
+  NEXT_PUBLIC_REFERRAL_CONTRACT_ID?: string;
   NEXT_PUBLIC_NETWORK: 'testnet' | 'mainnet' | 'standalone';
   NEXT_PUBLIC_HORIZON_URL?: string;
   NEXT_PUBLIC_SOROBAN_RPC_URL?: string;
@@ -96,6 +98,12 @@ export function validateEnv(): { valid: boolean; errors: EnvValidationError[] } 
     if (eurcError) errors.push(eurcError);
   }
 
+  const referralId = process.env.NEXT_PUBLIC_REFERRAL_CONTRACT_ID;
+  if (referralId) {
+    const referralError = validateContractId(referralId, 'NEXT_PUBLIC_REFERRAL_CONTRACT_ID');
+    if (referralError) errors.push(referralError);
+  }
+
   const networkError = validateNetwork(network);
   if (networkError) errors.push(networkError);
 
@@ -117,6 +125,7 @@ export function getEnvConfig(): EnvConfig {
     NEXT_PUBLIC_POOL_CONTRACT_ID: process.env.NEXT_PUBLIC_POOL_CONTRACT_ID || '',
     NEXT_PUBLIC_USDC_TOKEN_ID: process.env.NEXT_PUBLIC_USDC_TOKEN_ID || '',
     NEXT_PUBLIC_EURC_TOKEN_ID: process.env.NEXT_PUBLIC_EURC_TOKEN_ID,
+    NEXT_PUBLIC_REFERRAL_CONTRACT_ID: process.env.NEXT_PUBLIC_REFERRAL_CONTRACT_ID,
     NEXT_PUBLIC_NETWORK: network,
     NEXT_PUBLIC_HORIZON_URL: process.env.NEXT_PUBLIC_HORIZON_URL,
     NEXT_PUBLIC_SOROBAN_RPC_URL: process.env.NEXT_PUBLIC_SOROBAN_RPC_URL,

--- a/frontend/lib/errorHandling.ts
+++ b/frontend/lib/errorHandling.ts
@@ -1,7 +1,16 @@
 const ERROR_MAPPINGS: Array<{ match: RegExp; message: string }> = [
-  { match: /USER_DECLINED_ACCESS|user rejected|cancelled by user/i, message: 'Transaction cancelled by user' },
-  { match: /timeout|network error|failed to fetch|unreachable/i, message: 'Network error, please try again' },
-  { match: /InsufficientFunds|insufficient funds/i, message: 'Insufficient balance for this transaction' },
+  {
+    match: /USER_DECLINED_ACCESS|user rejected|cancelled by user/i,
+    message: 'Transaction cancelled by user',
+  },
+  {
+    match: /timeout|network error|failed to fetch|unreachable/i,
+    message: 'Network error, please try again',
+  },
+  {
+    match: /InsufficientFunds|insufficient funds/i,
+    message: 'Insufficient balance for this transaction',
+  },
   { match: /ContractPaused|contract is paused/i, message: 'Protocol is currently paused' },
   { match: /already initialized/i, message: 'Contract is already initialized' },
 ];
@@ -10,4 +19,13 @@ export function getUserFriendlyError(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error ?? 'Unknown error');
   const mapping = ERROR_MAPPINGS.find((item) => item.match.test(raw));
   return mapping?.message ?? raw;
+}
+
+// #800: "not found" failures are permanent (the Soroban-RPC analog of an HTTP
+// 404) — retrying them wastes cycles and delays surfacing the real problem.
+const NOT_FOUND_PATTERN = /not found|does not exist/i;
+
+export function isNotFoundError(error: unknown): boolean {
+  const raw = error instanceof Error ? error.message : String(error ?? '');
+  return NOT_FOUND_PATTERN.test(raw);
 }

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -41,6 +41,9 @@ export const ORACLE_REGISTRY_CONTRACT_ID =
 // #867: on-chain compliance / sanctions screening registry
 export const COMPLIANCE_CONTRACT_ID = process.env.NEXT_PUBLIC_COMPLIANCE_CONTRACT_ID ?? '';
 
+// #799: on-chain referral program — optional, unset until deployed.
+export const REFERRAL_CONTRACT_ID = process.env.NEXT_PUBLIC_REFERRAL_CONTRACT_ID ?? '';
+
 export const SHARE_TOKEN_ID = process.env.NEXT_PUBLIC_SHARE_TOKEN_ID ?? '';
 export const USDC_TOKEN_ID = process.env.NEXT_PUBLIC_USDC_TOKEN_ID ?? '';
 export const EURC_TOKEN_ID = process.env.NEXT_PUBLIC_EURC_TOKEN_ID ?? '';

--- a/frontend/lib/swrConfig.ts
+++ b/frontend/lib/swrConfig.ts
@@ -1,0 +1,23 @@
+import type { SWRConfiguration } from 'swr';
+import { CACHE_CONFIG } from './cache';
+import { isNotFoundError } from './errorHandling';
+
+// #800: Soroban RPC / Horizon occasionally return transient errors (rate
+// limiting, momentary unavailability, network blips). Without retry logic a
+// single transient failure put the whole page into a permanent error state
+// requiring a manual reload. This config makes SWR retry transient failures
+// with exponential backoff, while permanent ("not found") failures fail fast.
+export const MAX_RETRY_COUNT = 3;
+export const RETRY_BASE_DELAY_MS = 1000;
+
+export const swrConfig: SWRConfiguration = {
+  provider: () => new Map(),
+  ...CACHE_CONFIG.invoice,
+  errorRetryCount: MAX_RETRY_COUNT,
+  errorRetryInterval: RETRY_BASE_DELAY_MS,
+  onErrorRetry: (error, _key, _config, revalidate, { retryCount }) => {
+    if (isNotFoundError(error)) return;
+    if (retryCount >= MAX_RETRY_COUNT) return;
+    setTimeout(() => revalidate({ retryCount }), RETRY_BASE_DELAY_MS * 2 ** retryCount);
+  },
+};

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -301,3 +301,9 @@ export interface FullCreditScore {
   isStale: boolean;
   blendedScore: number;
 }
+
+/** #799: referral program stats for a referrer, from `referral.get_stats()`. */
+export interface ReferralStats {
+  referrer: StellarAddress;
+  referralCount: number;
+}

--- a/scripts/monitor_invoices.ts
+++ b/scripts/monitor_invoices.ts
@@ -1,0 +1,202 @@
+/**
+ * #801: Invoice default keeper monitor.
+ *
+ * Polls the invoice contract for `Funded` invoices whose grace period has
+ * expired and submits `mark_defaulted(id, keeper)` for each, signed by the
+ * keeper key configured below. The keeper address must first be whitelisted
+ * on-chain via `InvoiceContract.add_keeper(admin, keeper)` — it can only
+ * ever call `mark_defaulted`, no other admin function.
+ *
+ * Designed to be run as a periodic cron job or deployed as a Stellar Turret
+ * task; either way it is just "run this script every N minutes".
+ *
+ * Usage:
+ *   INVOICE_CONTRACT_ID=... KEEPER_SECRET_KEY=... npx tsx scripts/monitor_invoices.ts
+ *
+ * Environment:
+ *   RPC_URL              — Soroban RPC endpoint (default: https://soroban-testnet.stellar.org)
+ *   NETWORK_PASSPHRASE    — network passphrase (default: Test SDF Network ; September 2015)
+ *   INVOICE_CONTRACT_ID   — deployed invoice contract id (required)
+ *   KEEPER_SECRET_KEY     — secret key of the whitelisted keeper account (required)
+ *   POLL_INTERVAL_MS      — ms between sweeps when run continuously (default: 60000)
+ *   RUN_ONCE              — if "true", perform a single sweep and exit (for cron use)
+ */
+
+import * as dotenv from 'dotenv';
+import {
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  Contract,
+  rpc as StellarRpc,
+  Address,
+  nativeToScVal,
+  scValToNative,
+} from '@stellar/stellar-sdk';
+
+dotenv.config();
+
+interface Config {
+  rpcUrl: string;
+  networkPassphrase: string;
+  invoiceContractId: string;
+  keeperSecretKey: string;
+  pollIntervalMs: number;
+  runOnce: boolean;
+}
+
+function loadConfig(): Config {
+  const invoiceContractId = process.env.INVOICE_CONTRACT_ID || '';
+  const keeperSecretKey = process.env.KEEPER_SECRET_KEY || '';
+  if (!invoiceContractId) throw new Error('INVOICE_CONTRACT_ID is required');
+  if (!keeperSecretKey) throw new Error('KEEPER_SECRET_KEY is required');
+
+  return {
+    rpcUrl: process.env.RPC_URL || 'https://soroban-testnet.stellar.org',
+    networkPassphrase:
+      process.env.NETWORK_PASSPHRASE || 'Test SDF Network ; September 2015',
+    invoiceContractId,
+    keeperSecretKey,
+    pollIntervalMs: parseInt(process.env.POLL_INTERVAL_MS || '60000', 10),
+    runOnce: process.env.RUN_ONCE === 'true',
+  };
+}
+
+const INVOICE_STATUS_FUNDED = 'Funded';
+const SECS_PER_DAY = 86_400;
+
+class InvoiceMonitor {
+  private readonly config: Config;
+  private readonly keypair: Keypair;
+  private readonly server: StellarRpc.Server;
+  private readonly contract: Contract;
+
+  constructor(config: Config) {
+    this.config = config;
+    this.keypair = Keypair.fromSecret(config.keeperSecretKey);
+    this.server = new StellarRpc.Server(config.rpcUrl, { allowHttp: true });
+    this.contract = new Contract(config.invoiceContractId);
+  }
+
+  async sweep(): Promise<void> {
+    const invoiceCount = await this.readInvoiceCount();
+    const globalGraceDays = await this.readGraceDays();
+    const nowSecs = Math.floor(Date.now() / 1000);
+
+    for (let id = 1; id <= invoiceCount; id++) {
+      let invoice: any;
+      try {
+        invoice = await this.readInvoice(id);
+      } catch (err) {
+        console.error(`[monitor] failed to read invoice ${id}:`, err);
+        continue;
+      }
+      if (invoice.status !== INVOICE_STATUS_FUNDED) continue;
+
+      const graceDays: number = invoice.grace_period_override ?? globalGraceDays;
+      const defaultAt = Number(invoice.due_date) + graceDays * SECS_PER_DAY;
+      if (nowSecs < defaultAt) continue;
+
+      console.log(`[monitor] invoice ${id} past grace period (default_at=${defaultAt}), marking defaulted`);
+      try {
+        const hash = await this.markDefaulted(id);
+        console.log(`[monitor] invoice ${id} mark_defaulted submitted: ${hash}`);
+      } catch (err) {
+        console.error(`[monitor] mark_defaulted failed for invoice ${id}:`, err);
+      }
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.config.runOnce) {
+      await this.sweep();
+      return;
+    }
+    console.log(`[monitor] starting poll loop (every ${this.config.pollIntervalMs}ms)`);
+    for (;;) {
+      try {
+        await this.sweep();
+      } catch (err) {
+        console.error('[monitor] sweep error:', err);
+      }
+      await sleep(this.config.pollIntervalMs);
+    }
+  }
+
+  private async simulateRead(method: string, ...args: ReturnType<typeof nativeToScVal>[]): Promise<any> {
+    const account = await this.server.getAccount(this.keypair.publicKey());
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(this.contract.call(method, ...args))
+      .setTimeout(30)
+      .build();
+
+    const sim = await this.server.simulateTransaction(tx);
+    if (StellarRpc.Api.isSimulationError(sim)) {
+      throw new Error(`simulate ${method} failed: ${sim.error}`);
+    }
+    if (!StellarRpc.Api.isSimulationSuccess(sim) || !sim.result) {
+      throw new Error(`simulate ${method} returned no result`);
+    }
+    return scValToNative(sim.result.retval);
+  }
+
+  private async readInvoiceCount(): Promise<number> {
+    return Number(await this.simulateRead('get_invoice_count'));
+  }
+
+  private async readGraceDays(): Promise<number> {
+    return Number(await this.simulateRead('get_grace_period'));
+  }
+
+  private async readInvoice(id: number): Promise<any> {
+    return this.simulateRead('get_invoice', nativeToScVal(id, { type: 'u64' }));
+  }
+
+  private async markDefaulted(id: number): Promise<string> {
+    const account = await this.server.getAccount(this.keypair.publicKey());
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.config.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          'mark_defaulted',
+          nativeToScVal(id, { type: 'u64' }),
+          new Address(this.keypair.publicKey()).toScVal(),
+        ),
+      )
+      .setTimeout(30)
+      .build();
+
+    const sim = await this.server.simulateTransaction(tx);
+    if (StellarRpc.Api.isSimulationError(sim)) {
+      throw new Error(`simulate mark_defaulted failed: ${sim.error}`);
+    }
+    const prepared = StellarRpc.assembleTransaction(tx, sim).build();
+    prepared.sign(this.keypair);
+    const send = await this.server.sendTransaction(prepared);
+    return send.hash;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const monitor = new InvoiceMonitor(config);
+  await monitor.start();
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[monitor] fatal error:', err);
+    process.exit(1);
+  });
+}
+
+export { InvoiceMonitor, loadConfig };

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "astera-scripts",
+  "version": "1.0.0",
+  "description": "Astera off-chain operational scripts (#801: invoice default keeper monitor)",
+  "private": true,
+  "scripts": {
+    "monitor:invoices": "tsx monitor_invoices.ts"
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^12.0.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
  ## Summary

  Resolves four issues: two contract-level bug/feature fixes on the invoice contract, a new
  on-chain referral program, and a frontend RPC-retry fix.

  Closes #798
  Closes #799
  Closes #800
  Closes #801

  ## #798 — fix: invoice contract allows zero amount

  - `create_invoice()` now rejects `amount <= 0` with the typed `InvoiceError::InvalidAmount`.
  - `create_invoice()` now rejects a `due_date` that isn't in the future with the typed
  `InvoiceError::InvalidDueDate` (guards the edge case where an admin sets
  `MinDueDateWindowSecs` to 0, which would otherwise let a past due date slip through).
  - All validation runs before any storage write.
  - Unit tests cover zero amount, negative amount, and past due date, each asserting the exact
  typed error via `try_create_invoice`.

  ## #801 — feat: keeper role for automated invoice default monitoring

  - Added a `keeper` allowlist to the invoice contract: `add_keeper()` / `remove_keeper()`
  (admin-only) and `list_keepers()` (read-only).
  - `mark_defaulted()` now accepts a call from either the pool contract (existing flow,
  unchanged) or a whitelisted keeper — a keeper has no other privileges and cannot call any
  other admin- or pool-gated function.
  - Added `scripts/monitor_invoices.ts` — polls the invoice contract for `Funded` invoices
  past their grace period and submits `mark_defaulted()` signed by the keeper key. Supports a
  single-sweep mode (`RUN_ONCE=true`, for cron) and a long-lived poll loop (for a Turret task
  or systemd service).
  - Added `docs/keeper-monitor.md` with full deployment instructions (whitelisting a keeper,
  cron setup, continuous-process setup, Turret deployment, key-compromise response).
  - Tests: keeper can call `mark_defaulted` after grace period; non-keeper/non-pool caller is
  rejected with a typed `Unauthorized` error; removed keeper loses access.

  ## #799 — feat: referral program smart contract

  New `contracts/referral` crate:

  - `register(referee, referrer)` — one-time; the referrer cannot be changed once set.
  - `record_activity(caller, referee, kind, fee_amount, token)` — called by the pool contract
  on a qualifying fee event (`"borrow"` on invoice repayment, `"deposit"` on deposit).
  Activates the referral exactly once (increments `ReferralCount`) on the referee's first
  qualifying activity, and credits the referrer's pending balance at an admin-configurable bps
  rate — default 5% of factoring fees, 10% of yield fees, capped at 100%.
  - `claim_rewards(referrer, token)` — pays out the referrer's accrued balance for a token.
  - `get_stats(referrer)`, `get_referrer(referee)`, `get_pending_reward(referrer, token)` —
  read-only views.
  - Admin-only `set_borrow_reward_bps` / `set_deposit_reward_bps` / `set_pool` / `pause` /
  `unpause`.

  Pool contract integration (`set_referral_registry`, admin-only, unset by default so existing
  deployments are unaffected):

  - On full invoice repayment, pays the referrer their cut of the just-realized factoring fee
  — carved out of `protocol_revenue` (a redistribution of the existing fee, not new
  inflation), with the tokens actually transferred to the referral contract so
  `claim_rewards()` has funds to pay out.
  - On deposit, activates the referral (the pool has no separate yield fee to share yet, so
  this accrues 0 reward for now — a deliberate, honest scope boundary rather than inventing a
  new fee mechanism; see code comments).
  - All calls into the referral contract are `try_`-style and non-fatal: a misconfigured or
  unreachable referral contract never blocks a repayment or deposit.

  Frontend: a "Invite friends" card on the SME dashboard with a shareable referral link and
  copy-to-clipboard, gated on `NEXT_PUBLIC_REFERRAL_CONTRACT_ID` being configured; read/write
  helpers (`getReferrer`, `getReferralStats`, `buildRegisterReferralTx`) and SWR hooks
  (`useReferrer`, `useReferralStats`, `useRegisterReferral`) for future registration-flow UI.
  Tests: 12 unit tests in `contracts/referral/tests/lifecycle_tests.rs` (registration lock,
  self-referral rejection, non-pool caller rejection, activation-once semantics, bps math for
  both activity kinds, admin bps configuration, claim/reset, pause). Plus two pool-level
  integration tests using the real `referral` crate as a dev-dependency (matching the existing
  `compliance` integration-test pattern): `test_referral_reward_paid_on_invoice_repayment`
  (fund → repay → asserts the referrer's pending reward, the referral contract's actual token
  balance, and that `protocol_revenue` was correctly debited — then claims and verifies the
  payout) and `test_referral_activates_on_first_deposit`.

  ## #800 — fix: frontend API calls lack retry logic
  ## #800 — fix: frontend API calls lack retry logic

  - Added `frontend/lib/swrConfig.ts` — a global SWR `onErrorRetry` with exponential backoff
  (1s, 2s, 4s — up to 3 retries). Permanent "not found" errors (the RPC-layer analog of an
  HTTP 404) fail fast without retrying.
  - Wired in app-wide via a new `SWRProvider` client component in the root layout.
  - Added a small reusable `RetryIndicator` component — a subtle "Retrying…" state while a
  retry is in flight, and an explicit error message with a manual "Retry" button once retries
  are exhausted — wired into `APYCalculator` as the first concrete usage (the app's one direct
  consumer of the SWR-backed `lib/cache.ts` hooks today).
  - Unit tests (`frontend/__tests__/lib/swrConfig.test.tsx`): backoff timing and doubling,
  retry exhaustion at the configured cap, no retry on a "not found" error, and an end-to-end
  test through real SWR + real timers where a mocked RPC fails twice then succeeds and data
  loads correctly.
  
  ## Test plan

  - [x] `cargo test -p invoice` — 144/144 passing (all test targets)
  - [x] `cargo test -p pool` — 270/270 passing (all test targets, including the two new
  referral integration tests)
  - [x] `cargo test -p referral` — 12/12 passing
  - [x] `cargo build --release --target wasm32v1-none -p invoice -p pool -p referral` — builds
  cleanly
  - [x] `npx tsc --noEmit` (frontend) — no errors
  - [x] `npx jest` (frontend) — 248/248 passing across all 35 suites
  