### PR TITLE
Add governance/insurance event parsing, SDK batch-read helpers, honest upgrade docs

### DIFF
--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -6,6 +6,10 @@ migrated after an upgrade. For the operational deploy runbook see
 [`contract-upgrade-guide.md`](./contract-upgrade-guide.md); this document focuses
 on the on-chain mechanism and the version/migration hooks added in #397.
 
+The newer `governance` and `insurance` contracts do **not** currently
+implement this flow at all — see [Per-contract status](#per-contract-status)
+below.
+
 ## Overview
 
 Each contract supports an in-place WASM upgrade behind a 24-hour timelock, plus a
@@ -106,7 +110,26 @@ stellar contract invoke --id <CONTRACT_ID> -- migration_version
 | `invoice` | ✅ | ✅ | ✅ |
 | `pool` | ✅ | ✅ | ✅ |
 | `credit_score` | ✅ | ✅ | ✅ |
+| `governance` | ❌ | ❌ | ❌ |
+| `insurance` | ❌ | ❌ | ❌ |
 
-`CURRENT_MIGRATION_VERSION` is currently `1` in each contract; freshly
-initialized contracts start at `migration_version() == 0` until `run_migration`
-is invoked.
+`CURRENT_MIGRATION_VERSION` is currently `1` in each contract that has one;
+freshly initialized contracts start at `migration_version() == 0` until
+`run_migration` is invoked.
+
+### `governance` and `insurance` — no upgrade mechanism yet (#988)
+
+Neither contract implements any part of the flow above — there is no
+`propose_upgrade`/`execute_upgrade`/`run_migration`/`version`/
+`migration_version` in `contracts/governance/src/lib.rs` or
+`contracts/insurance/src/lib.rs` (confirmed by grepping both files; none of
+those identifiers appear at all). A deployed `governance` or `insurance`
+contract today has **no in-place upgrade path** — replacing its logic
+requires deploying a new contract instance and migrating state manually.
+
+Adding the timelocked upgrade + migration mechanism to these two contracts —
+following the same `propose_upgrade`/`execute_upgrade`/`run_migration`
+pattern as `invoice`/`pool`/`credit_score` — is real contract work (new
+`DataKey` variants, new admin-gated entry points, tests), not a documentation
+change, and is out of scope here. This section exists so the gap is explicit
+rather than silently assumed away.

--- a/packages/sdk/jest.config.js
+++ b/packages/sdk/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+};

--- a/packages/sdk/src/clients/invoice.batch.test.ts
+++ b/packages/sdk/src/clients/invoice.batch.test.ts
@@ -1,0 +1,58 @@
+import { xdr } from '@stellar/stellar-sdk';
+import { InvoiceClient } from './invoice';
+
+describe('InvoiceClient.getMultipleInvoices (#987)', () => {
+  function invoiceScVal(id: number): xdr.ScVal {
+    return xdr.ScVal.scvMap(
+      Object.entries({
+        id: xdr.ScVal.scvU64(new xdr.Uint64(id)),
+        owner: xdr.ScVal.scvString('GOWNER'),
+        debtor: xdr.ScVal.scvString('GDEBTOR'),
+        amount: xdr.ScVal.scvI128(
+          new xdr.Int128Parts({ hi: xdr.Int64.fromString('0'), lo: xdr.Uint64.fromString('500') }),
+        ),
+        due_date: xdr.ScVal.scvU64(new xdr.Uint64(1700086400)),
+        description: xdr.ScVal.scvString('test invoice'),
+        status: xdr.ScVal.scvSymbol('Pending'),
+        created_at: xdr.ScVal.scvU64(new xdr.Uint64(1700000000)),
+        funded_at: xdr.ScVal.scvU64(new xdr.Uint64(0)),
+        paid_at: xdr.ScVal.scvU64(new xdr.Uint64(0)),
+        pool_contract: xdr.ScVal.scvString('CPOOL'),
+      }).map(([key, val]) => new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol(key), val })),
+    );
+  }
+
+  it('decodes a batch of invoices in request order', async () => {
+    const client = new InvoiceClient({
+      rpcUrl: 'https://example.com',
+      network: 'Test SDF Network ; September 2015',
+      contractId: 'CINVOICE',
+    });
+
+    const retval = xdr.ScVal.scvVec([invoiceScVal(1), invoiceScVal(2)]);
+
+    jest.spyOn(client as any, 'simulate').mockResolvedValue({
+      result: { retval },
+    });
+
+    const result = await client.getMultipleInvoices([1, 2]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe(1n);
+    expect(result[1].id).toBe(2n);
+  });
+
+  it('propagates a simulation error instead of decoding', async () => {
+    const client = new InvoiceClient({
+      rpcUrl: 'https://example.com',
+      network: 'Test SDF Network ; September 2015',
+      contractId: 'CINVOICE',
+    });
+
+    jest.spyOn(client as any, 'simulate').mockResolvedValue({
+      error: 'HostError: some failure',
+    });
+
+    await expect(client.getMultipleInvoices([1, 2])).rejects.toThrow('Simulation failed');
+  });
+});

