### PR TITLE
feat(exchange-rates): add confirmation modal for exchange rate submis…

### DIFF
--- a/frontend/app/admin/exchange-rates/page.test.tsx
+++ b/frontend/app/admin/exchange-rates/page.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AdminExchangeRatesPage from './page';
+
+const mockGetAcceptedTokens = jest.fn();
+const mockGetExchangeRate = jest.fn();
+const mockBuildSetExchangeRateTx = jest.fn();
+const mockSubmitTx = jest.fn();
+const mockSignTransaction = jest.fn();
+
+jest.mock('@/lib/contracts', () => ({
+  getAcceptedTokens: (...args: unknown[]) => mockGetAcceptedTokens(...args),
+  getExchangeRate: (...args: unknown[]) => mockGetExchangeRate(...args),
+  buildSetExchangeRateTx: (...args: unknown[]) => mockBuildSetExchangeRateTx(...args),
+  submitTx: (...args: unknown[]) => mockSubmitTx(...args),
+}));
+
+jest.mock('@/lib/store', () => ({
+  useStore: () => ({
+    wallet: { address: 'GABC123', connected: true, network: 'testnet' },
+  }),
+}));
+
+jest.mock('@stellar/freighter-api', () => ({
+  signTransaction: (...args: unknown[]) => mockSignTransaction(...args),
+}));
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/Skeleton', () => ({
+  Skeleton: ({ className }: { className: string }) => <div data-testid="skeleton" className={className} />,
+}));
+
+describe('AdminExchangeRatesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAcceptedTokens.mockResolvedValue(['USDC', 'EURC']);
+    mockGetExchangeRate.mockImplementation((token: string) =>
+      Promise.resolve(token === 'USDC' ? 10_000 : 10_800),
+    );
+    mockBuildSetExchangeRateTx.mockResolvedValue('xdr');
+    mockSubmitTx.mockResolvedValue(undefined);
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: 'signed-xdr', error: null });
+  });
+
+  it('requires confirmation before submitting the exchange rate transaction', async () => {
+    const user = userEvent.setup();
+
+    render(<AdminExchangeRatesPage />);
+
+    await waitFor(() => expect(screen.getByText('Current Rates')).toBeInTheDocument());
+
+    await user.type(screen.getByPlaceholderText('e.g. 100'), '108');
+    await user.click(screen.getByRole('button', { name: /set exchange rate/i }));
+
+    expect(screen.getByText(/review exchange rate update/i)).toBeInTheDocument();
+    expect(mockBuildSetExchangeRateTx).not.toHaveBeenCalled();
+    expect(mockSubmitTx).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /confirm & submit/i }));
+
+    await waitFor(() => expect(mockBuildSetExchangeRateTx).toHaveBeenCalledWith('GABC123', 'USDC', 10_800));
+    expect(mockSubmitTx).toHaveBeenCalledWith('signed-xdr');
+  });
+});

--- a/frontend/app/admin/exchange-rates/page.tsx
+++ b/frontend/app/admin/exchange-rates/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useStore } from '@/lib/store';
 import { Skeleton } from '@/components/Skeleton';
+import ConfirmActionModal from '@/components/ConfirmActionModal';
 import {
   getAcceptedTokens,
   getExchangeRate,
@@ -20,6 +21,8 @@ export default function AdminExchangeRatesPage() {
   const [txLoading, setTxLoading] = useState(false);
   const [selectedToken, setSelectedToken] = useState('');
   const [newRatePct, setNewRatePct] = useState('');
+  const [showReviewModal, setShowReviewModal] = useState(false);
+  const [pendingRate, setPendingRate] = useState<{ token: string; pct: string; bps: number } | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -54,8 +57,7 @@ export default function AdminExchangeRatesPage() {
     await submitTx(signedTxXdr);
   }
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  function openReviewModal() {
     if (!wallet.address || !selectedToken || !newRatePct) return;
 
     const bps = Math.round(parseFloat(newRatePct) * 100);
@@ -64,15 +66,30 @@ export default function AdminExchangeRatesPage() {
       return;
     }
 
+    setPendingRate({ token: selectedToken, pct: newRatePct, bps });
+    setShowReviewModal(true);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    openReviewModal();
+  }
+
+  async function confirmAndSubmit() {
+    if (!wallet.address || !pendingRate) return;
+
+    const { token, pct, bps } = pendingRate;
+    setShowReviewModal(false);
     setTxLoading(true);
     try {
-      const xdr = await buildSetExchangeRateTx(wallet.address, selectedToken, bps);
+      const xdr = await buildSetExchangeRateTx(wallet.address, token, bps);
       await signAndSubmit(xdr);
-      setRates((prev) => ({ ...prev, [selectedToken]: bps }));
+      setRates((prev) => ({ ...prev, [token]: bps }));
       toast.success(
-        `Exchange rate for ${stablecoinLabel(selectedToken)} set to ${newRatePct}% of USD (${bps} bps).`,
+        `Exchange rate for ${stablecoinLabel(token)} set to ${pct}% of USD (${bps} bps).`,
       );
       setNewRatePct('');
+      setPendingRate(null);
     } catch (e: unknown) {
       toast.error(e instanceof Error ? e.message : 'Transaction failed.');
     } finally {
@@ -170,6 +187,36 @@ export default function AdminExchangeRatesPage() {
           • Rates are used for display/reporting only; pool accounting stays in native token units.
         </p>
       </div>
+
+      <ConfirmActionModal
+        title="Review exchange rate update"
+        description={`Please confirm the exchange rate update for ${stablecoinLabel(pendingRate?.token ?? selectedToken)} before it is submitted on-chain.`}
+        isOpen={showReviewModal}
+        onConfirm={() => void confirmAndSubmit()}
+        onCancel={() => {
+          setShowReviewModal(false);
+          setPendingRate(null);
+        }}
+        confirmLabel="Confirm & Submit"
+        cancelLabel="Back"
+      >
+        {pendingRate && (
+          <div className="space-y-3 rounded-xl border border-brand-border bg-brand-dark p-4 text-sm text-brand-muted">
+            <div className="flex items-center justify-between">
+              <span>Token</span>
+              <span className="font-medium text-white">{stablecoinLabel(pendingRate.token)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Rate entered</span>
+              <span className="font-medium text-white">{pendingRate.pct}% of USD</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Internal bps</span>
+              <span className="font-medium text-white">{pendingRate.bps} bps</span>
+            </div>
+          </div>
+        )}
+      </ConfirmActionModal>
     </div>
   );
 }


### PR DESCRIPTION
closes #961 
Added a confirmation modal before the transaction is signed/submitted.
Kept the existing on-chain submission flow intact after confirmation.
Added a regression test.