### PR TITLE
feat: on-chain governance — snapshot-weighted voting, configurable thresholds, proposal expiry

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -12,6 +12,10 @@ const DEFAULT_VOTING_PERIOD_SECS: u64 = 7 * 86_400;
 const DEFAULT_EXECUTION_DELAY_SECS: u64 = 48 * 3_600;
 const DEFAULT_QUORUM_BPS: u32 = 1_000;
 const DEFAULT_PASS_BPS: u32 = 6_000;
+/// A passed proposal not executed within this window of passing expires and
+/// can no longer be executed, so a stale approval can't be enacted long after
+/// the conditions that justified it have changed.
+const EXECUTION_EXPIRY_SECS: u64 = 7 * 86_400;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -21,6 +25,7 @@ pub enum ProposalStatus {
     Rejected,
     Executed,
     Cancelled,
+    Expired,
 }
 
 #[contracttype]
@@ -42,6 +47,9 @@ pub struct Proposal {
     /// calculations always use this value so that post-creation minting cannot
     /// retroactively suppress a proposal that had already reached quorum.
     pub snapshot_supply: i128,
+    /// Ledger timestamp at which the proposal transitioned to `Passed`, or 0 if
+    /// it has not (yet) passed. Used to enforce `EXECUTION_EXPIRY_SECS`.
+    pub passed_at: u64,
 }
 
 #[contracttype]
@@ -79,6 +87,8 @@ pub enum GovernanceError {
     QuorumNotMet = 8,
     InvalidProposalState = 9,
     Unauthorized = 10,
+    ProposalExpired = 11,
+    InvalidConfig = 12,
 }
 
 type GovernanceResult<T> = Result<T, GovernanceError>;
