### PR TITLE
feat: add pre-flight balance check before deposit and commit

### DIFF
--- a/frontend/__tests__/lib/contracts.test.ts
+++ b/frontend/__tests__/lib/contracts.test.ts
@@ -32,7 +32,7 @@ jest.mock('@stellar/stellar-sdk', () => {
 
 import * as stellar from '@/lib/stellar';
 import { Account, Keypair } from '@stellar/stellar-sdk';
-import { buildCreateInvoiceTx } from '@/lib/contracts';
+import { buildCreateInvoiceTx, buildDepositTx, buildCommitToInvoiceTx } from '@/lib/contracts';
 
 describe('contract error handling', () => {
   it('maps wallet rejection to user-facing message', () => {
@@ -121,5 +121,32 @@ describe('buildCreateInvoiceTx validation (#687)', () => {
     expect(typeof xdr).toBe('string');
     expect(xdr).toBe('BASE64_XDR_STRING');
     expect(rpcExecute).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects deposit before simulation when the native balance is insufficient', async () => {
+    const token = 'CC4UBX4HPQ6N4UJ5F5GX2KQJ3E6ZLZ5JQ6P5T3X4VY3QYJ2NTQJX5V5X';
+    const account = new Account(owner, '0');
+    Object.assign(account, {
+      balances: [{ asset_type: 'native', balance: '0.0000001' }],
+    });
+
+    rpcExecute.mockResolvedValueOnce(account);
+
+    await expect(buildDepositTx(owner, token, 1_000_000n)).rejects.toThrow(/insufficient balance/i);
+    expect(rpcExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects commit-to-invoice before simulation when the wallet cannot cover the fee', async () => {
+    const account = new Account(owner, '0');
+    Object.assign(account, {
+      balances: [{ asset_type: 'native', balance: '0.0000000' }],
+    });
+
+    rpcExecute.mockResolvedValueOnce(account);
+
+    await expect(
+      buildCommitToInvoiceTx({ investor: owner, invoiceId: 7, amount: 1_000n }),
+    ).rejects.toThrow(/insufficient balance/i);
+    expect(rpcExecute).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -107,6 +107,22 @@ function getRpcAccount(address: string): Promise<RpcAccount> {
   return rpcExecute<RpcAccount>((server) => server.getAccount(address));
 }
 
+function getNativeBalanceStroops(account: Pick<RpcAccount, 'balances'> | undefined): bigint {
+  if (!account?.balances) return 0n;
+  const nativeBalance = account.balances.find((balance) => balance.asset_type === 'native');
+  if (!nativeBalance?.balance) return 0n;
+  return BigInt(Math.round(Number.parseFloat(nativeBalance.balance) * 1_000_000));
+}
+
+function ensureSufficientNativeBalance(
+  account: Pick<RpcAccount, 'balances'>,
+  requiredStroops = BigInt(BASE_FEE),
+) {
+  if (getNativeBalanceStroops(account) < requiredStroops) {
+    throw new Error('Insufficient balance for this transaction');
+  }
+}
+
 function simulateRpcTransaction(
   tx: RpcBuiltTransaction,
 ): Promise<StellarRpc.Api.SimulateTransactionResponse> {
@@ -469,6 +485,7 @@ export async function buildDepositTx(
   amount: bigint,
 ): Promise<string> {
   const account = await getRpcAccount(investor);
+  ensureSufficientNativeBalance(account);
   const contract = new Contract(POOL_CONTRACT_ID);
 
   const tx = new TransactionBuilder(account, {
@@ -631,6 +648,7 @@ export async function buildCommitToInvoiceTx(params: {
   amount: bigint;
 }): Promise<string> {
   const account = await getRpcAccount(params.investor);
+  ensureSufficientNativeBalance(account);
   const contract = new Contract(POOL_CONTRACT_ID);
 
   const tx = new TransactionBuilder(account, {


### PR DESCRIPTION
closes #964 
## Summary
This PR adds a client-side pre-flight balance check before building deposit and commit-to-invoice transactions.

## What changed
- Checks the wallet’s native Stellar balance before creating a deposit transaction
- Checks the wallet’s native Stellar balance before creating a commit-to-invoice transaction
- Prevents users from wasting a signature round-trip and network fee when the wallet cannot cover the transaction

## Why
Transactions that fail due to insufficient balance were still being built and simulated, leading to unnecessary user friction and wasted fees. This change surfaces the issue earlier and gives the user a clear error before signing.

## Testing
- Added regression tests covering insufficient-balance cases for:
  - deposit transactions
  - commit-to-invoice transactions
- Verified locally with:
  - `cd /workspaces/Astera/frontend && npm test -- --runInBand __tests__/lib/contracts.test.ts`