--- a/packages/sdk/src/clients/invoice.ts
+++ b/packages/sdk/src/clients/invoice.ts
@@ -1,5 +1,5 @@
 import { Contract, TransactionBuilder, BASE_FEE, rpc as StellarRpc } from '@stellar/stellar-sdk';
-import { BaseClient, nativeToScVal, scValToNative, Address } from './base';
+import { BaseClient, nativeToScVal, scValToNative, Address, xdr } from './base';
 import type { ClientConfig, Invoice, InvoiceMetadata, TransactionProgress } from '../types';
 import type { Signer } from '../types';
 
@@ -37,6 +37,21 @@ export class InvoiceClient extends BaseClient {
       throw new Error(`Simulation failed: ${sim.error}`);
     }
     return scValToNative(sim.result!.retval) as Invoice;
+  }
+
+  /**
+   * #987 — batch-read helper matching the on-chain get_multiple_invoices, so
+   * consumers don't have to assemble the Vec<u64> call manually or fall back
+   * to one RPC per id. Order of the returned array matches `ids`.
+   */
+  async getMultipleInvoices(ids: Array<bigint | number>): Promise<Invoice[]> {
+    const sim = await this.simulate('get_multiple_invoices', [
+      xdr.ScVal.scvVec(ids.map((id) => nativeToScVal(id, { type: 'u64' }))),
+    ]);
+    if (StellarRpc.Api.isSimulationError(sim)) {
+      throw new Error(`Simulation failed: ${sim.error}`);
+    }
+    return scValToNative(sim.result!.retval) as Invoice[];
   }
 
   async getMetadata(id: bigint | number): Promise<InvoiceMetadata> {

--- a/packages/sdk/src/clients/pool.batch.test.ts
+++ b/packages/sdk/src/clients/pool.batch.test.ts
@@ -1,0 +1,65 @@
+import { xdr } from '@stellar/stellar-sdk';
+import { PoolClient } from './pool';
+
+describe('PoolClient.getFundedInvoicesBatch (#987)', () => {
+  function scvMap(fields: Record<string, xdr.ScVal>): xdr.ScVal {
+    return xdr.ScVal.scvMap(
+      Object.entries(fields).map(
+        ([key, val]) =>
+          new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol(key), val }),
+      ),
+    );
+  }
+
+  function fundedInvoiceScVal(invoiceId: number): xdr.ScVal {
+    return scvMap({
+      invoice_id: xdr.ScVal.scvU64(new xdr.Uint64(invoiceId)),
+      sme: xdr.ScVal.scvString('GSME'),
+      token: xdr.ScVal.scvString('GTOKEN'),
+      principal: xdr.ScVal.scvI128(
+        new xdr.Int128Parts({ hi: xdr.Int64.fromString('0'), lo: xdr.Uint64.fromString('1000') }),
+      ),
+      funded_at: xdr.ScVal.scvU64(new xdr.Uint64(1700000000)),
+      due_date: xdr.ScVal.scvU64(new xdr.Uint64(1700086400)),
+    });
+  }
+
+  it('decodes a batch response preserving null entries for missing invoices', async () => {
+    const client = new PoolClient({
+      rpcUrl: 'https://example.com',
+      network: 'Test SDF Network ; September 2015',
+      contractId: 'CPOOL',
+    });
+
+    const retval = xdr.ScVal.scvVec([
+      fundedInvoiceScVal(1),
+      xdr.ScVal.scvVoid(),
+      fundedInvoiceScVal(3),
+    ]);
+
+    jest.spyOn(client as any, 'simulate').mockResolvedValue({
+      result: { retval },
+    });
+
+    const result = await client.getFundedInvoicesBatch([1, 2, 3]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]?.invoiceId).toBe(1n);
+    expect(result[1]).toBeNull();
+    expect(result[2]?.invoiceId).toBe(3n);
+  });
+
+  it('propagates a simulation error (e.g. batch-too-large rejection) instead of decoding', async () => {
+    const client = new PoolClient({
+      rpcUrl: 'https://example.com',
+      network: 'Test SDF Network ; September 2015',
+      contractId: 'CPOOL',
+    });
+
+    jest.spyOn(client as any, 'simulate').mockResolvedValue({
+      error: 'HostError: Error(Contract, #BatchTooLarge)',
+    });
+
+    await expect(client.getFundedInvoicesBatch([1, 2, 3])).rejects.toThrow('Simulation failed');
+  });
+});

