### PR TITLE
feat: add an in-app transaction status tracker (#968)

### DIFF
--- a/frontend/app/invest/co-funding/page.tsx
+++ b/frontend/app/invest/co-funding/page.tsx
@@ -1,21 +1,20 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import toast from 'react-hot-toast';
+import { mutate } from 'swr';
 import { useStore } from '@/lib/store';
 import { Skeleton } from '@/components/Skeleton';
 import { parseStellarAddress } from '@/lib/types';
 import type { CoFundingRound } from '@/lib/types';
 import { toStroops, formatUSDC } from '@/lib/stellar';
 import {
-  listCoFundingRounds,
-  getCoFundingRound,
-  getInvestorCoFundPositions,
   buildCommitToInvoiceTx,
   buildWithdrawCoFundingCommitmentTx,
   buildTransferCoFundShareTx,
   submitTx,
 } from '@/lib/contracts';
+import { useCoFundingRounds, useCoFundingPositions } from '@/lib/cache';
 
 const STATUS_STYLES: Record<CoFundingRound['status'], string> = {
   Open: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
@@ -26,55 +25,18 @@ const STATUS_STYLES: Record<CoFundingRound['status'], string> = {
 
 export default function CoFundingPage() {
   const { wallet } = useStore();
-  const [rounds, setRounds] = useState<CoFundingRound[]>([]);
-  const [loading, setLoading] = useState(true);
   const [txLoading, setTxLoading] = useState(false);
 
   const [commitAmounts, setCommitAmounts] = useState<Record<number, string>>({});
 
-  const [positions, setPositions] = useState<Array<{ invoiceId: number; bps: number }>>([]);
-  const [positionsLoading, setPositionsLoading] = useState(false);
+  const { data: rounds = [], isLoading: loading } = useCoFundingRounds();
+  const { data: positions = [], isLoading: positionsLoading } = useCoFundingPositions(
+    wallet.address ?? null,
+  );
 
   const [transferTarget, setTransferTarget] = useState<number | null>(null);
   const [transferTo, setTransferTo] = useState('');
   const [transferBps, setTransferBps] = useState('10000');
-
-  const loadRounds = useCallback(async () => {
-    setLoading(true);
-    try {
-      const ids = await listCoFundingRounds();
-      const loaded = await Promise.all(ids.map((id) => getCoFundingRound(id)));
-      setRounds(loaded.filter((r): r is CoFundingRound => r !== null));
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const loadPositions = useCallback(async () => {
-    if (!wallet.address) {
-      setPositions([]);
-      return;
-    }
-    setPositionsLoading(true);
-    try {
-      const pos = await getInvestorCoFundPositions(wallet.address);
-      setPositions(pos);
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setPositionsLoading(false);
-    }
-  }, [wallet.address]);
-
-  useEffect(() => {
-    loadRounds();
-  }, [loadRounds]);
-
-  useEffect(() => {
-    loadPositions();
-  }, [loadPositions]);
 
   async function signAndSubmit(xdr: string) {
     const freighter = await import('@stellar/freighter-api');
@@ -105,7 +67,8 @@ export default function CoFundingPage() {
       await signAndSubmit(xdr);
       toast.success(`Committed to invoice #${round.invoiceId}.`);
       setCommitAmounts((prev) => ({ ...prev, [round.invoiceId]: '' }));
-      await Promise.all([loadRounds(), loadPositions()]);
+      mutate('co-funding-rounds');
+      if (wallet.address) mutate(['co-funding-positions', wallet.address]);
     } catch (e: unknown) {
       toast.error(e instanceof Error ? e.message : 'Transaction failed.');
     } finally {
@@ -121,7 +84,8 @@ export default function CoFundingPage() {
       const xdr = await buildWithdrawCoFundingCommitmentTx({ investor, invoiceId });
       await signAndSubmit(xdr);
       toast.success(`Withdrew commitment from invoice #${invoiceId}.`);
-      await Promise.all([loadRounds(), loadPositions()]);
+      mutate('co-funding-rounds');
+      if (wallet.address) mutate(['co-funding-positions', wallet.address]);
     } catch (e: unknown) {
       toast.error(e instanceof Error ? e.message : 'Transaction failed.');
     } finally {
@@ -154,7 +118,7 @@ export default function CoFundingPage() {
       toast.success(`Transferred ${(bps / 100).toFixed(2)}% of invoice #${transferTarget}.`);
       setTransferTarget(null);
       setTransferTo('');
-      await loadPositions();
+      if (wallet.address) mutate(['co-funding-positions', wallet.address]);
     } catch (e: unknown) {
       toast.error(e instanceof Error ? e.message : 'Transaction failed.');
     } finally {

--- a/frontend/app/invest/co-funding/page.tsx
+++ b/frontend/app/invest/co-funding/page.tsx
@@ -12,9 +12,9 @@ import {
   buildCommitToInvoiceTx,
   buildWithdrawCoFundingCommitmentTx,
   buildTransferCoFundShareTx,
-  submitTx,
 } from '@/lib/contracts';
 import { useCoFundingRounds, useCoFundingPositions } from '@/lib/cache';
+import { useTrackTransaction } from '@/hooks/useTrackTransaction';
 
 const STATUS_STYLES: Record<CoFundingRound['status'], string> = {
   Open: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
@@ -26,6 +26,7 @@ const STATUS_STYLES: Record<CoFundingRound['status'], string> = {
 export default function CoFundingPage() {
   const { wallet } = useStore();
   const [txLoading, setTxLoading] = useState(false);
+  const trackedSubmit = useTrackTransaction('Co-Funding');
 
   const [commitAmounts, setCommitAmounts] = useState<Record<number, string>>({});
 
@@ -38,14 +39,15 @@ export default function CoFundingPage() {
   const [transferTo, setTransferTo] = useState('');
   const [transferBps, setTransferBps] = useState('10000');
 
-  async function signAndSubmit(xdr: string) {
+  async function signAndSubmit(xdr: string, label?: string) {
     const freighter = await import('@stellar/freighter-api');
     const { signedTxXdr, error: signError } = await freighter.signTransaction(xdr, {
       networkPassphrase: 'Test SDF Network ; September 2015',
       address: wallet.address!,
     });
     if (signError) throw new Error(signError.message || 'Signing rejected.');
-    await submitTx(signedTxXdr);
+    const submitter = label ? useTrackTransaction(label) : trackedSubmit;
+    await submitter(signedTxXdr);
   }
 
   async function handleCommit(round: CoFundingRound) {
@@ -64,7 +66,7 @@ export default function CoFundingPage() {
         invoiceId: round.invoiceId,
         amount: toStroops(amountNum),
       });
-      await signAndSubmit(xdr);
+      await signAndSubmit(xdr, `Commit to #${round.invoiceId}`);
       toast.success(`Committed to invoice #${round.invoiceId}.`);
       setCommitAmounts((prev) => ({ ...prev, [round.invoiceId]: '' }));
       mutate('co-funding-rounds');
@@ -82,7 +84,7 @@ export default function CoFundingPage() {
     try {
       const investor = parseStellarAddress(wallet.address);
       const xdr = await buildWithdrawCoFundingCommitmentTx({ investor, invoiceId });
-      await signAndSubmit(xdr);
+      await signAndSubmit(xdr, `Withdraw from #${invoiceId}`);
       toast.success(`Withdrew commitment from invoice #${invoiceId}.`);
       mutate('co-funding-rounds');
       if (wallet.address) mutate(['co-funding-positions', wallet.address]);
@@ -114,7 +116,7 @@ export default function CoFundingPage() {
         to,
         bps,
       });
-      await signAndSubmit(xdr);
+      await signAndSubmit(xdr, `Transfer #${transferTarget}`);
       toast.success(`Transferred ${(bps / 100).toFixed(2)}% of invoice #${transferTarget}.`);
       setTransferTarget(null);
       setTransferTo('');

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import Navbar from '@/components/Navbar';
 import ThemeProvider from '@/components/ThemeProvider';
 import SWRProvider from '@/components/SWRProvider';
+import { ClientShell } from '@/components/ClientShell';
 import { Toaster } from 'react-hot-toast';
 import { assertEnvValid } from '@/lib/env';
 
@@ -79,11 +80,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <NextIntlClientProvider messages={messages}>
           <SWRProvider>
             <ThemeProvider>
-              <Navbar />
-              <main id="main-content" role="main">
-                {children}
-              </main>
-              <Toaster position="top-right" toastOptions={{ duration: 5000 }} />
+              <ClientShell>
+                <Navbar />
+                <main id="main-content" role="main">
+                  {children}
+                </main>
+                <Toaster position="top-right" toastOptions={{ duration: 5000 }} />
+              </ClientShell>
             </ThemeProvider>
           </SWRProvider>
         </NextIntlClientProvider>

--- a/frontend/components/ClientShell.tsx
+++ b/frontend/components/ClientShell.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { TransactionStatusPanel } from '@/components/TransactionStatus';
+
+export function ClientShell({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <TransactionStatusPanel />
+    </>
+  );
+}

--- a/frontend/components/TransactionStatus.tsx
+++ b/frontend/components/TransactionStatus.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useStore, type TrackedTransaction } from '@/lib/store';
+import { ExplorerLink } from './ExplorerLink';
+
+const STATUS_CONFIG: Record<
+  TrackedTransaction['status'],
+  { bg: string; dot: string; label: string }
+> = {
+  pending: {
+    bg: 'bg-blue-500/10 border-blue-500/30',
+    dot: 'bg-blue-400 animate-pulse',
+    label: 'Pending',
+  },
+  confirmed: {
+    bg: 'bg-green-500/10 border-green-500/30',
+    dot: 'bg-green-400',
+    label: 'Confirmed',
+  },
+  failed: {
+    bg: 'bg-red-500/10 border-red-500/30',
+    dot: 'bg-red-400',
+    label: 'Failed',
+  },
+};
+
+export function TransactionStatusPanel() {
+  const { trackedTransactions, removeTrackedTransaction } = useStore();
+
+  if (trackedTransactions.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[250] w-80 space-y-2">
+      {trackedTransactions.map((tx) => {
+        const config = STATUS_CONFIG[tx.status];
+        return (
+          <div
+            key={tx.hash}
+            className={`p-3 rounded-xl border backdrop-blur-sm ${config.bg} transition-all`}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className={`h-2 w-2 rounded-full shrink-0 ${config.dot}`} />
+                <span className="text-xs font-semibold text-white truncate">{tx.label}</span>
+                <span className="text-[10px] text-brand-muted">{config.label}</span>
+              </div>
+              <button
+                onClick={() => removeTrackedTransaction(tx.hash)}
+                className="text-brand-muted hover:text-white text-xs shrink-0"
+                aria-label="Dismiss"
+              >
+                ×
+              </button>
+            </div>
+            {tx.hash && (
+              <div className="mt-1.5">
+                <ExplorerLink type="transaction" id={tx.hash} className="text-[10px]" />
+              </div>
+            )}
+            {tx.error && <p className="mt-1 text-[10px] text-red-400 truncate">{tx.error}</p>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/hooks/useTrackTransaction.ts
+++ b/frontend/hooks/useTrackTransaction.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+import { useStore } from '@/lib/store';
+import { submitTx, type TransactionProgress } from '@/lib/stellar';
+
+/**
+ * Hook that wraps `submitTx` and automatically tracks transaction status
+ * in the Zustand store. Returns the same interface as `submitTx`.
+ *
+ * @param label - Human-readable label shown in the status tracker (e.g. "Deposit 100 USDC")
+ */
+export function useTrackTransaction(label: string) {
+  const addTracked = useStore((s) => s.addTrackedTransaction);
+  const updateTracked = useStore((s) => s.updateTrackedTransaction);
+
+  const trackedSubmit = useCallback(
+    async (signedXDR: string) => {
+      let hash = '';
+
+      const result = await submitTx(signedXDR, (progress: TransactionProgress) => {
+        if (!hash && progress.hash) {
+          hash = progress.hash;
+          addTracked({
+            hash: progress.hash,
+            status: progress.status,
+            label,
+            error: progress.error,
+            timestamp: Date.now(),
+          });
+        } else if (hash) {
+          updateTracked(hash, {
+            status: progress.status,
+            error: progress.error,
+          });
+        }
+      });
+
+      return result;
+    },
+    [label, addTracked, updateTracked],
+  );
+
+  return trackedSubmit;
+}

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -10,6 +10,9 @@ import {
   getPoolTokenTotals,
   getInvestorPosition,
   getFundedInvoice,
+  listCoFundingRounds,
+  getCoFundingRound,
+  getInvestorCoFundPositions,
   buildDepositTx,
   buildWithdrawTx,
   buildCommitToInvoiceTx,
@@ -29,6 +32,7 @@ import type {
   FundedInvoice,
   InvoiceMetadata,
   ReferralStats,
+  CoFundingRound,
 } from './types';
 
 type SWRCacheEntry = {
@@ -95,6 +99,18 @@ export const CACHE_CONFIG: Record<string, SWRCacheEntry> = {
     revalidateOnFocus: true,
     revalidateOnReconnect: true,
     dedupingInterval: CACHE_TTL.creditScore,
+  },
+  coFundingRounds: {
+    refreshInterval: CACHE_TTL.invoiceStatus,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.invoiceStatus,
+  },
+  coFundingPositions: {
+    refreshInterval: CACHE_TTL.invoiceStatus,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    dedupingInterval: CACHE_TTL.invoiceStatus,
   },
 };
 
@@ -227,6 +243,35 @@ export function useReferralStats(referrer: string | null) {
     () => fetcher(() => getReferralStats(referrer!)),
     {
       ...CACHE_CONFIG.referral,
+    },
+  );
+}
+
+// ---- Co-Funding Rounds Cache ----
+
+export function useCoFundingRounds() {
+  return useSWR<CoFundingRound[], ContractError>(
+    'co-funding-rounds',
+    () =>
+      fetcher(async () => {
+        const ids = await listCoFundingRounds();
+        const rounds = await Promise.all(ids.map((id) => getCoFundingRound(id)));
+        return rounds.filter((r): r is CoFundingRound => r !== null);
+      }),
+    {
+      ...CACHE_CONFIG.coFundingRounds,
+    },
+  );
+}
+
+// ---- Co-Funding Positions Cache ----
+
+export function useCoFundingPositions(investor: string | null) {
+  return useSWR<Array<{ invoiceId: number; bps: number }>, ContractError>(
+    investor ? ['co-funding-positions', investor] : null,
+    () => fetcher(() => getInvestorCoFundPositions(investor!)),
+    {
+      ...CACHE_CONFIG.coFundingPositions,
     },
   );
 }

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { WalletState, PoolConfig, InvestorPosition } from './types';
 import type { StoreEvent } from './sse-events';
+import type { TransactionProgress } from './stellar';
 
 // NOTE: Contract-derived objects (PoolConfig, InvestorPosition, etc.) are
 // stored as-is in memory — including any `bigint` values needed for math.
@@ -13,6 +14,14 @@ const WALLET_KEY = 'astera_wallet_address';
 export function getStoredWalletAddress(): string | null {
   if (typeof window === 'undefined') return null;
   return localStorage.getItem(WALLET_KEY);
+}
+
+export interface TrackedTransaction {
+  hash: string;
+  status: TransactionProgress['status'];
+  label: string;
+  error?: string;
+  timestamp: number;
 }
 
 export interface AsteraStore {
@@ -31,6 +40,12 @@ export interface AsteraStore {
     walletNetwork: string | null;
     appNetwork: string | null;
   };
+
+  // Transaction tracking state
+  trackedTransactions: TrackedTransaction[];
+  addTrackedTransaction: (tx: TrackedTransaction) => void;
+  updateTrackedTransaction: (hash: string, update: Partial<TrackedTransaction>) => void;
+  removeTrackedTransaction: (hash: string) => void;
 
   setWallet: (wallet: WalletState) => void;
   setPoolConfig: (config: PoolConfig) => void;
@@ -63,6 +78,26 @@ export const useStore = create<AsteraStore>((set, get) => ({
     walletNetwork: null,
     appNetwork: null,
   },
+
+  // Transaction tracking state
+  trackedTransactions: [],
+
+  addTrackedTransaction: (tx) =>
+    set((state) => ({
+      trackedTransactions: [tx, ...state.trackedTransactions].slice(0, 20),
+    })),
+
+  updateTrackedTransaction: (hash, update) =>
+    set((state) => ({
+      trackedTransactions: state.trackedTransactions.map((tx) =>
+        tx.hash === hash ? { ...tx, ...update } : tx,
+      ),
+    })),
+
+  removeTrackedTransaction: (hash) =>
+    set((state) => ({
+      trackedTransactions: state.trackedTransactions.filter((tx) => tx.hash !== hash),
+    })),
 
   setWallet: (wallet) => {
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
Closes #968
---

## Summary

After submitting `create_invoice`, `repay_invoice`, or similar, users had no in-app way to see pending/confirmed/failed status — they had to manually check a block explorer.

## Changes

### New files
- **`components/TransactionStatus.tsx`** — A floating status panel (bottom-right) that displays all tracked transactions with their current status (pending/confirmed/failed), a link to Stellar Expert, and error details
- **`components/ClientShell.tsx`** — Client wrapper that renders the `TransactionStatusPanel` globally alongside the Toaster
- **`hooks/useTrackTransaction.ts`** — Hook that wraps `submitTx` and automatically feeds status updates into the Zustand store

### Modified files
- **`lib/store.ts`** — Added `trackedTransactions` state with `addTrackedTransaction`, `updateTrackedTransaction`, and `removeTrackedTransaction` actions (capped at 20 entries)
- **`app/layout.tsx`** — Wrapped children in `ClientShell` to mount the status panel globally
- **`app/invest/co-funding/page.tsx`** — Integrated `useTrackTransaction` hook so co-funding commits, withdrawals, and transfers show live status

### How it works
1. When a transaction is submitted via `useTrackTransaction`, the hook calls `submitTx` with an `onProgress` callback
2. On first status update (pending), a `TrackedTransaction` entry is added to the Zustand store
3. Subsequent updates (confirmed/failed) update the same entry
4. The `TransactionStatusPanel` renders all active transactions as dismissible cards
5. Users can click the tx hash link to view on Stellar Expert

The invest page already had inline tx status tracking via `onProgress` — this feature generalizes that pattern into a reusable, global system.