@@ -87,6 +97,7 @@ type GovernanceResult<T> = Result<T, GovernanceError>;
 pub trait ShareTokenContract {
     fn balance(env: Env, id: Address) -> i128;
     fn total_supply(env: Env) -> i128;
+    fn balance_at(env: Env, id: Address, timestamp: u64) -> i128;
 }
 
 fn load_config(env: &Env) -> GovernanceResult<GovernanceConfig> {
@@ -96,8 +107,12 @@ fn load_config(env: &Env) -> GovernanceResult<GovernanceConfig> {
         .ok_or(GovernanceError::NotInitialized)
 }
 
-fn proposal_weight(env: &Env, share_token: &Address, voter: &Address) -> i128 {
-    ShareTokenClient::new(env, share_token).balance(voter)
+/// Voting weight is the holder's share balance at the moment the proposal was
+/// created (`snapshot_at`), not their balance at vote time — otherwise shares
+/// acquired mid-vote (or borrowed just long enough to vote) would inflate
+/// voting power beyond what backed the proposal when it was created.
+fn proposal_weight(env: &Env, share_token: &Address, voter: &Address, snapshot_at: u64) -> i128 {
+    ShareTokenClient::new(env, share_token).balance_at(voter, &snapshot_at)
 }
 
 fn finalize_proposal(env: &Env, proposal: &mut Proposal) -> GovernanceResult<()> {
@@ -121,11 +136,29 @@ fn finalize_proposal(env: &Env, proposal: &mut Proposal) -> GovernanceResult<()>
 
     if proposal.votes_for * 10_000i128 >= total_votes * config.pass_bps as i128 {
         proposal.status = ProposalStatus::Passed;
+        // Anchored to voting_ends_at (not "now") so a delayed finalization
+        // call can't push back the execution-expiry window.
+        proposal.passed_at = proposal.voting_ends_at;
+        env.events()
+            .publish((EVT, symbol_short!("passed")), proposal.id);
     } else {
         proposal.status = ProposalStatus::Rejected;
     }
 
     Ok(())
+}
+
+/// Transitions a `Passed` proposal to `Expired` once `EXECUTION_EXPIRY_SECS`
+/// has elapsed since it passed. Returns true if the proposal is (now) expired.
+fn mark_expired_if_due(env: &Env, proposal: &mut Proposal) -> bool {
+    if proposal.status == ProposalStatus::Passed
+        && env.ledger().timestamp() > proposal.passed_at.saturating_add(EXECUTION_EXPIRY_SECS)
+    {
+        proposal.status = ProposalStatus::Expired;
+        true
+    } else {
+        proposal.status == ProposalStatus::Expired
+    }
 }
 
 #[contract]
@@ -198,7 +231,8 @@ impl Governance {
     ) -> Result<u64, GovernanceError> {
         proposer.require_auth();
         let config = load_config(&env)?;
-        let balance = proposal_weight(&env, &config.share_token, &proposer);
+        let now = env.ledger().timestamp();
+        let balance = proposal_weight(&env, &config.share_token, &proposer, now);
         if balance < config.min_share_balance {
             return Err(GovernanceError::InsufficientShareBalance);
         }
@@ -209,7 +243,6 @@ impl Governance {
             .get(&DataKey::ProposalCount)
             .unwrap_or(0);
         let id = count + 1;
-        let now = env.ledger().timestamp();
         let snapshot_supply = ShareTokenClient::new(&env, &config.share_token).total_supply();
         let proposal = Proposal {
             id,
@@ -225,6 +258,7 @@ impl Governance {
             voting_ends_at: now.saturating_add(config.voting_period_secs),
             execution_delay: config.execution_delay_secs,
             snapshot_supply,
+            passed_at: 0,
         };
 
         env.storage()
@@ -267,7 +301,7 @@ impl Governance {
             return Err(GovernanceError::VotingPeriodActive);
         }
 
-        let weight = proposal_weight(&env, &config.share_token, &voter);
+        let weight = proposal_weight(&env, &config.share_token, &voter, proposal.created_at);
         if weight <= 0 {
             return Err(GovernanceError::InsufficientShareBalance);
         }
@@ -302,6 +336,7 @@ impl Governance {
 
         if proposal.status == ProposalStatus::Cancelled
             || proposal.status == ProposalStatus::Executed
+            || proposal.status == ProposalStatus::Expired
         {
             return Err(GovernanceError::ProposalInactive);
         }
@@ -323,6 +358,13 @@ impl Governance {
         finalization?;
         if proposal.status != ProposalStatus::Passed {
             return Err(GovernanceError::InvalidProposalState);
+        }
+
+        if mark_expired_if_due(&env, &mut proposal) {
+            env.storage()
+                .instance()
+                .set(&DataKey::Proposal(proposal_id), &proposal);
+            return Err(GovernanceError::ProposalExpired);
         }
 
         env.events().publish(
@@ -391,10 +433,17 @@ impl Governance {
                 .instance()
                 .get::<DataKey, Proposal>(&DataKey::Proposal(id))
             {
+                let mut changed = false;
                 if proposal.status == ProposalStatus::Active
                     && env.ledger().timestamp() > proposal.voting_ends_at
                 {
                     let _ = finalize_proposal(&env, &mut proposal);
+                    changed = true;
+                }
+                if mark_expired_if_due(&env, &mut proposal) {
+                    changed = true;
+                }
+                if changed {
                     env.storage()
                         .instance()
                         .set(&DataKey::Proposal(id), &proposal);
@@ -407,5 +456,37 @@ impl Governance {
 
     pub fn get_config(env: Env) -> Result<GovernanceConfig, GovernanceError> {
         load_config(&env)
+    }
+
+    /// Updates the quorum and pass-threshold, gated to the address holding
+    /// governance authority (`config.admin`) so quorum/threshold stay
+    /// configurable by current governance rather than fixed at deploy time.
+    /// Does not affect proposals already created — their `snapshot_supply`
+    /// and finalization use the config values in effect when `execute_proposal`
+    /// runs, consistent with how quorum/threshold already work today.
+    pub fn update_config(
+        env: Env,
+        caller: Address,
+        quorum_bps: u32,
+        pass_bps: u32,
+    ) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        let mut config = load_config(&env)?;
+        if caller != config.admin {
+            return Err(GovernanceError::Unauthorized);
+        }
+        if quorum_bps == 0 || quorum_bps > 10_000 {
+            return Err(GovernanceError::InvalidConfig);
+        }
+        if pass_bps <= 5_000 || pass_bps > 10_000 {
+            return Err(GovernanceError::InvalidConfig);
+        }
+
+        config.quorum_bps = quorum_bps;
+        config.pass_bps = pass_bps;
+        env.storage().instance().set(&DataKey::Config, &config);
+        env.events()
+            .publish((EVT, symbol_short!("cfg")), (caller, quorum_bps, pass_bps));
+        Ok(())
     }
 }

--- a/contracts/governance/tests/lib.rs
+++ b/contracts/governance/tests/lib.rs
@@ -391,3 +391,179 @@ fn test_cancel_proposal_by_proposer() {
     let proposal = gov.get_proposal(&id).unwrap();
     assert_eq!(proposal.status, ProposalStatus::Cancelled);
 }
+
+// ── vote weight is snapshotted at proposal creation ──────────────────────────
+
+#[test]
+fn test_vote_weight_ignores_shares_acquired_after_proposal_creation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _share_admin) = setup_share(&env);
+    let (gov, _) = setup_governance(&env, &share_id);
+
+    let proposer = Address::generate(&env);
+    let latecomer = Address::generate(&env);
+    share.mint(&proposer, &1_000_000i128);
+
+    let id = make_proposal(&env, &gov, &proposer, &proposer);
+
+    // latecomer acquires a large share balance only after the proposal was
+    // created (in a later ledger) — this must not count toward voting weight.
+    env.ledger().with_mut(|l| l.timestamp += 10);
+    share.mint(&latecomer, &5_000_000i128);
+    let result = gov.try_vote(&id, &latecomer, &true);
+    assert!(
+        result.is_err(),
+        "voter with zero balance at snapshot time must not be able to vote"
+    );
+}
+
+#[test]
+fn test_vote_weight_uses_balance_at_creation_not_at_vote_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _share_admin) = setup_share(&env);
+    let (gov, _) = setup_governance(&env, &share_id);
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    share.mint(&proposer, &1_000i128);
+    share.mint(&voter, &50_000i128);
+    // Supply at creation = 51_000; quorum (10%) = 5_100
+
+    let id = make_proposal(&env, &gov, &proposer, &proposer);
+
+    // Voter transfers away most of their shares after the snapshot (in a
+    // later ledger) but before voting — their voting weight must still
+    // reflect the creation-time balance (50_000), not the post-transfer live
+    // balance.
+    env.ledger().with_mut(|l| l.timestamp += 10);
+    let stranger = Address::generate(&env);
+    share.transfer(&voter, &stranger, &49_000i128);
+    assert_eq!(share.balance(&voter), 1_000);
+
+    gov.vote(&id, &voter, &true);
+
+    env.ledger()
+        .with_mut(|l| l.timestamp += VOTING_PERIOD + EXEC_DELAY + 2);
+    gov.execute_proposal(&id);
+
+    let proposal = gov.get_proposal(&id).unwrap();
+    assert_eq!(proposal.votes_for, 50_000i128);
+    assert_eq!(proposal.status, ProposalStatus::Executed);
+}
+
+// ── governance-configurable quorum / pass threshold ──────────────────────────
+
+#[test]
+fn test_update_config_by_admin_changes_quorum_and_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (_share, share_id, _share_admin) = setup_share(&env);
+    let (gov, gov_admin) = setup_governance(&env, &share_id);
+
+    gov.update_config(&gov_admin, &2_000u32, &5_500u32);
+
+    let config = gov.get_config();
+    assert_eq!(config.quorum_bps, 2_000);
+    assert_eq!(config.pass_bps, 5_500);
+}
+
+#[test]
+fn test_update_config_rejects_non_admin_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (_share, share_id, _share_admin) = setup_share(&env);
+    let (gov, _gov_admin) = setup_governance(&env, &share_id);
+
+    let impostor = Address::generate(&env);
+    let result = gov.try_update_config(&impostor, &2_000u32, &5_500u32);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_update_config_rejects_invalid_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (_share, share_id, _share_admin) = setup_share(&env);
+    let (gov, gov_admin) = setup_governance(&env, &share_id);
+
+    // pass_bps must be > 5_000
+    let result = gov.try_update_config(&gov_admin, &2_000u32, &5_000u32);
+    assert!(result.is_err());
+}
+
+// ── passed proposals expire if not executed in time ──────────────────────────
+
+#[test]
+fn test_passed_proposal_expires_if_not_executed_within_seven_days() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _share_admin) = setup_share(&env);
+    let (gov, _) = setup_governance(&env, &share_id);
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    share.mint(&proposer, &1_000i128);
+    share.mint(&voter, &200_000i128);
+
+    let id = make_proposal(&env, &gov, &proposer, &proposer);
+    gov.vote(&id, &voter, &true);
+
+    // Past voting period + execution delay, proposal is Passed but not yet executed.
+    env.ledger()
+        .with_mut(|l| l.timestamp += VOTING_PERIOD + EXEC_DELAY + 2);
+    gov.list_proposals();
+    let proposal = gov.get_proposal(&id).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Passed);
+
+    // Advance 7 days past passing without executing.
+    env.ledger().with_mut(|l| l.timestamp += 7 * 86_400 + 1);
+
+    let result = gov.try_execute_proposal(&id);
+    assert!(result.is_err(), "expired proposal must not be executable");
+
+    gov.list_proposals();
+    let proposal = gov.get_proposal(&id).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Expired);
+}
+
+#[test]
+fn test_passed_proposal_executes_within_expiry_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _share_admin) = setup_share(&env);
+    let (gov, _) = setup_governance(&env, &share_id);
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    share.mint(&proposer, &1_000i128);
+    share.mint(&voter, &200_000i128);
+
+    let id = make_proposal(&env, &gov, &proposer, &proposer);
+    gov.vote(&id, &voter, &true);
+
+    env.ledger()
+        .with_mut(|l| l.timestamp += VOTING_PERIOD + EXEC_DELAY + 2);
+
+    // Executed comfortably within the 7-day expiry window.
+    env.ledger().with_mut(|l| l.timestamp += 3 * 86_400);
+    gov.execute_proposal(&id);
+
+    let proposal = gov.get_proposal(&id).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Executed);
+}

