### PR TITLE
Security & reliability fixes: confirm-before-sign, CSRF, pause exemptions, lifecycle test

### DIFF
--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -916,7 +916,10 @@ impl InvoiceContract {
         }
         env.storage().instance().set(&DataKey::Paused, &true);
         bump_instance(&env);
-        env.events().publish((EVT, symbol_short!("paused")), admin);
+        env.events().publish(
+            (EVT, symbol_short!("paused")),
+            (admin, env.ledger().timestamp()),
+        );
     }
 
     pub fn unpause(env: Env, admin: Address) {
@@ -931,8 +934,10 @@ impl InvoiceContract {
         }
         env.storage().instance().set(&DataKey::Paused, &false);
         bump_instance(&env);
-        env.events()
-            .publish((EVT, symbol_short!("unpaused")), admin);
+        env.events().publish(
+            (EVT, symbol_short!("unpaused")),
+            (admin, env.ledger().timestamp()),
+        );
     }
 
     pub fn is_paused(env: Env) -> bool {
@@ -3572,11 +3577,28 @@ mod test {
 
     #[test]
     fn test_pause_and_unpause() {
+        // #779: paused/unpaused events must carry both the pausing admin and
+        // a timestamp.
+        use soroban_sdk::testutils::Events;
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin, _pool, _sme) = setup(&env);
+
         client.pause(&admin);
         assert!(client.is_paused());
+        let pause_ts = env.ledger().timestamp();
+        let expected_paused: soroban_sdk::Vec<soroban_sdk::Val> =
+            (EVT, symbol_short!("paused")).into_val(&env);
+        let paused_event = env
+            .events()
+            .all()
+            .iter()
+            .find(|e| e.1 == expected_paused)
+            .expect("paused event not emitted");
+        let (event_admin, event_ts): (Address, u64) = paused_event.2.into_val(&env);
+        assert_eq!(event_admin, admin);
+        assert_eq!(event_ts, pause_ts);
+
         client.unpause(&admin);
         assert!(!client.is_paused());
     }

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -1746,12 +1746,17 @@ impl FundingPool {
     pub fn pause(env: Env, admin: Address) -> Result<(), PoolError> {
         admin.require_auth();
         Self::require_admin(&env, &admin)?;
-        // Pause policy: all user state-changing actions are blocked while paused,
-        // including deposit, withdraw, funding, and repayment. Admin emergency
-        // controls (set_yield, set_investor_kyc, unpause) remain available.
+        // #779: pause policy — new deposits, withdrawals, and funding are
+        // blocked while paused. Admin emergency controls (set_yield,
+        // set_investor_kyc, unpause) and repay_invoice() remain available:
+        // borrowers must always be able to exit their debt, even during an
+        // emergency freeze.
         env.storage().instance().set(&DataKey::Paused, &true);
         bump_instance(&env);
-        env.events().publish((EVT, symbol_short!("paused")), admin);
+        env.events().publish(
+            (EVT, symbol_short!("paused")),
+            (admin, env.ledger().timestamp()),
+        );
         Ok(())
     }
 
@@ -1760,8 +1765,10 @@ impl FundingPool {
         Self::require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Paused, &false);
         bump_instance(&env);
-        env.events()
-            .publish((EVT, symbol_short!("unpaused")), admin);
+        env.events().publish(
+            (EVT, symbol_short!("unpaused")),
+            (admin, env.ledger().timestamp()),
+        );
         Ok(())
     }
 
@@ -3382,7 +3389,8 @@ impl FundingPool {
     ) -> Result<(), PoolError> {
         payer.require_auth();
         bump_instance(&env);
-        Self::require_not_paused(&env);
+        // #779: repayment is explicitly exempt from the pause guard — see
+        // the policy note on `pause()`.
         Self::repay_invoice_request(&env, invoice_id, payer, amount)
     }
 
@@ -8062,8 +8070,10 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Error(Contract, #12)")]
-    fn test_repay_invoice_when_paused_panics() {
+    fn test_repay_invoice_allowed_when_paused() {
+        // #779: repayment must stay open during an emergency pause so
+        // borrowers can always exit their debt, even while new deposits and
+        // funding are frozen.
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin, usdc_id, _share_token) = setup(&env);
@@ -8082,8 +8092,11 @@ mod test {
             &usdc_id,
         );
         client.pause(&admin);
+        assert!(client.is_paused());
         let amount_due = client.estimate_repayment(&1u64, &None);
         client.repay_invoice(&1u64, &sme, &amount_due);
+        let fi = client.get_funded_invoice(&1u64).unwrap();
+        assert!(fi.repaid_amount >= amount_due);
     }
 
     #[test]
@@ -8295,15 +8308,42 @@ mod test {
 
     #[test]
     fn test_pause_events_emitted() {
+        // #779: the paused/unpaused events must carry both the pausing admin
+        // and a timestamp, not just the admin address.
+        use soroban_sdk::testutils::Events;
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin, _usdc_id, _share_token) = setup(&env);
 
         client.pause(&admin);
         assert!(client.is_paused());
+        let pause_ts = env.ledger().timestamp();
+        let expected_paused: soroban_sdk::Vec<soroban_sdk::Val> =
+            (EVT, symbol_short!("paused")).into_val(&env);
+        let paused_event = env
+            .events()
+            .all()
+            .iter()
+            .find(|e| e.1 == expected_paused)
+            .expect("paused event not emitted");
+        let (event_admin, event_ts): (Address, u64) = paused_event.2.into_val(&env);
+        assert_eq!(event_admin, admin);
+        assert_eq!(event_ts, pause_ts);
 
         client.unpause(&admin);
         assert!(!client.is_paused());
+        let unpause_ts = env.ledger().timestamp();
+        let expected_unpaused: soroban_sdk::Vec<soroban_sdk::Val> =
+            (EVT, symbol_short!("unpaused")).into_val(&env);
+        let unpaused_event = env
+            .events()
+            .all()
+            .iter()
+            .find(|e| e.1 == expected_unpaused)
+            .expect("unpaused event not emitted");
+        let (event_admin, event_ts): (Address, u64) = unpaused_event.2.into_val(&env);
+        assert_eq!(event_admin, admin);
+        assert_eq!(event_ts, unpause_ts);
     }
 
     // ---- Issue #138: Partial Repayment Tests ----

--- a/contracts/tests/tests/integration_tests.rs
+++ b/contracts/tests/tests/integration_tests.rs
@@ -210,6 +210,165 @@ fn test_complete_invoice_lifecycle() {
     assert!(investor_balance > 5_000_000_000i128); // Should have earned yield
 }
 
+/// Integration test (#769): the complete borrower journey in a single test —
+/// invoice creation, collateral posting, pool funding, the due-date window,
+/// full repayment, and the resulting credit score update — with an explicit
+/// assertion after every step rather than relying on separate unit tests to
+/// each cover one piece of the flow in isolation.
+#[test]
+fn test_full_borrower_lifecycle() {
+    let env = test_env();
+    env.mock_all_auths_allowing_non_root_auth();
+    env.ledger().with_mut(|l| l.timestamp = 100_000);
+
+    let admin = Address::generate(&env);
+    let sme = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let invoice_id_addr = env.register_contract_wasm(None, invoice::WASM);
+    let pool_id = env.register_contract_wasm(None, pool::WASM);
+    let credit_id = env.register_contract_wasm(None, credit_score::WASM);
+    let share_id = env.register_contract_wasm(None, share::WASM);
+    let usdc_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    let invoice_client = invoice::Client::new(&env, &invoice_id_addr);
+    let pool_client = pool::Client::new(&env, &pool_id);
+    let credit_client = credit_score::Client::new(&env, &credit_id);
+    let share_client = share::Client::new(&env, &share_id);
+
+    invoice_client.initialize(
+        &admin,
+        &pool_id,
+        &10_000_000_000i128,
+        &(30u64 * 86_400u64),
+        &7u32,
+    );
+    share_client.initialize(
+        &admin,
+        &7u32,
+        &String::from_str(&env, "Pool Shares"),
+        &String::from_str(&env, "POOL"),
+    );
+    initialize_pool(&pool_client, &admin, &usdc_id, &share_id, &invoice_id_addr);
+    credit_client.initialize(&admin, &invoice_id_addr, &pool_id);
+
+    // Any invoice over 1_000 requires 20% collateral.
+    propose_and_execute_set_collateral_config(&env, &pool_client, &admin, 1_000i128, 2_000u32);
+
+    let principal: i128 = 5_000;
+    let due_date = env.ledger().timestamp() + 30 * 86_400;
+    let required_col = pool_client.required_collateral_for(&principal);
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id).mint(&investor, &20_000i128);
+    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id)
+        .mint(&sme, &(principal + required_col));
+
+    // Baseline score for a borrower with no payment history yet.
+    let score_before = credit_client.get_credit_score(&sme);
+
+    // Step 1: borrower creates the invoice — starts out Pending.
+    let inv_id = invoice_client.create_invoice(
+        &sme,
+        &String::from_str(&env, "ACME Corp"),
+        &principal,
+        &due_date,
+        &String::from_str(&env, "Invoice #001"),
+        &String::from_str(&env, "hash123"),
+        &metadata_url(&env),
+    );
+    assert_eq!(
+        invoice_client.get_invoice(&inv_id).status,
+        invoice::InvoiceStatus::Pending
+    );
+
+    // Step 2: borrower posts the required collateral before it can be funded.
+    assert_eq!(required_col, principal * 2_000 / 10_000); // 20% of principal
+    let sme_before_collateral = soroban_sdk::token::Client::new(&env, &usdc_id).balance(&sme);
+    pool_client.deposit_collateral(&inv_id, &sme, &usdc_id, &required_col);
+    let collateral = pool_client.get_collateral_deposit(&inv_id).unwrap();
+    assert_eq!(collateral.amount, required_col);
+    assert!(!collateral.settled);
+    assert_eq!(
+        soroban_sdk::token::Client::new(&env, &usdc_id).balance(&sme),
+        sme_before_collateral - required_col
+    );
+
+    // Step 3: an investor supplies pool liquidity, then the pool funds the
+    // invoice — the borrower receives the principal and pool liquidity drops
+    // by the same amount.
+    pool_client.deposit(&investor, &usdc_id, &20_000i128);
+    let pool_available_before_funding = pool_client.available_liquidity(&usdc_id);
+    let sme_before_funding = soroban_sdk::token::Client::new(&env, &usdc_id).balance(&sme);
+
+    pool_client.fund_invoice(&admin, &inv_id, &principal, &sme, &due_date, &usdc_id);
+    invoice_client.mark_funded(&inv_id, &pool_id);
+
+    assert_eq!(
+        invoice_client.get_invoice(&inv_id).status,
+        invoice::InvoiceStatus::Funded
+    );
+    assert_eq!(
+        soroban_sdk::token::Client::new(&env, &usdc_id).balance(&sme),
+        sme_before_funding + principal
+    );
+    assert_eq!(
+        pool_client.available_liquidity(&usdc_id),
+        pool_available_before_funding - principal
+    );
+    assert_eq!(pool_client.get_token_totals(&usdc_id).total_deployed, principal);
+
+    // Step 4: time passes but the due date hasn't arrived — still Funded.
+    env.ledger().with_mut(|l| l.timestamp = due_date - 86_400);
+    assert_eq!(
+        invoice_client.get_invoice(&inv_id).status,
+        invoice::InvoiceStatus::Funded
+    );
+
+    // Step 5: borrower repays in full before the due date. The pool absorbs
+    // the repayment (principal + accrued yield/fees) and releases the
+    // borrower's collateral.
+    let total_due = pool_client.estimate_repayment(&inv_id, &None);
+    let sme_before_repay = soroban_sdk::token::Client::new(&env, &usdc_id).balance(&sme);
+    let pool_value_before_repay = pool_client.get_token_totals(&usdc_id).pool_value;
+
+    pool_client.repay_invoice(&inv_id, &sme, &total_due);
+    invoice_client.mark_paid(&inv_id, &pool_id);
+
+    assert_eq!(
+        invoice_client.get_invoice(&inv_id).status,
+        invoice::InvoiceStatus::Paid
+    );
+    let totals_after_repay = pool_client.get_token_totals(&usdc_id);
+    assert_eq!(totals_after_repay.total_deployed, 0);
+    assert_eq!(
+        totals_after_repay.pool_value,
+        pool_value_before_repay + total_due
+    );
+    let collateral_after = pool_client.get_collateral_deposit(&inv_id).unwrap();
+    assert!(collateral_after.settled);
+    assert_eq!(
+        soroban_sdk::token::Client::new(&env, &usdc_id).balance(&sme),
+        sme_before_repay - total_due + required_col
+    );
+
+    // Step 6: on-time repayment is reflected in the borrower's credit score.
+    credit_client.record_payment(
+        &pool_id,
+        &inv_id,
+        &sme,
+        &principal,
+        &due_date,
+        &env.ledger().timestamp(),
+    );
+    let score_after = credit_client.get_credit_score(&sme);
+    assert_eq!(score_after.total_invoices, 1);
+    assert_eq!(score_after.paid_on_time, 1);
+    assert!(score_after.score > score_before.score);
+}
+
 /// Integration test: Default scenario with grace period
 #[test]
 fn test_default_with_grace_period() {

--- a/frontend/__tests__/middleware.test.ts
+++ b/frontend/__tests__/middleware.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { middleware } from '../middleware';
+
+// #770: double-submit-cookie CSRF protection for state-mutating /api/*
+// routes. A request with no token, or a mismatched header/cookie pair, must
+// be rejected before it reaches the route handler.
+
+function makeRequest(
+  path: string,
+  opts: { method?: string; headers?: Record<string, string>; cookie?: string } = {},
+): NextRequest {
+  const headers = new Headers(opts.headers);
+  if (opts.cookie) headers.set('cookie', opts.cookie);
+  return new NextRequest(new URL(path, 'http://localhost:3000'), {
+    method: opts.method ?? 'GET',
+    headers,
+  });
+}
+
+describe('CSRF middleware (#770)', () => {
+  it('mints a csrf cookie on a fresh page navigation', () => {
+    const res = middleware(makeRequest('/dashboard'));
+    expect(res.cookies.get('csrf_token')?.value).toBeTruthy();
+  });
+
+  it('does not re-mint a cookie that already exists', () => {
+    const res = middleware(makeRequest('/dashboard', { cookie: 'csrf_token=existing-token' }));
+    expect(res.cookies.get('csrf_token')).toBeUndefined();
+  });
+
+  it('rejects a mutating /api request with no csrf token at all', async () => {
+    const res = middleware(makeRequest('/api/notifications/preferences', { method: 'POST' }));
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('invalid_csrf_token');
+  });
+
+  it('rejects a mutating /api request when only the cookie is present', () => {
+    const res = middleware(
+      makeRequest('/api/notifications/preferences', {
+        method: 'POST',
+        cookie: 'csrf_token=right-token',
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a mutating /api request when header and cookie disagree', () => {
+    const res = middleware(
+      makeRequest('/api/notifications/preferences', {
+        method: 'POST',
+        headers: { 'x-csrf-token': 'wrong-token' },
+        cookie: 'csrf_token=right-token',
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('allows a mutating /api request when the header matches the cookie', () => {
+    const res = middleware(
+      makeRequest('/api/notifications/preferences', {
+        method: 'POST',
+        headers: { 'x-csrf-token': 'matching-token' },
+        cookie: 'csrf_token=matching-token',
+      }),
+    );
+    expect(res.status).not.toBe(403);
+  });
+
+  it('allows a GET request to a mutating-only route without a token', () => {
+    const res = middleware(makeRequest('/api/auth/me', { method: 'GET' }));
+    expect(res.status).not.toBe(403);
+  });
+
+  it.each(['/api/auth/challenge', '/api/auth/token'])(
+    'exempts the wallet-signature-verified route %s from the csrf check',
+    (path) => {
+      const res = middleware(makeRequest(path, { method: 'POST' }));
+      expect(res.status).not.toBe(403);
+    },
+  );
+});

--- a/frontend/app/invest/__tests__/page.test.tsx
+++ b/frontend/app/invest/__tests__/page.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// #780: the withdraw form used to sign-and-submit immediately on click, with
+// no confirmation dialog in between. This test locks in the fix — a
+// confirmation modal must appear before the wallet is asked to sign, and
+// cancelling it must not build or submit a transaction.
+
+const mockUseStore = jest.fn();
+jest.mock('@/lib/store', () => ({
+  useStore: () => mockUseStore(),
+}));
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock('next/link', () => {
+  const Link = ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  );
+  Link.displayName = 'Link';
+  return Link;
+});
+
+jest.mock('@/components/PoolStats', () => ({
+  __esModule: true,
+  default: () => null,
+  PoolStatsSkeleton: () => null,
+}));
+jest.mock('@/components/APYCalculator', () => ({ APYCalculator: () => null }));
+jest.mock('@/components/ScenarioModeler', () => ({ ScenarioModeler: () => null }));
+jest.mock('@/components/analytics', () => ({ RateCurveChart: () => null }));
+
+const mockBuildWithdrawTx = jest.fn();
+const mockBuildDepositTx = jest.fn();
+const mockSubmitTx = jest.fn();
+const mockGetAcceptedTokens = jest.fn();
+
+jest.mock('@/lib/contracts', () => ({
+  getPoolConfig: jest.fn().mockResolvedValue({ yieldBps: 800 }),
+  getInvestorPosition: jest.fn().mockResolvedValue({
+    deposited: 1_000_0000000n,
+    available: 1_000_0000000n,
+    deployed: 0n,
+    earned: 0n,
+    depositCount: 1,
+  }),
+  getAcceptedTokens: (...args: unknown[]) => mockGetAcceptedTokens(...args),
+  getPoolTokenTotals: jest.fn().mockResolvedValue({
+    totalDeposited: 1_000_0000000n,
+    totalDeployed: 0n,
+    totalPaidOut: 0n,
+    totalFeeRevenue: 0n,
+  }),
+  getTokenDepositCap: jest.fn().mockResolvedValue(0n),
+  buildDepositTx: (...args: unknown[]) => mockBuildDepositTx(...args),
+  buildWithdrawTx: (...args: unknown[]) => mockBuildWithdrawTx(...args),
+  submitTx: (...args: unknown[]) => mockSubmitTx(...args),
+  getKycRequired: jest.fn().mockResolvedValue(false),
+  getInvestorKyc: jest.fn().mockResolvedValue(true),
+  getRateModelConfig: jest.fn().mockResolvedValue(null),
+  getCurrentRate: jest.fn().mockResolvedValue(null),
+}));
+
+const mockSignTransaction = jest.fn();
+jest.mock('@stellar/freighter-api', () => ({
+  signTransaction: (...args: unknown[]) => mockSignTransaction(...args),
+}));
+
+import InvestPage from '../page';
+
+describe('InvestPage withdraw confirmation (#780)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAcceptedTokens.mockResolvedValue(['TOKEN_A']);
+    mockBuildWithdrawTx.mockResolvedValue('withdraw-xdr');
+    mockSubmitTx.mockResolvedValue(undefined);
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: 'signed-xdr', error: null });
+    mockUseStore.mockReturnValue({
+      wallet: { address: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', connected: true },
+      poolConfig: { yieldBps: 800 },
+      setPoolConfig: jest.fn(),
+      position: {
+        deposited: 1_000_0000000n,
+        available: 1_000_0000000n,
+        deployed: 0n,
+        earned: 0n,
+        depositCount: 1,
+      },
+      setPosition: jest.fn(),
+    });
+  });
+
+  async function enterWithdrawAmount() {
+    render(<InvestPage />);
+
+    // Switch to withdraw mode (exact match distinguishes it from the submit
+    // button, whose accessible name also contains "modes.withdraw").
+    fireEvent.click(await screen.findByRole('button', { name: 'modes.withdraw' }));
+
+    const amountInput = screen.getByPlaceholderText('0.00');
+    fireEvent.change(amountInput, { target: { value: '100' } });
+
+    const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+    // selectedToken is only populated once getAcceptedTokens() resolves, which
+    // also gates the submit button — wait for it before interacting further.
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+    return submitButton;
+  }
+
+  it('shows a confirmation dialog instead of signing immediately', async () => {
+    const submitButton = await enterWithdrawAmount();
+
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(mockBuildWithdrawTx).not.toHaveBeenCalled();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  it('submits no transaction when the dialog is cancelled', async () => {
+    const submitButton = await enterWithdrawAmount();
+    fireEvent.click(submitButton);
+
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+    expect(mockBuildWithdrawTx).not.toHaveBeenCalled();
+    expect(mockSubmitTx).not.toHaveBeenCalled();
+  });
+
+  it('builds and submits the withdrawal once confirmed', async () => {
+    const submitButton = await enterWithdrawAmount();
+    fireEvent.click(submitButton);
+
+    await screen.findByRole('dialog');
+    fireEvent.click(screen.getByRole('button', { name: /^Withdraw$/i }));
+
+    await waitFor(() => expect(mockBuildWithdrawTx).toHaveBeenCalledTimes(1));
+    expect(mockSubmitTx).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/invest/page.tsx
+++ b/frontend/app/invest/page.tsx
@@ -9,6 +9,7 @@ import { PoolStatsSkeleton } from '@/components/PoolStats';
 import PoolStats from '@/components/PoolStats';
 import { APYCalculator } from '@/components/APYCalculator';
 import { ScenarioModeler } from '@/components/ScenarioModeler';
+import ConfirmActionModal from '@/components/ConfirmActionModal';
 import {
   getPoolConfig,
   getInvestorPosition,
@@ -39,6 +40,10 @@ export default function InvestPage() {
   const [txStatus, setTxStatus] = useState<'idle' | 'pending' | 'confirmed' | 'failed'>('idle');
   const [txHash, setTxHash] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
+  // #780: withdrawals sign and submit immediately with no chance to back out —
+  // route them through a confirmation dialog first (deposits stay direct, since
+  // they're easily reversed by a later withdrawal).
+  const [confirmWithdrawOpen, setConfirmWithdrawOpen] = useState(false);
 
   const [acceptedTokens, setAcceptedTokens] = useState<string[]>([]);
   const [selectedToken, setSelectedToken] = useState<string>('');
@@ -214,6 +219,15 @@ export default function InvestPage() {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
+    if (mode === 'withdraw') {
+      setConfirmWithdrawOpen(true);
+      return;
+    }
+    await submitTransaction();
+  }
+
+  async function handleConfirmWithdraw() {
+    setConfirmWithdrawOpen(false);
     await submitTransaction();
   }
 
@@ -517,6 +531,16 @@ export default function InvestPage() {
           />
         </section>
       </div>
+
+      <ConfirmActionModal
+        title={`Withdraw ${amount ? formatUSDC(toStroops(parseFloat(amount))) : ''} ${stablecoinLabel(selectedToken)}`}
+        description="This will submit an on-chain withdrawal from the pool for wallet signing. Withdrawn funds leave the pool immediately and stop earning yield. This action cannot be undone."
+        onConfirm={() => void handleConfirmWithdraw()}
+        onCancel={() => setConfirmWithdrawOpen(false)}
+        variant="destructive"
+        isOpen={confirmWithdrawOpen}
+        confirmLabel="Withdraw"
+      />
     </div>
   );
 }

--- a/frontend/app/settings/notifications/page.tsx
+++ b/frontend/app/settings/notifications/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import type { AlertType } from '@/lib/alert-rules';
+import { csrfFetch } from '@/lib/csrf';
 import {
   DEFAULT_NOTIFICATION_PREFERENCES,
   loadNotificationPreferences,
@@ -121,7 +122,7 @@ export default function NotificationSettingsPage() {
 
     setSaving(true);
     try {
-      const res = await fetch('/api/notifications/preferences', {
+      const res = await csrfFetch('/api/notifications/preferences', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: prefs.email, webhook: prefs.webhook }),
@@ -144,7 +145,7 @@ export default function NotificationSettingsPage() {
 
     setTestingWebhook(true);
     try {
-      const res = await fetch('/api/notifications/webhook/test', {
+      const res = await csrfFetch('/api/notifications/webhook/test', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ url: prefs.webhook.url }),

--- a/frontend/lib/csrf.ts
+++ b/frontend/lib/csrf.ts
@@ -1,0 +1,21 @@
+const CSRF_COOKIE_NAME = 'csrf_token';
+const CSRF_HEADER_NAME = 'x-csrf-token';
+
+/** Reads the CSRF token minted by `middleware.ts` into `document.cookie`. */
+export function getCsrfToken(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(new RegExp(`(?:^|; )${CSRF_COOKIE_NAME}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]!) : null;
+}
+
+/**
+ * `fetch` wrapper that echoes the CSRF cookie back as a header, satisfying
+ * the double-submit check in `middleware.ts` for state-mutating requests.
+ * Use for every POST/PUT/PATCH/DELETE to a same-origin `/api/*` route.
+ */
+export function csrfFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+  const token = getCsrfToken();
+  const headers = new Headers(init.headers);
+  if (token) headers.set(CSRF_HEADER_NAME, token);
+  return fetch(input, { ...init, headers });
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// #770: CSRF protection for state-mutating API routes.
+//
+// Astera has no cookie-based session today — the SEP-10 flow issues a JWT
+// that the client stores and sends as `Authorization: Bearer <token>`, which
+// a cross-site request cannot forge (browsers don't attach custom headers to
+// cross-origin requests automatically). Two routes rely on that instead of a
+// CSRF token:
+//   - /api/auth/challenge issues a stateless, unauthenticated SEP-10 nonce
+//     scoped to the account the caller names; it has no side effect worth
+//     forging.
+//   - /api/auth/token only succeeds if the request body carries a
+//     transaction signed by the claimed account's private key — the
+//     signature itself is the anti-forgery proof.
+// Every other state-mutating /api/* route is protected with the
+// double-submit cookie pattern below.
+const CSRF_COOKIE = 'csrf_token';
+const CSRF_HEADER = 'x-csrf-token';
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const WALLET_SIGNATURE_EXEMPT = new Set(['/api/auth/challenge', '/api/auth/token']);
+
+function generateToken(): string {
+  return crypto.randomUUID().replace(/-/g, '') + crypto.randomUUID().replace(/-/g, '');
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const cookieToken = request.cookies.get(CSRF_COOKIE)?.value;
+
+  if (
+    pathname.startsWith('/api/') &&
+    MUTATING_METHODS.has(request.method) &&
+    !WALLET_SIGNATURE_EXEMPT.has(pathname)
+  ) {
+    const headerToken = request.headers.get(CSRF_HEADER);
+    if (!headerToken || !cookieToken || headerToken !== cookieToken) {
+      return NextResponse.json({ error: 'invalid_csrf_token' }, { status: 403 });
+    }
+  }
+
+  const response = NextResponse.next();
+
+  // Mint a token on first contact (session start) so the frontend has one to
+  // echo back by the time it makes its first mutating request. Runs on page
+  // navigations too (see matcher below), not just /api/*, since that's the
+  // only way the cookie exists before the very first POST. Deliberately NOT
+  // HttpOnly: the double-submit pattern depends on same-origin JS being able
+  // to read the cookie and attach it as a header — an attacker's cross-site
+  // page can trigger a request but cannot read this cookie itself, so it
+  // can't reproduce the header.
+  if (!cookieToken) {
+    response.cookies.set(CSRF_COOKIE, generateToken(), {
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+    });
+  }
+
+  return response;
+}
+
+export const config = {
+  // Run on every navigable route and API call (excluding static/image
+  // assets) so the CSRF cookie is minted well before the first mutation.
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
## Summary

Four issues assigned to me, bundled into one branch/PR per maintainer preference:

- Closes #780 — frontend missing confirmation dialog before irreversible transactions
- Closes #770 — frontend missing CSRF protection on API routes
- Closes #779 — contract pause mechanism (emergency stop)
- Closes #769 — end-to-end borrower lifecycle integration test

### #780 — confirm before signing irreversible transactions
`Mark Invoice as Defaulted` already used `ConfirmActionModal`. The real gap was the `/invest` withdraw form, which signed and submitted immediately on click with no way to back out of a misclick. Routed it through the existing `ConfirmActionModal` and added tests for: dialog-before-signing, cancel submits nothing, confirm builds and submits.

`Seize Collateral` and `Remove Token` have no frontend UI today — both are already gated behind a two-step propose/execute timelock at the contract level (#742), with no direct-call path, so there's no button yet to attach a dialog to. Building that admin UI is a separate, larger feature and out of scope here.

### #770 — CSRF protection
Added `frontend/middleware.ts` implementing the double-submit-cookie pattern for state-mutating `/api/*` routes, plus `frontend/lib/csrf.ts` (reads the cookie, wraps `fetch`) wired into the two routes that actually mutate state (notification preferences, webhook test).

`/api/auth/challenge` and `/api/auth/token` are exempted and documented inline: they authenticate via a SEP-10 Stellar wallet signature, which a cross-site request cannot forge, so CSRF (which exploits ambient cookie credentials) doesn't apply to them.

### #779 — contract pause mechanism
This already exists in full across all five contracts (invoice, pool, credit_score, compliance, oracle_registry) from prior work — `pause()`/`unpause()`/`is_paused()` with a guard on every user-facing write function. Two things didn't match the issue's acceptance criteria and are fixed here:
- `pool::repay_invoice()` was itself blocked by the pause guard, contradicting "borrowers must always be able to repay." Removed the guard; borrowers can now exit their debt during an emergency pause.
- The `paused`/`unpaused` events only carried the admin address, not a timestamp. Added `env.ledger().timestamp()` to both payloads on the invoice and pool contracts.

### #769 — full lifecycle integration test
Added `test_full_borrower_lifecycle` to `contracts/tests/tests/integration_tests.rs`: create_invoice → deposit_collateral → fund_invoice → time passes (still Funded) → repay_invoice in full → credit score update, with an explicit assertion after every step (status transitions, balances, pool totals, collateral release, credit score).

## Test plan
- [x] Manual review of all diffs (no `cargo test` / `npm test` run per repo constraints on this pass)
- [ ] CI: frontend jest suite (new tests in `frontend/app/invest/__tests__/page.test.tsx`, `frontend/__tests__/middleware.test.ts`)
- [ ] CI: contract test suite (`cargo test`, including the new/updated pool pause tests and `test_full_borrower_lifecycle`)