### PR TITLE
feat(admin/aging): add CSV export to the invoice aging report

### DIFF
--- a/frontend/app/admin/aging/page.tsx
+++ b/frontend/app/admin/aging/page.tsx
@@ -136,6 +136,53 @@ export default function AdminAgingPage() {
   const totalOverdueAmount = overdueBuckets.reduce((sum, b) => sum + b.totalAmount, 0n);
   const totalOverdueCount = overdueBuckets.reduce((sum, b) => sum + b.invoices.length, 0);
 
+  const exportCSV = useCallback(() => {
+    const headers = ['Invoice ID', 'Debtor', 'Owner', 'Amount (USDC)', 'Due Date', 'Status', 'Aging Bucket', 'Days Overdue'];
+    const rows: string[][] = [];
+
+    for (const bucket of overdueBuckets) {
+      for (const inv of bucket.invoices) {
+        const overdueDays = Math.floor((nowSecs - inv.dueDate) / 86400);
+        rows.push([
+          inv.id.toString(),
+          inv.debtor,
+          inv.owner,
+          formatUSDC(inv.amount),
+          formatDate(inv.dueDate),
+          inv.status,
+          bucket.label,
+          overdueDays > 0 ? `${overdueDays}d` : '0d',
+        ]);
+      }
+    }
+
+    for (const inv of atRiskInvoices) {
+      const overdueDays = Math.floor((nowSecs - inv.dueDate) / 86400);
+      rows.push([
+        inv.id.toString(),
+        inv.debtor,
+        inv.owner,
+        formatUSDC(inv.amount),
+        formatDate(inv.dueDate),
+        inv.status,
+        'At Risk (due within 7 days)',
+        `${overdueDays > 0 ? overdueDays : 0}d`,
+      ]);
+    }
+
+    const csv = [headers, ...rows]
+      .map((r) => r.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+      .join('\n');
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `astera-aging-report-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [overdueBuckets, atRiskInvoices, nowSecs]);
+
   if (loading) {
     return (
       <div className="space-y-6">
@@ -152,11 +199,22 @@ export default function AdminAgingPage() {
 
   return (
     <div className="space-y-8">
-      <div>
-        <h1 className="text-3xl font-bold mb-2">Invoice Aging Report</h1>
-        <p className="text-brand-muted text-sm">
-          Overdue and at-risk invoices grouped by aging period.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold mb-2">Invoice Aging Report</h1>
+          <p className="text-brand-muted text-sm">
+            Overdue and at-risk invoices grouped by aging period.
+          </p>
+        </div>
+        <button
+          onClick={exportCSV}
+          className="px-4 py-2 bg-brand-gold text-black font-semibold rounded-xl hover:brightness-110 transition-all text-sm flex items-center gap-2"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          Download CSV
+        </button>
       </div>
 
       {/* Summary Cards */}


### PR DESCRIPTION
## Overview

Adds a "Download CSV" button to the invoice aging report (`app/admin/aging`), enabling finance and operations teams to export aging data for offline reconciliation and reporting. The export includes all overdue buckets (Critical 90+, Severe 61�90, Moderate 31�60, Mild 1�30) and at-risk invoices grouped with their aging metadata.

## Related Issue

Closes #959

## Changes

### `frontend/app/admin/aging/page.tsx`

- **[ADD]** `exportCSV` callback � builds a CSV with columns: Invoice ID, Debtor, Owner, Amount (USDC), Due Date, Status, Aging Bucket, Days Overdue
- **[ADD]** "Download CSV" button in the page header, styled as a gold-toned icon button consistent with the existing design system
- The export function follows the exact Blob/download pattern already established by the history page (`app/history/page.tsx`) and the invoice import page (`app/invoice/import/page.tsx`) for consistency

### CSV Format

| Column | Source |
|--------|--------|
| Invoice ID | `inv.id` |
| Debtor | `inv.debtor` |
| Owner | `inv.owner` |
| Amount (USDC) | `formatUSDC(inv.amount)` |
| Due Date | `formatDate(inv.dueDate)` |
| Status | `inv.status` |
| Aging Bucket | Derived from overdue days (e.g., "90+ Days Overdue") |
| Days Overdue | Computed on export |

## Verification Results

```
npm run typecheck
No new type errors (all pre-existing errors in unrelated files)
```

Acceptance Criteria | Status
-- | --
CSV export button is visible on the aging report page | ?
CSV includes all overdue buckets and at-risk invoices | ?
CSV columns match the table columns displayed on screen | ?
Download filename includes date (`astera-aging-report-YYYY-MM-DD.csv`) | ?
Follows existing CSV export pattern from history/invoice-import pages | ?
No regression in page rendering or existing functionality | ? 