--- a/contracts/share/src/lib.rs
+++ b/contracts/share/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol,
+    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec,
 };
 
 const EVT: Symbol = symbol_short!("share");
@@ -14,6 +14,34 @@ pub enum DataKey {
     Balance(Address),
     Allowance(Address, Address),
     TotalSupply,
+    /// Historical (timestamp, balance) checkpoints per holder, append-only and
+    /// ordered by timestamp. Lets callers (e.g. governance) read a holder's
+    /// balance as of a past point in time instead of their current balance,
+    /// so voting power reflects the snapshot at proposal creation rather than
+    /// whatever the holder's balance happens to be when they cast their vote.
+    Checkpoints(Address),
+}
+
+/// Records a checkpoint of `who`'s new balance at the current ledger timestamp.
+/// Multiple writes within the same timestamp overwrite the last checkpoint for
+/// that timestamp rather than appending, keeping the list free of duplicates.
+fn write_checkpoint(env: &Env, who: &Address, new_balance: i128) {
+    let key = DataKey::Checkpoints(who.clone());
+    let mut checkpoints: Vec<(u64, i128)> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    let now = env.ledger().timestamp();
+    if let Some(last) = checkpoints.last() {
+        if last.0 == now {
+            checkpoints.set(checkpoints.len() - 1, (now, new_balance));
+            env.storage().persistent().set(&key, &checkpoints);
+            return;
+        }
+    }
+    checkpoints.push_back((now, new_balance));
+    env.storage().persistent().set(&key, &checkpoints);
 }
 
 #[contract]
