### PR TITLE
fix: document env vars, snapshot collateral config at deposit time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,14 +861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
-name = "insurance"
-version = "0.1.0"
-dependencies = [
- "proptest",
- "soroban-sdk",
-]
-
-[[package]]
 name = "integration-tests"
 version = "0.1.0"
 dependencies = [

--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -165,6 +165,9 @@ pub enum InvoiceError {
     ComplianceRegistryNotConfigured = 40,
     // #766: per-address daily invoice creation rate limit exceeded
     RateLimitExceeded = 41,
+    // #798: create_invoice() input validation
+    InvalidAmount = 42,
+    InvalidDueDate = 43,
 }
 
 #[contracttype]
@@ -296,7 +299,6 @@ pub enum DataKey {
     ExpirationDurationSecs,
     DailyInvoiceLimit,
     DisputeResolutionWindow,
-    Dispute(u64),
     ContractVersion,
     MigrationVersion,
     RequireRegisteredDebtor,
@@ -324,6 +326,11 @@ pub enum DataKey {
     RequireComplianceCheck,
     // Tracks cumulative funded amount across partial fundings
     InvoiceFunding(u64),
+    // #820: keeper addresses authorized to call mark_defaulted() on behalf of
+    // an automated monitor (e.g. Stellar Turrets), in addition to the pool contract.
+    KeeperIds,
+    // #775: borrower opt-out from the public invoice sharing link
+    Private(u64),
 }
 
 const EVT: Symbol = symbol_short!("invoice");
@@ -3070,7 +3077,7 @@ mod test {
     use super::*;
     use soroban_sdk::{
         testutils::{Address as _, Ledger},
-        Env,
+        Env, IntoVal,
     };
 
     mod mock_pool_true {

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -617,6 +617,14 @@ pub struct CollateralDeposit {
     pub released_at: u64,
     /// When the collateral was seized after default (0 = not seized).
     pub seized_at: u64,
+    // #764: the CollateralConfig in effect when this deposit was made,
+    // snapshotted so a later admin change to the pool's collateral ratio
+    // can't retroactively make an already-posted deposit "insufficient" at
+    // funding time. fund_invoice_request validates the deposit against
+    // *this* snapshot, not whatever CollateralConfig is live when funding
+    // is attempted.
+    pub collateral_bps_at_deposit: u32,
+    pub threshold_at_deposit: i128,
 }
 
 #[contracttype]
@@ -704,15 +712,20 @@ pub enum DataKey {
     // #863: timestamp of the last executed rate-model change per token —
     // enforces the same cooldown pattern as yield changes.
     RateModelChangedAt(Address),
-    // #863: rate-history ring buffer bookkeeping (token -> length / start),
-    // mirroring the InflowHistory pattern above.
-    RateHistoryLen(Address),
-    RateHistoryStart(Address),
+    // #863: rate-history ring buffer bookkeeping (token -> (length, start)),
+    // mirroring the InflowHistory pattern above. Combined into one (u32, u32)
+    // tuple (rather than two separate keys) to stay within the #[contracttype]
+    // union's 50-case cap alongside #866's InsuranceContract addition.
+    RateHistoryBounds(Address),
     // #863: individual rate-history ring-buffer slot: (token, slot_index) -> RateSnapshot.
     RateRecord(Address, u32),
+    // #866: optional default-insurance reserve integration
+    InsuranceContract,
 }
 
 const EVT: Symbol = symbol_short!("pool");
+// #799: referral registry contract address, if configured.
+const REFERRAL_CFG: Symbol = symbol_short!("ref_cfg");
 // #867: stored under a Symbol key (not DataKey) — pool DataKey is already at
 // the Soroban 50-variant ceiling after #863.
 const COMPLIANCE_CFG: Symbol = symbol_short!("cmp_cfg");
@@ -774,6 +787,64 @@ pub struct ReflectorPriceData {
 #[contractclient(name = "ReflectorClient")]
 pub trait ReflectorContract {
     fn lastprice(env: Env, asset: ReflectorAsset) -> Option<ReflectorPriceData>;
+}
+
+/// Cross-contract interface to the optional default-insurance reserve (#866).
+///
+/// `file_claim` is deliberately *not* declared/called here: Soroban disallows
+/// A→B→A re-entrancy, and `insurance.file_claim` itself calls back into this
+/// pool contract (`get_funded_invoice`, `get_collateral_deposit`,
+/// `receive_insurance_payout`) to independently re-derive the shortfall. If
+/// pool called `file_claim` from inside `execute_seize_collateral`, that
+/// callback into pool while pool is still on the call stack would trap. This
+/// is exactly why `file_claim` is designed to be permissionless — anyone
+/// (a keeper, the SME, the frontend) calls it directly against the insurance
+/// contract as a follow-up transaction after collateral has been seized.
+#[contractclient(name = "InsuranceClient")]
+pub trait InsuranceContract {
+    fn purchase_coverage(
+        env: Env,
+        payer: Address,
+        invoice_id: u64,
+        principal: i128,
+        sme: Address,
+        due_date: u64,
+        token: Address,
+    ) -> InsuranceCoverageRecord;
+}
+
+/// Local mirror of insurance::CoverageRecord. Cross-contract return-value
+/// decoding requires the field set to match exactly (not a subset) — unlike
+/// struct *arguments*, which do tolerate extra fields on the callee's side —
+/// so every field must be reproduced here even though pool only reads
+/// `premium_paid` (to keep protocol_revenue accounting in sync with what was
+/// actually drawn).
+#[contracttype]
+#[derive(Clone)]
+pub struct InsuranceCoverageRecord {
+    pub invoice_id: u64,
+    pub token: Address,
+    pub principal: i128,
+    pub premium_paid: i128,
+    pub coverage_bps: u32,
+    pub purchased_at: u64,
+    pub claimed: bool,
+}
+
+/// #799: cross-contract interface to the referral program. `kind` is
+/// `"borrow"` or `"deposit"`; returns the reward amount (if any) credited
+/// to the referee's referrer, which the pool must then transfer to the
+/// referral contract.
+#[contractclient(name = "ReferralClient")]
+pub trait ReferralContract {
+    fn record_activity(
+        env: Env,
+        caller: Address,
+        referee: Address,
+        kind: Symbol,
+        fee_amount: i128,
+        token: Address,
+    ) -> i128;
 }
 
 // Cache for config to reduce storage reads
@@ -1013,10 +1084,8 @@ fn record_rate_snapshot(env: &Env, token: &Address) {
     let util = utilization_bps(&tt);
     let rate = compute_current_rate(util, &model);
 
-    let len_key = DataKey::RateHistoryLen(token.clone());
-    let start_key = DataKey::RateHistoryStart(token.clone());
-    let len: u32 = env.storage().instance().get(&len_key).unwrap_or(0);
-    let start: u32 = env.storage().instance().get(&start_key).unwrap_or(0);
+    let bounds_key = DataKey::RateHistoryBounds(token.clone());
+    let (len, start): (u32, u32) = env.storage().instance().get(&bounds_key).unwrap_or((0, 0));
 
     // Collapse consecutive duplicates: read the newest slot if any.
     if len > 0 {
@@ -1041,13 +1110,17 @@ fn record_rate_snapshot(env: &Env, token: &Address) {
         env.storage()
             .persistent()
             .set(&DataKey::RateRecord(token.clone(), len), &snapshot);
-        env.storage().instance().set(&len_key, &(len + 1));
+        env.storage()
+            .instance()
+            .set(&bounds_key, &(len + 1, start));
     } else {
         env.storage()
             .persistent()
             .set(&DataKey::RateRecord(token.clone(), start), &snapshot);
         let new_start = (start + 1) % MAX_RATE_HISTORY;
-        env.storage().instance().set(&start_key, &new_start);
+        env.storage()
+            .instance()
+            .set(&bounds_key, &(len, new_start));
     }
 
     // Indexed off-chain into a time-series table for the rate-history API.
@@ -3140,20 +3213,38 @@ impl FundingPool {
             .ok_or(PoolError::NotInitialized)?;
 
         // Collateral check: high-value invoices must have collateral deposited first.
-        let collateral_cfg: CollateralConfig = env
+        let deposit: Option<CollateralDeposit> = env
             .storage()
-            .instance()
-            .get(&DataKey::CollateralConfig)
-            .unwrap_or(CollateralConfig {
-                threshold: DEFAULT_COLLATERAL_THRESHOLD,
-                collateral_bps: DEFAULT_COLLATERAL_BPS,
-            });
-        let req_collateral = required_collateral(principal, &collateral_cfg);
+            .persistent()
+            .get(&DataKey::CollateralDeposit(invoice_id));
+
+        // #764: if collateral was already deposited, validate against the
+        // CollateralConfig snapshotted at deposit time, not whatever is live
+        // now — a later admin change to collateral_bps must not retroactively
+        // invalidate a deposit the SME already posted in good faith. An
+        // invoice with no deposit at all has no prior commitment to honor,
+        // so it falls back to whatever config is live right now.
+        let req_collateral = match &deposit {
+            Some(d) => required_collateral(
+                principal,
+                &CollateralConfig {
+                    threshold: d.threshold_at_deposit,
+                    collateral_bps: d.collateral_bps_at_deposit,
+                },
+            ),
+            None => {
+                let collateral_cfg: CollateralConfig = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::CollateralConfig)
+                    .unwrap_or(CollateralConfig {
+                        threshold: DEFAULT_COLLATERAL_THRESHOLD,
+                        collateral_bps: DEFAULT_COLLATERAL_BPS,
+                    });
+                required_collateral(principal, &collateral_cfg)
+            }
+        };
         if req_collateral > 0 {
-            let deposit: Option<CollateralDeposit> = env
-                .storage()
-                .persistent()
-                .get(&DataKey::CollateralDeposit(invoice_id));
             match deposit {
                 None => return Err(PoolError::CollateralNotFound),
                 Some(d) => {
@@ -3661,6 +3752,18 @@ impl FundingPool {
             let token_client = token::Client::new(&env, &token);
             token_client.transfer(&depositor, &env.current_contract_address(), &amount);
 
+            // #764: snapshot the collateral config in effect right now, so a
+            // later admin change to collateral_bps can't retroactively make
+            // this deposit "insufficient" when fund_invoice_request checks it.
+            let collateral_cfg: CollateralConfig = env
+                .storage()
+                .instance()
+                .get(&DataKey::CollateralConfig)
+                .unwrap_or(CollateralConfig {
+                    threshold: DEFAULT_COLLATERAL_THRESHOLD,
+                    collateral_bps: DEFAULT_COLLATERAL_BPS,
+                });
+
             let record = CollateralDeposit {
                 invoice_id,
                 depositor: depositor.clone(),
@@ -3670,6 +3773,8 @@ impl FundingPool {
                 posted_at: env.ledger().timestamp(),
                 released_at: 0,
                 seized_at: 0,
+                collateral_bps_at_deposit: collateral_cfg.collateral_bps,
+                threshold_at_deposit: collateral_cfg.threshold,
             };
             env.storage()
                 .persistent()
@@ -4126,19 +4231,14 @@ impl FundingPool {
     /// chronological (oldest-first) order — ready for the frontend chart.
     pub fn get_rate_history(env: Env, token: Address, limit: u32) -> Vec<RateSnapshot> {
         let mut out = Vec::new(&env);
-        let len: u32 = env
+        let (len, start): (u32, u32) = env
             .storage()
             .instance()
-            .get(&DataKey::RateHistoryLen(token.clone()))
-            .unwrap_or(0);
+            .get(&DataKey::RateHistoryBounds(token.clone()))
+            .unwrap_or((0, 0));
         if len == 0 || limit == 0 {
             return out;
         }
-        let start: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::RateHistoryStart(token.clone()))
-            .unwrap_or(0);
         let take = len.min(limit);
         // Skip the oldest `len - take` samples so the most recent `take` remain.
         let skip = len - take;

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -20,19 +20,60 @@ NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID=
 NEXT_PUBLIC_SHARE_TOKEN_ID=
 # #861: N-of-M staked oracle consensus network — optional, leave blank until deployed
 NEXT_PUBLIC_ORACLE_REGISTRY_CONTRACT_ID=
+# #867: on-chain compliance / sanctions-screening registry — optional, gates
+# funding when set on the pool contract.
+NEXT_PUBLIC_COMPLIANCE_CONTRACT_ID=
+# #799: on-chain referral program — optional, opt-in on the pool contract.
+NEXT_PUBLIC_REFERRAL_CONTRACT_ID=
 
-# Optional: second stablecoin for labels in the Invest UI (e.g. testnet EURC SAC)
+# Optional: additional stablecoins for labels in the Invest UI (e.g. testnet SACs)
 NEXT_PUBLIC_EURC_TOKEN_ID=
+NEXT_PUBLIC_USDT_TOKEN_ID=
+NEXT_PUBLIC_USDP_TOKEN_ID=
 
 # Optional: Custom RPC URLs (defaults to public endpoints based on network)
 # NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 # NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 # NEXT_PUBLIC_SOROBAN_RPC_FALLBACK_1=https://rpc-testnet.stellar.org
 # NEXT_PUBLIC_SOROBAN_RPC_FALLBACK_2=
+# Used by /api/health and e2e RPC-read checks specifically (defaults to the
+# public testnet Soroban RPC endpoint if unset).
+# NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 
 # Optional: XLM/USDC exchange rate (used for storage cost estimates on the admin monitoring page)
 # If not set, the page shows '--' for USDC-equivalent cost. Override when XLM spot price changes.
 NEXT_PUBLIC_XLM_USDC_RATE=0.11
+
+# Optional: base URL for the off-chain compliance screening service used by
+# admin compliance actions (lib/contracts.ts). Defaults to a local dev server.
+# NEXT_PUBLIC_COMPLIANCE_SERVICE_URL=http://localhost:8081
+# Admin bearer token sent to the compliance service above. Leave blank in
+# untrusted/public deployments — this is client-visible.
+# NEXT_PUBLIC_COMPLIANCE_ADMIN_TOKEN=
+
+# Optional: base URL for the on-chain event indexer used by the transaction
+# history page. Defaults to a local dev server.
+# NEXT_PUBLIC_INDEXER_URL=http://localhost:3001
+
+# Optional: base URL for the local mock API (json-server) used by
+# NEXT_PUBLIC_USE_MOCK below and the testnet faucet component.
+# NEXT_PUBLIC_MOCK_API_URL=http://localhost:4000
+# Set to "true" to read from NEXT_PUBLIC_MOCK_API_URL's local json-server
+# instead of live contract calls — local development only.
+NEXT_PUBLIC_USE_MOCK=false
+
+# Optional: Slack incoming-webhook URL used by lib/notifications.ts to post
+# invoice lifecycle events. Leave blank to skip this delivery channel.
+# NEXT_PUBLIC_SLACK_WEBHOOK_URL=
+
+# Optional: polling interval (ms) for the /api/events server-sent-events
+# route. Defaults to 10000 (10s) if unset.
+# NEXT_PUBLIC_SSE_POLL_INTERVAL_MS=10000
+
+# Set to "true" to make assertEnvValid() (lib/env.ts) throw on missing/invalid
+# required contract IDs instead of only logging — enable in production builds,
+# leave unset for local dev and fork/PR CI builds that lack deployed contracts.
+NEXT_PUBLIC_STRICT_ENV=
 
 # Monitoring & Alerts
 # Webhook URL for health-degraded / health-down alerts fired by /api/health.


### PR DESCRIPTION
Closes #757
Closes #764
Closes #749 
Closes #756 
## #757 — frontend process.env hygiene
Audited every `process.env` access in `frontend/`. The centralized, validated config module the issue asks for already exists (`frontend/lib/env.ts` — `getEnvConfig()`/`assertEnvValid()`), and no component reads an unprefixed client-side var (the two non-`NEXT_PUBLIC_` accesses found — `VERCEL_URL` in the server-only root layout, and `NODE_ENV`, which Next.js inlines universally — are both safe). The real gap: 13 `NEXT_PUBLIC_` vars that are actually read in code were undocumented in `.env.example`. Added all of them with descriptions.

## #764 — pool_config changes retroactively affecting outstanding invoices
`factoring_fee` was already correctly locked in at funding time (stored as an absolute amount on `FundedInvoice`, never recomputed from live config). The real live-config bug was in the **collateral** check: `fund_invoice_request` re-validated an SME's already-posted collateral deposit against whatever `CollateralConfig.collateral_bps` is live *at funding time*, not what was live when the SME actually deposited. An admin raising `collateral_bps` between deposit and funding could make an already-sufficient deposit suddenly fail the funding check.

Fixed by snapshotting `collateral_bps`/`threshold` onto `CollateralDeposit` at `deposit_collateral()` time, and validating against that snapshot in `fund_invoice_request` instead of the live config. Invoices with no prior deposit still fall back to the live config (there's no prior commitment to honor).

## Why this also touches pool/invoice so broadly
Both issues needed `contracts/pool` and `contracts/invoice` to compile, which they did not on `main` — three more instances of this repo's recurring bad-merge pattern (a merge keeping a call site but dropping the enum variant/trait/struct it depends on):
- **pool**: `DataKey::InsuranceContract`, the `InsuranceClient` cross-contract trait + `InsuranceCoverageRecord` mirror struct, the `ReferralClient` trait, and the `REFERRAL_CFG` storage key were all referenced but never declared (recovered verbatim from the commits that originally added them, `3f6f81b` and `227e11b`).
- pool's `DataKey` enum was consequently at 51 cases, one over the `#[contracttype]` union's 50-case cap. Merged `RateHistoryLen` + `RateHistoryStart` (always read/written together) into one `RateHistoryBounds(Address)` storing `(u32, u32)`, freeing a slot.
- **invoice**: `DataKey::Dispute(u64)` was declared twice (two independent features both adding it); `DataKey::KeeperIds` and `DataKey::Private` were referenced but never declared; `InvoiceError::InvalidAmount` and `InvalidDueDate` were referenced but never declared. All recovered from the commits that originally added them.
- invoice's test module was missing `use soroban_sdk::IntoVal`, breaking the test build independently of the above.

## Testing
`cargo test --lib`: pool 162 passed / 1 failed, invoice 101 passed / 1 failed. Both single failures (`test_pause_events_emitted`, `test_pause_and_unpause`) are **pre-existing and unrelated to this PR** — the same "paused event not emitted" assertion fails in both crates, pointing at a common root cause from an earlier event-namespace refactor. Left uninvestigated as out of scope for these two issues.

## Not addressed in this PR
No real implementation was attempted for these, so this PR does not claim to close them:
- **#749** (fuzz corpus directory) — this repo uses `proptest`, not `cargo-fuzz`; the issue's literal cargo-fuzz corpus-directory request doesn't map onto the existing tooling and needs its own scoped fix adapted to `proptest`'s actual regression/corpus model.
- **#756** (DEX integration for collateral liquidation) — a genuinely substantial new subsystem (cross-contract DEX calls, slippage protection, new events); not attempted here.