--- a/packages/sdk/src/clients/pool.ts
+++ b/packages/sdk/src/clients/pool.ts
@@ -78,6 +78,23 @@ function rateModelConfigFromScVal(raw: Record<string, unknown>): RateModelConfig
   };
 }
 
+function mapFundedInvoice(raw: unknown): FundedInvoice | null {
+  if (!raw) return null;
+  const r = raw as Record<string, unknown>;
+  return {
+    invoiceId: BigInt(String(r.invoice_id)),
+    sme: r.sme as string,
+    token: r.token as string,
+    principal: BigInt(String(r.principal)),
+    committed: BigInt(String(r.committed ?? 0)),
+    fundedAt: Number(r.funded_at),
+    factoringFee: BigInt(String(r.factoring_fee ?? 0)),
+    dueDate: Number(r.due_date),
+    repaidAmount: BigInt(String(r.repaid_amount ?? 0)),
+    coFundingRoundId: r.co_funding_round_id != null ? BigInt(String(r.co_funding_round_id)) : undefined,
+  };
+}
+
 export class PoolClient extends BaseClient {
   constructor(config: ClientConfig) {
     super(config);
@@ -577,21 +594,24 @@ export class PoolClient extends BaseClient {
     if (StellarRpc.Api.isSimulationError(sim)) {
       throw new Error(`Simulation failed: ${sim.error}`);
     }
-    const raw = scValToNative(sim.result!.retval);
-    if (!raw) return null;
-    const r = raw as Record<string, unknown>;
-    return {
-      invoiceId: BigInt(String(r.invoice_id)),
-      sme: r.sme as string,
-      token: r.token as string,
-      principal: BigInt(String(r.principal)),
-      committed: BigInt(String(r.committed ?? 0)),
-      fundedAt: Number(r.funded_at),
-      factoringFee: BigInt(String(r.factoring_fee ?? 0)),
-      dueDate: Number(r.due_date),
-      repaidAmount: BigInt(String(r.repaid_amount ?? 0)),
-      coFundingRoundId: r.co_funding_round_id != null ? BigInt(String(r.co_funding_round_id)) : undefined,
-    };
+    return mapFundedInvoice(scValToNative(sim.result!.retval));
+  }
+
+  /**
+   * #987 — batch-read helper matching the on-chain get_funded_invoices_batch,
+   * so consumers don't have to assemble the Vec<u64> call manually or fall
+   * back to one RPC per id. Order of the returned array matches `invoiceIds`
+   * (null entries mean that id has no funded-invoice record).
+   */
+  async getFundedInvoicesBatch(invoiceIds: Array<bigint | number>): Promise<Array<FundedInvoice | null>> {
+    const sim = await this.simulate('get_funded_invoices_batch', [
+      xdr.ScVal.scvVec(invoiceIds.map((id) => nativeToScVal(id, { type: 'u64' }))),
+    ]);
+    if (StellarRpc.Api.isSimulationError(sim)) {
+      throw new Error(`Simulation failed: ${sim.error}`);
+    }
+    const raw = scValToNative(sim.result!.retval) as unknown[];
+    return raw.map((entry) => mapFundedInvoice(entry));
   }
 
   async getPoolTokenTotals(token: string): Promise<PoolTokenTotals> {

--- a/sdk/src/events.ts
+++ b/sdk/src/events.ts
@@ -62,6 +62,85 @@ export interface ShareApproveEvent {
   amount: bigint;
 }
 
+// #985 — governance contract events (topic namespace "gov")
+export interface GovernanceProposalCreatedEvent {
+  type: 'governance:proposal_created';
+  proposalId: bigint;
+  proposer: string;
+}
+
+export interface GovernanceVoteCastEvent {
+  type: 'governance:vote_cast';
+  proposalId: bigint;
+  voter: string;
+  inFavor: boolean;
+  weight: bigint;
+}
+
+export interface GovernanceProposalExecutedEvent {
+  type: 'governance:proposal_executed';
+  proposalId: bigint;
+  targetContract: string;
+  functionName: string;
+  calldata: unknown[];
+}
+
+export interface GovernanceProposalCancelledEvent {
+  type: 'governance:proposal_cancelled';
+  proposalId: bigint;
+  caller: string;
+}
+
+// #985 — insurance contract events (topic namespace "INSURNCE", matching
+// the on-chain `symbol_short!("INSURNCE")` EVT constant exactly)
+export interface InsuranceInitializedEvent {
+  type: 'insurance:initialized';
+  admin: string;
+}
+
+export interface InsurancePremiumConfigSetEvent {
+  type: 'insurance:premium_config_set';
+  admin: string;
+}
+
+export interface InsuranceMinCoverageRatioSetEvent {
+  type: 'insurance:min_coverage_ratio_set';
+  admin: string;
+  token: string;
+  minRatioBps: number;
+}
+
+export interface InsurancePausedEvent {
+  type: 'insurance:paused';
+  admin: string;
+}
+
+export interface InsuranceUnpausedEvent {
+  type: 'insurance:unpaused';
+  admin: string;
+}
+
+export interface InsuranceReserveFundedEvent {
+  type: 'insurance:reserve_funded';
+  admin: string;
+  token: string;
+  amount: bigint;
+}
+
+export interface InsuranceCoveragePurchasedEvent {
+  type: 'insurance:coverage_purchased';
+  invoiceId: bigint;
+  payer: string;
+  premium: bigint;
+  coverageBps: number;
+}
+
+export interface InsuranceClaimPaidEvent {
+  type: 'insurance:claim_paid';
+  invoiceId: bigint;
+  payout: bigint;
+}
+
 export type ContractEventType =
   | PoolDepositEvent
   | PoolWithdrawalEvent
@@ -69,7 +148,19 @@ export type ContractEventType =
   | ShareMintEvent
   | ShareBurnEvent
   | ShareTransferEvent
-  | ShareApproveEvent;
+  | ShareApproveEvent
+  | GovernanceProposalCreatedEvent
+  | GovernanceVoteCastEvent
+  | GovernanceProposalExecutedEvent
+  | GovernanceProposalCancelledEvent
+  | InsuranceInitializedEvent
+  | InsurancePremiumConfigSetEvent
+  | InsuranceMinCoverageRatioSetEvent
+  | InsurancePausedEvent
+  | InsuranceUnpausedEvent
+  | InsuranceReserveFundedEvent
+  | InsuranceCoveragePurchasedEvent
+  | InsuranceClaimPaidEvent;
 
 export function parseContractEvent(event: {
   topic: string[];
@@ -169,6 +260,132 @@ export function parseContractEvent(event: {
             spender: String(spender),
             amount: BigInt(String(amount)),
           } as ShareApproveEvent;
+        }
+      }
+    }
+
+    // #985 — governance contract events (EVT = symbol_short!("gov"))
+    if (namespace === 'gov') {
+      const values = event.value.map((v) => scValToNative(v));
+
+      switch (action) {
+        case 'create': {
+          const [id, proposer] = values;
+          return {
+            type: 'governance:proposal_created',
+            proposalId: BigInt(String(id)),
+            proposer: String(proposer),
+          } as GovernanceProposalCreatedEvent;
+        }
+
+        case 'vote': {
+          const [proposalId, voter, inFavor, weight] = values;
+          return {
+            type: 'governance:vote_cast',
+            proposalId: BigInt(String(proposalId)),
+            voter: String(voter),
+            inFavor: Boolean(inFavor),
+            weight: BigInt(String(weight)),
+          } as GovernanceVoteCastEvent;
+        }
+
+        case 'execute': {
+          const [proposalId, targetContract, functionName, calldata] = values;
+          return {
+            type: 'governance:proposal_executed',
+            proposalId: BigInt(String(proposalId)),
+            targetContract: String(targetContract),
+            functionName: String(functionName),
+            calldata: Array.isArray(calldata) ? calldata : [calldata],
+          } as GovernanceProposalExecutedEvent;
+        }
+
+        case 'cancel': {
+          const [proposalId, caller] = values;
+          return {
+            type: 'governance:proposal_cancelled',
+            proposalId: BigInt(String(proposalId)),
+            caller: String(caller),
+          } as GovernanceProposalCancelledEvent;
+        }
+      }
+    }
+
+    // #985 — insurance contract events (EVT = symbol_short!("INSURNCE"))
+    if (namespace === 'INSURNCE') {
+      const values = event.value.map((v) => scValToNative(v));
+
+      switch (action) {
+        case 'init': {
+          const [admin] = values;
+          return {
+            type: 'insurance:initialized',
+            admin: String(admin),
+          } as InsuranceInitializedEvent;
+        }
+
+        case 'cfg_set': {
+          const [admin] = values;
+          return {
+            type: 'insurance:premium_config_set',
+            admin: String(admin),
+          } as InsurancePremiumConfigSetEvent;
+        }
+
+        case 'mcr_set': {
+          const [admin, token, minRatioBps] = values;
+          return {
+            type: 'insurance:min_coverage_ratio_set',
+            admin: String(admin),
+            token: String(token),
+            minRatioBps: Number(minRatioBps),
+          } as InsuranceMinCoverageRatioSetEvent;
+        }
+
+        case 'paused': {
+          const [admin] = values;
+          return {
+            type: 'insurance:paused',
+            admin: String(admin),
+          } as InsurancePausedEvent;
+        }
+
+        case 'unpaused': {
+          const [admin] = values;
+          return {
+            type: 'insurance:unpaused',
+            admin: String(admin),
+          } as InsuranceUnpausedEvent;
+        }
+
+        case 'funded': {
+          const [admin, token, amount] = values;
+          return {
+            type: 'insurance:reserve_funded',
+            admin: String(admin),
+            token: String(token),
+            amount: BigInt(String(amount)),
+          } as InsuranceReserveFundedEvent;
+        }
+
+        case 'covered': {
+          const [invoiceId, payer, premium, coverageBps] = values;
+          return {
+            type: 'insurance:coverage_purchased',
+            invoiceId: BigInt(String(invoiceId)),
+            payer: String(payer),
+            premium: BigInt(String(premium)),
+            coverageBps: Number(coverageBps),
+          } as InsuranceCoveragePurchasedEvent;
+        }
+
+        case 'claimed': {
+          const [invoiceId, payout] = values;
+          return {
+            type: 'insurance:claim_paid',
+            invoiceId: BigInt(String(invoiceId)),
+            payout: BigInt(String(payout)),
+          } as InsuranceClaimPaidEvent;
         }
       }
     }


### PR DESCRIPTION
Closes #985
Closes #986
Closes #987
Closes #988

## #985 — add event helpers for governance and insurance contracts
`sdk/src/events.ts` previously only parsed `pool` and `share` namespace events (not even invoice/oracle_registry, despite the issue's premise — verified those aren't parsed either, but out of scope here). Added parsing for all 4 governance events (`create`/`vote`/`execute`/`cancel`, topic `"gov"`) and all 8 insurance events (`init`/`cfg_set`/`mcr_set`/`paused`/`unpaused`/`funded`/`covered`/`claimed`, topic `"INSURNCE"` — matching the on-chain `symbol_short!()` value exactly, not `"insurance"`), matching the existing pool/share decoding pattern and extending `ContractEventType`.

## #987 — add batch-read helpers to the SDK
Added `PoolClient.getFundedInvoicesBatch()` and `InvoiceClient.getMultipleInvoices()` in `packages/sdk/src/clients/`, matching the on-chain `get_funded_invoices_batch`/`get_multiple_invoices` functions. Both build the `Vec<u64>` argument directly (`xdr.ScVal.scvVec`) instead of requiring callers to do it themselves or fall back to one RPC call per id. `getFundedInvoicesBatch` reuses the same field-mapping logic as the existing single-item `getFundedInvoice` (extracted into a shared `mapFundedInvoice()` so the two can't drift). Added `packages/sdk/jest.config.js` (ts-jest preset) since no jest config existed anywhere in this package — the `"test"` script was previously non-functional — plus tests for both new methods covering the success decode path (including null entries for missing invoices) and the simulation-error path.

## #986 — network passphrase hardcoded to testnet in `stellar.ts`
Already fixed / not actually present on `main` — `AsteraConfig.network` is a required constructor field threaded all the way through `AsteraClient` → each sub-client → `BaseClient` → `TransactionBuilder`'s `networkPassphrase` and `TransactionBuilder.fromXDR` (verified by reading `packages/sdk/src/clients/base.ts` and `astera-client.ts` directly; no hardcoded `"Test SDF Network..."`/`"Public Global Stellar Network..."` string exists anywhere in `sdk/src/*.ts` or `packages/sdk/src/*.ts`). No code change needed for this one.

## #988 — document the upgrade timelock flow for governance/insurance
Grepped both contracts for `propose_upgrade`/`execute_upgrade`/`run_migration`/`migration_version`/`version` — none of these exist in `contracts/governance/src/lib.rs` or `contracts/insurance/src/lib.rs` at all. There is no upgrade-timelock flow to document for these two contracts because it hasn't been built yet. Writing documentation describing a mechanism that doesn't exist would be actively misleading, so instead updated `docs/upgrades.md`'s "Per-contract status" table to show governance/insurance as ❌ across the board, with a new section explaining exactly what's missing and that implementing it is a separate, real contract-engineering task (new `DataKey` variants, admin-gated entry points, tests) — out of scope for a docs fix.

## Not addressed — pre-existing, unrelated
`sdk/src/client.ts` (and `index.ts`) fail to type-check independent of this PR: `client.ts` imports `AsteraConfig`/`AttestorType`/etc. from `'../../packages/sdk/src/types'`, which doesn't export several of those names, and `index.ts` re-exports from both `./types` and `./events`, which both already independently declared `PoolDepositEvent`/`PoolWithdrawalEvent`/etc. before this PR touched anything — confirmed via `git stash` (25 pre-existing `tsc` errors, unchanged with or without this PR's changes). None of the names this PR adds (`Governance*`/`Insurance*` event types) appear in that error list. `packages/sdk` (where the real, working client code and my new batch methods live) type-checks and tests cleanly on its own.

## Testing
- `packages/sdk`: `npx tsc --noEmit` clean; `npx jest` 4/4 passing (new).
- `sdk/`: pre-existing 25 `tsc` errors unchanged by this PR (see above); `events.ts` itself has no errors attributable to the new event types.