@@ -41,9 +69,11 @@ impl ShareToken {
             panic!("amount must be positive");
         }
         let balance = Self::balance(env.clone(), to.clone());
+        let new_balance = balance + amount;
         env.storage()
             .persistent()
-            .set(&DataKey::Balance(to.clone()), &(balance + amount));
+            .set(&DataKey::Balance(to.clone()), &new_balance);
+        write_checkpoint(&env, &to, new_balance);
 
         let total: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap();
         let new_total = total + amount;
@@ -64,9 +94,11 @@ impl ShareToken {
         if balance < amount {
             panic!("insufficient balance");
         }
+        let new_balance = balance - amount;
         env.storage()
             .persistent()
-            .set(&DataKey::Balance(from.clone()), &(balance - amount));
+            .set(&DataKey::Balance(from.clone()), &new_balance);
+        write_checkpoint(&env, &from, new_balance);
 
         let total: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap();
         let new_total = total - amount;
@@ -86,14 +118,18 @@ impl ShareToken {
         if balance_from < amount {
             panic!("insufficient balance");
         }
+        let new_balance_from = balance_from - amount;
         env.storage()
             .persistent()
-            .set(&DataKey::Balance(from.clone()), &(balance_from - amount));
+            .set(&DataKey::Balance(from.clone()), &new_balance_from);
+        write_checkpoint(&env, &from, new_balance_from);
 
         let balance_to = Self::balance(env.clone(), to.clone());
+        let new_balance_to = balance_to + amount;
         env.storage()
             .persistent()
-            .set(&DataKey::Balance(to.clone()), &(balance_to + amount));
+            .set(&DataKey::Balance(to.clone()), &new_balance_to);
+        write_checkpoint(&env, &to, new_balance_to);
         env.events()
             .publish((EVT, symbol_short!("transfer")), (from, to, amount));
     }
@@ -131,13 +167,17 @@ impl ShareToken {
             panic!("insufficient balance");
         }
 
+        let new_balance_from = balance_from - amount;
         env.storage()
             .persistent()
-            .set(&DataKey::Balance(from.clone()), &(balance_from - amount));
+            .set(&DataKey::Balance(from.clone()), &new_balance_from);
+        write_checkpoint(&env, &from, new_balance_from);
         let balance_to = Self::balance(env.clone(), to.clone());
+        let new_balance_to = balance_to + amount;
         env.storage()
             .persistent()
-            .set(&DataKey::Balance(to.clone()), &(balance_to + amount));
+            .set(&DataKey::Balance(to.clone()), &new_balance_to);
+        write_checkpoint(&env, &to, new_balance_to);
         env.storage().persistent().set(
             &DataKey::Allowance(from.clone(), spender.clone()),
             &(allowed - amount),
@@ -153,6 +193,41 @@ impl ShareToken {
             .persistent()
             .get(&DataKey::Balance(id))
             .unwrap_or(0)
+    }
+
+    /// Returns `id`'s balance as of `timestamp` (inclusive), based on recorded
+    /// checkpoints. Governance uses this to weight votes by the balance a
+    /// holder had at proposal creation, rather than their balance at vote
+    /// time — otherwise a holder could acquire shares mid-vote (or borrow them
+    /// just long enough to vote) to inflate their voting power.
+    pub fn balance_at(env: Env, id: Address, timestamp: u64) -> i128 {
+        let checkpoints: Vec<(u64, i128)> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Checkpoints(id))
+            .unwrap_or(Vec::new(&env));
+
+        if checkpoints.is_empty() {
+            return 0;
+        }
+
+        // Binary search for the latest checkpoint at or before `timestamp`.
+        let mut lo: u32 = 0;
+        let mut hi: u32 = checkpoints.len();
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            if checkpoints.get(mid).unwrap().0 <= timestamp {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+
+        if lo == 0 {
+            0
+        } else {
+            checkpoints.get(lo - 1).unwrap().1
+        }
     }
 
     pub fn total_supply(env: Env) -> i128 {
@@ -178,7 +253,8 @@ impl ShareToken {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Env};
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::Env;
 
     fn setup(env: &Env) -> (ShareTokenClient<'_>, Address) {
         let contract_id = env.register(ShareToken, ());
@@ -433,5 +509,78 @@ mod test {
         client.mint(&owner, &1_000i128);
         client.approve(&owner, &spender, &100i128);
         client.transfer_from(&spender, &owner, &recipient, &101i128);
+    }
+
+    #[test]
+    fn test_balance_at_before_any_checkpoint_is_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        let (client, _admin) = setup(&env);
+        let alice = Address::generate(&env);
+
+        assert_eq!(client.balance_at(&alice, &500), 0);
+    }
+
+    #[test]
+    fn test_balance_at_reflects_balance_at_past_timestamp() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        let (client, _admin) = setup(&env);
+        let alice = Address::generate(&env);
+
+        client.mint(&alice, &100i128);
+
+        env.ledger().with_mut(|l| l.timestamp = 2_000);
+        client.mint(&alice, &400i128);
+
+        env.ledger().with_mut(|l| l.timestamp = 3_000);
+        client.burn(&alice, &200i128);
+
+        // Balance history: t=1000 -> 100, t=2000 -> 500, t=3000 -> 300
+        assert_eq!(client.balance_at(&alice, &1_000), 100);
+        assert_eq!(client.balance_at(&alice, &1_500), 100);
+        assert_eq!(client.balance_at(&alice, &2_000), 500);
+        assert_eq!(client.balance_at(&alice, &2_999), 500);
+        assert_eq!(client.balance_at(&alice, &3_000), 300);
+        assert_eq!(client.balance_at(&alice, &10_000), 300);
+    }
+
+    #[test]
+    fn test_balance_at_not_affected_by_later_transfers() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        let (client, _admin) = setup(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &1_000i128);
+        let snapshot_ts = env.ledger().timestamp();
+
+        env.ledger().with_mut(|l| l.timestamp = 2_000);
+        client.transfer(&alice, &bob, &1_000i128);
+
+        // Historical balance at proposal-creation time is unaffected by the
+        // later transfer that drained alice's live balance to zero.
+        assert_eq!(client.balance_at(&alice, &snapshot_ts), 1_000);
+        assert_eq!(client.balance(&alice), 0);
+    }
+
+    #[test]
+    fn test_balance_at_dedupes_same_timestamp_writes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        let (client, _admin) = setup(&env);
+        let alice = Address::generate(&env);
+
+        // transfer-to-self writes two checkpoints for alice at the same
+        // timestamp; balance_at must reflect the final value, not stack
+        // duplicate entries.
+        client.mint(&alice, &200i128);
+        client.transfer(&alice, &alice, &100i128);
+        assert_eq!(client.balance_at(&alice, &1_000), 200);
     }
 }

--- a/frontend/app/governance/page.tsx
+++ b/frontend/app/governance/page.tsx
@@ -20,7 +20,14 @@ const PROPOSALS_PAGE_SIZE = 10;
 
 type StatusFilter = 'All' | ProposalStatus;
 
-const STATUS_FILTERS: StatusFilter[] = ['All', 'Active', 'Passed', 'Rejected', 'Executed'];
+const STATUS_FILTERS: StatusFilter[] = [
+  'All',
+  'Active',
+  'Passed',
+  'Rejected',
+  'Executed',
+  'Expired',
+];
 
 export default function GovernancePage() {
   const { wallet } = useStore();

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -121,7 +121,7 @@ export interface RateSnapshot {
   rateBps: number;
 }
 
-export type ProposalStatus = 'Active' | 'Passed' | 'Rejected' | 'Executed' | 'Cancelled';
+export type ProposalStatus = 'Active' | 'Passed' | 'Rejected' | 'Executed' | 'Cancelled' | 'Expired';
 
 export interface GovernanceProposal {
   id: number;


### PR DESCRIPTION
## Summary

Closes #785, Closes #786, Closes #787, Closes #788

- Vote weight is now snapshotted at proposal creation (`ShareToken::balance_at`), not read live at vote time, closing a window where shares acquired or borrowed mid-vote could inflate voting power.
- `Governance::update_config` lets quorum/pass-threshold be updated by current governance instead of being fixed at deploy time.
- Passed proposals now expire (`ProposalStatus::Expired`) if not executed within 7 days of passing, per the acceptance criteria.
- A `ProposalPassed` event is now emitted when a proposal finalizes as passed, alongside the existing `ProposalCreated`/`VoteCast`/`ProposalExecuted` events.
- Frontend `ProposalStatus` type and the governance page's status filter updated for the new `Expired` state.

Note: `governance` (create_proposal/vote/execute_proposal) and the frontend governance page already existed on `main` from prior work; this PR closes the remaining gaps against the acceptance criteria in #785 (snapshot voting weight, configurable thresholds, proposal expiry, ProposalPassed event).

## Test plan

- [x] `cargo test -p governance -p share` — 18 governance tests + 20 share unit tests + 5 fuzz tests + 12 integration tests, all passing
- [x] `cargo clippy -p governance -p share --tests -- -D warnings` — clean
- [x] `cargo fmt -p governance -p share -- --check` — clean
- [ ] Frontend governance page manually exercised against a deployed testnet contract