### PR TITLE
fix: withdraw liquidity check, named test actors, SEO metadata, codecov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown,wasm32v1-none
-          components: clippy, rustfmt
+          components: clippy, rustfmt, llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
       - name: Lint contracts with clippy
@@ -42,6 +42,22 @@ jobs:
       - name: Run integration tests
         timeout-minutes: 15
         run: cargo test -p integration-tests --test integration_tests
+      # #781: code coverage for the Soroban contracts. Runs after the tests
+      # above (not instead of them) since cargo-llvm-cov's own instrumented
+      # `cargo test` still needs the prebuilt wasm32v1-none release
+      # artifacts from the "Build contracts for integration tests" step.
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+      - name: Generate contracts coverage report
+        timeout-minutes: 15
+        run: cargo llvm-cov --workspace --lcov --output-path contracts-lcov.info
+      - name: Upload contracts coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: contracts-lcov.info
+          flags: contracts
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
       - name: Install binaryen (wasm-opt)
         run: sudo apt-get update && sudo apt-get install -y binaryen
       - name: Check WASM size
@@ -97,6 +113,19 @@ jobs:
       - name: Run cross-contract integration tests
         working-directory: .
         run: cargo test --manifest-path contracts/tests/Cargo.toml
+
+      # #781: frontend Jest coverage, uploaded to Codecov under its own flag
+      # so contract and frontend coverage are tracked (and can regress)
+      # independently.
+      - name: Frontend tests with coverage
+        run: npm test -- --coverage --coverageReporters=lcov
+      - name: Upload frontend coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   # E2E Tests job is temporarily disabled: frontend/e2e/contract-ids.ts
   # deliberately fails fast in CI when real (non-placeholder) contract IDs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Astera
 
 [![Soroban Contracts CI](https://github.com/Jayy4rl/Astera/actions/workflows/contracts.yml/badge.svg?branch=main)](https://github.com/Jayy4rl/Astera/actions/workflows/contracts.yml)
+[![codecov](https://codecov.io/gh/astera-hq/Astera/branch/main/graph/badge.svg)](https://codecov.io/gh/astera-hq/Astera)
 
 **Real World Assets on Stellar. Invoice financing for emerging markets.**
 
@@ -268,6 +269,21 @@ Branch protection for `main` should be configured so that:
 To apply, in GitHub: **Settings → Branches → Branch protection rules → Add rule** for
 `main`, enable **Require status checks to pass before merging**, and select
 `Build & test Soroban contracts` from the list of checks.
+
+### Code coverage
+
+CI uploads coverage to [Codecov](https://codecov.io/gh/astera-hq/Astera) as two independent
+flags, each with its own PR status check (configured in [`codecov.yml`](codecov.yml)):
+
+| Flag        | Source                               | Target |
+| ----------- | ------------------------------------- | ------ |
+| `contracts` | `cargo llvm-cov` over the whole Rust workspace | 80% |
+| `frontend`  | `next test -- --coverage` (Jest)      | 70%    |
+
+A PR fails the corresponding status check if it drops a flag's coverage by more than the
+configured 1% threshold. Uploading requires a `CODECOV_TOKEN` repository secret from
+codecov.io; until that secret is set, the upload steps no-op (`fail_ci_if_error: false`)
+rather than failing CI outright.
 
 ---
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+# #781: per-flag coverage tracking for contracts vs. frontend, with a
+# required PR status check that fails when either flag's coverage drops
+# below its target. `informational: false` (the default) is what makes the
+# status check actually block/fail the PR rather than just report a number.
+coverage:
+  status:
+    project:
+      default: false
+      contracts:
+        target: 80%
+        flags:
+          - contracts
+        threshold: 1%
+      frontend:
+        target: 70%
+        flags:
+          - frontend
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+flags:
+  contracts:
+    paths:
+      - contracts/
+    carryforward: false
+  frontend:
+    paths:
+      - frontend/
+    carryforward: false
+
+comment:
+  layout: 'reach, diff, flags, files'
+  behavior: default
+  require_changes: false

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -2549,9 +2549,14 @@ impl FundingPool {
             .checked_div(rate_bps as i128)
             .ok_or(PoolError::AmountOverflow)?;
 
+        // #782: reject before any state change (share burn / pool_value update
+        // below) when the pool doesn't have enough undeployed liquidity to
+        // cover this withdrawal — otherwise the accounting step could
+        // succeed while the token transfer later fails, burning the
+        // investor's shares without paying them out.
         let available_liquidity = tt.pool_value - tt.total_deployed;
         if available_liquidity < usdc_amount {
-            return Err(PoolError::InvalidAmount);
+            return Err(PoolError::InsufficientLiquidity);
         }
 
         // #244: single-withdrawal cap (skip for admin) — compare in USDC terms
@@ -7985,6 +7990,47 @@ mod test {
         // Attempt to withdraw more shares than owned
         let result = client.try_withdraw(&investor, &usdc_id, &1_000i128);
         assert_eq!(result, Err(Ok(PoolError::InvalidAmount)));
+    }
+
+    #[test]
+    fn test_withdraw_insufficient_liquidity_rejected_before_burning_shares() {
+        // #782: 90% of the pool deployed into a funded invoice, leaving only
+        // 10% liquid. An investor's shares are worth the full deposit, but
+        // the pool cannot actually pay out that much — withdraw() must
+        // reject with InsufficientLiquidity *before* burning any shares,
+        // not fail at the token transfer after accounting already changed.
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, usdc_id, share_token) = setup(&env);
+        let investor = Address::generate(&env);
+        let sme = Address::generate(&env);
+
+        mint(&env, &usdc_id, &investor, 1_000);
+        client.deposit(&investor, &usdc_id, &1_000);
+
+        client.fund_invoice(
+            &admin,
+            &1u64,
+            &900i128,
+            &sme,
+            &(env.ledger().timestamp() + 10_000),
+            &usdc_id,
+        );
+        assert_eq!(client.available_liquidity(&usdc_id), 100);
+
+        let share_client = token::Client::new(&env, &share_token);
+        let shares_before = share_client.balance(&investor);
+
+        let result = client.try_withdraw(&investor, &usdc_id, &shares_before);
+        assert_eq!(result, Err(Ok(PoolError::InsufficientLiquidity)));
+
+        // Shares must NOT be burned and pool_value must be untouched.
+        assert_eq!(share_client.balance(&investor), shares_before);
+        assert_eq!(client.get_token_totals(&usdc_id).pool_value, 1_000);
+
+        // A withdrawal that fits within the 100 still-liquid units succeeds.
+        client.withdraw(&investor, &usdc_id, &100);
+        assert_eq!(share_client.balance(&investor), shares_before - 100);
     }
 
     #[test]

--- a/contracts/tests/tests/integration_tests.rs
+++ b/contracts/tests/tests/integration_tests.rs
@@ -46,6 +46,28 @@ fn test_env() -> Env {
     env
 }
 
+/// #774: a named set of standard test actors, generated fresh per test via
+/// `Address::generate` (never a hardcoded address literal — those break the
+/// instant Soroban's `testutils` address-generation format changes between
+/// SDK versions). Centralizing the three roles most integration tests need
+/// also avoids copy-paste mistakes where the same generated address gets
+/// reused for two logically different actors.
+struct TestActors {
+    admin: Address,
+    sme: Address,
+    investor: Address,
+}
+
+impl TestActors {
+    fn new(env: &Env) -> Self {
+        Self {
+            admin: Address::generate(env),
+            sme: Address::generate(env),
+            investor: Address::generate(env),
+        }
+    }
+}
+
 fn initialize_pool(
     pool_client: &pool::Client<'_>,
     admin: &Address,
@@ -112,9 +134,7 @@ fn test_complete_invoice_lifecycle() {
     env.ledger().with_mut(|l| l.timestamp = 100_000);
 
     // Deploy contracts
-    let admin = Address::generate(&env);
-    let sme = Address::generate(&env);
-    let investor = Address::generate(&env);
+    let actors = TestActors::new(&env);
     let token_admin = Address::generate(&env);
 
     let invoice_id = env.register_contract_wasm(None, invoice::WASM);
@@ -132,28 +152,29 @@ fn test_complete_invoice_lifecycle() {
 
     // Initialize contracts
     invoice_client.initialize(
-        &admin,
+        &actors.admin,
         &pool_id,
         &10_000_000_000i128,
         &(30u64 * 86_400u64),
         &7u32,
     );
     share_client.initialize(
-        &admin,
+        &actors.admin,
         &7u32,
         &String::from_str(&env, "Pool Shares"),
         &String::from_str(&env, "POOL"),
     );
-    initialize_pool(&pool_client, &admin, &usdc_id, &share_id, &invoice_id);
-    credit_client.initialize(&admin, &invoice_id, &pool_id);
+    initialize_pool(&pool_client, &actors.admin, &usdc_id, &share_id, &invoice_id);
+    credit_client.initialize(&actors.admin, &invoice_id, &pool_id);
 
     // Mint tokens to investor and SME
     soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id)
-        .mint(&investor, &10_000_000_000i128);
-    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id).mint(&sme, &10_000_000_000i128);
+        .mint(&actors.investor, &10_000_000_000i128);
+    soroban_sdk::token::StellarAssetClient::new(&env, &usdc_id)
+        .mint(&actors.sme, &10_000_000_000i128);
 
     // Step 1: Investor deposits into pool
-    pool_client.deposit(&investor, &usdc_id, &5_000_000_000i128);
+    pool_client.deposit(&actors.investor, &usdc_id, &5_000_000_000i128);
     let totals = pool_client.get_token_totals(&usdc_id);
     assert_eq!(totals.pool_value, 5_000_000_000i128);
     // Assert deposit event includes depositor and token
@@ -180,7 +201,7 @@ fn test_complete_invoice_lifecycle() {
     // Step 2: SME creates invoice
     let due_date = env.ledger().timestamp() + 30 * 86_400; // 30 days
     let inv_id = invoice_client.create_invoice(
-        &sme,
+        &actors.sme,
         &String::from_str(&env, "ACME Corp"),
         &2_000_000_000i128,
         &due_date,
@@ -192,10 +213,10 @@ fn test_complete_invoice_lifecycle() {
 
     // Step 3: Pool funds the invoice
     pool_client.fund_invoice(
-        &admin,
+        &actors.admin,
         &inv_id,
         &2_000_000_000i128,
-        &sme,
+        &actors.sme,
         &due_date,
         &usdc_id,
     );
@@ -232,7 +253,7 @@ fn test_complete_invoice_lifecycle() {
     // Step 4: SME repays invoice
     env.ledger().with_mut(|l| l.timestamp += 25 * 86_400); // 25 days later
     let amount_due = pool_client.estimate_repayment(&inv_id, &None);
-    pool_client.repay_invoice(&inv_id, &sme, &amount_due);
+    pool_client.repay_invoice(&inv_id, &actors.sme, &amount_due);
 
     // Assert repaid event includes payer
     let events = env.events().all();
@@ -284,7 +305,7 @@ fn test_complete_invoice_lifecycle() {
     credit_client.record_payment(
         &pool_id,
         &inv_id,
-        &sme,
+        &actors.sme,
         &2_000_000_000i128,
         &due_date,
         &env.ledger().timestamp(),
@@ -311,14 +332,14 @@ fn test_complete_invoice_lifecycle() {
         "payment event must include (caller, sme, invoice_id, status, score, timestamp)"
     );
 
-    let credit_data = credit_client.get_credit_score(&sme);
+    let credit_data = credit_client.get_credit_score(&actors.sme);
     assert_eq!(credit_data.total_invoices, 1);
     assert_eq!(credit_data.paid_on_time, 1);
     assert!(credit_data.score > 500);
 
     // Step 7: Investor withdraws with yield
-    let shares = share_client.balance(&investor);
-    pool_client.withdraw(&investor, &usdc_id, &shares);
+    let shares = share_client.balance(&actors.investor);
+    pool_client.withdraw(&actors.investor, &usdc_id, &shares);
 
     // Assert withdraw event includes investor and token
     let events = env.events().all();
@@ -344,7 +365,8 @@ fn test_complete_invoice_lifecycle() {
         "withdraw event must include (investor, token, amount, shares, timestamp)"
     );
 
-    let investor_balance = soroban_sdk::token::Client::new(&env, &usdc_id).balance(&investor);
+    let investor_balance =
+        soroban_sdk::token::Client::new(&env, &usdc_id).balance(&actors.investor);
     assert!(investor_balance > 5_000_000_000i128); // Should have earned yield
 }
 

--- a/frontend/app/analytics/layout.tsx
+++ b/frontend/app/analytics/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+// #783: /analytics is a client component (page.tsx), which can't itself
+// export `metadata` — a sibling server-component layout is the standard
+// Next.js App Router way to attach a canonical tag to a client page.
+export const metadata: Metadata = {
+  title: 'Analytics — Astera',
+  description: 'Live pool utilization, yield performance, and invoice funnel analytics.',
+  alternates: { canonical: '/analytics' },
+};
+
+export default function AnalyticsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/app/glossary/page.tsx
+++ b/frontend/app/glossary/page.tsx
@@ -4,6 +4,8 @@ import { glossary } from '@/lib/glossary';
 export const metadata: Metadata = {
   title: 'Glossary — Astera',
   description: 'Plain-language explanations of the Stellar and Soroban terms used across Astera.',
+  // #783: canonical tag, resolved against metadataBase in the root layout.
+  alternates: { canonical: '/glossary' },
 };
 
 export default function GlossaryPage() {

--- a/frontend/app/invest/page.tsx
+++ b/frontend/app/invest/page.tsx
@@ -423,6 +423,35 @@ export default function InvestPage() {
                         })}
                       </p>
                     )}
+                    {mode === 'withdraw' && tokenTotals && (
+                      // #782: pool_value minus deployed capital is the actual
+                      // ceiling on any single withdrawal — a user's own share
+                      // balance can exceed this when most of the pool is
+                      // deployed in active invoices.
+                      (() => {
+                        const poolLiquidity =
+                          tokenTotals.totalDeposited > tokenTotals.totalDeployed
+                            ? tokenTotals.totalDeposited - tokenTotals.totalDeployed
+                            : 0n;
+                        const exceedsLiquidity =
+                          !!amount && toStroops(parseFloat(amount || '0')) > poolLiquidity;
+                        return (
+                          <p
+                            className={`text-xs mt-1 ${exceedsLiquidity ? 'text-red-400' : 'text-brand-muted'}`}
+                          >
+                            {exceedsLiquidity
+                              ? t('exceedsLiquidity', {
+                                  amount: formatUSDC(poolLiquidity),
+                                  token: stablecoinLabel(selectedToken),
+                                })
+                              : t('poolLiquidity', {
+                                  amount: formatUSDC(poolLiquidity),
+                                  token: stablecoinLabel(selectedToken),
+                                })}
+                          </p>
+                        );
+                      })()
+                    )}
                     {mode === 'deposit' && tokenDepositCap > 0n && tokenTotals && (
                       <div className="mt-3">
                         <div className="flex justify-between text-xs text-brand-muted mb-1">

--- a/frontend/app/invoice/[id]/layout.tsx
+++ b/frontend/app/invoice/[id]/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+import { isInvoicePrivate } from '@/lib/contracts';
+
+// #783: /invoice/[id] is a client component (page.tsx), which can't itself
+// export `metadata` — a sibling server-component layout is the standard
+// Next.js App Router way to attach metadata to a client page. A private
+// invoice (#775 opt-out) still resolves at this URL for anyone holding the
+// direct link, but is marked `noindex` and given no canonical tag so search
+// engines don't surface or dedupe it as a public page.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+
+  let isPrivate = false;
+  try {
+    isPrivate = await isInvoicePrivate(Number(id));
+  } catch {
+    // Contract unreachable or invoice not found — fall through to the
+    // public default rather than blocking the page from rendering.
+  }
+
+  if (isPrivate) {
+    return { robots: { index: false, follow: false } };
+  }
+
+  return { alternates: { canonical: `/invoice/${id}` } };
+}
+
+export default function InvoiceLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,7 +4,7 @@ import Navbar from '@/components/Navbar';
 import ThemeProvider from '@/components/ThemeProvider';
 import SWRProvider from '@/components/SWRProvider';
 import { Toaster } from 'react-hot-toast';
-import { assertEnvValid } from '@/lib/env';
+import { assertEnvValid, getAppUrl } from '@/lib/env';
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -13,11 +13,8 @@ export const viewport: Viewport = {
 };
 
 // #765: base URL used to resolve relative OG/Twitter image paths into the
-// absolute URLs social platforms require. Falls back to the Vercel preview
-// URL, then localhost, so previews still render correctly in development.
-const APP_URL =
-  process.env.NEXT_PUBLIC_APP_URL ??
-  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+// absolute URLs social platforms require.
+const APP_URL = getAppUrl();
 
 const SITE_TITLE = 'Astera — Real World Assets on Stellar';
 const SITE_DESCRIPTION =

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import GlossaryTerm from '@/components/GlossaryTerm';
+
+// #783: canonical tag for the landing page — resolved against
+// metadataBase (set in the root layout) into an absolute URL.
+export const metadata: Metadata = {
+  alternates: { canonical: '/' },
+};
 
 const stats = [
   { label: 'Trade Finance Gap', value: '$1.7T', sub: 'in emerging markets' },

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from 'next';
+import { getAppUrl } from '@/lib/env';
+
+// #783: static, public-facing routes only — authenticated/app routes
+// (dashboard, invest, portfolio, admin, settings, etc.) aren't meant to be
+// indexed and are already excluded via robots.txt.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = getAppUrl();
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/analytics`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/glossary`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+  ];
+}

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -148,6 +148,16 @@ export function formatEnvErrors(errors: EnvValidationError[]): string {
   return errors.map((e) => `  - ${e.variable}: ${e.message}`).join('\n');
 }
 
+// #783: canonical/absolute base URL for metadata (OG images, canonical tags,
+// sitemap entries). Falls back to the Vercel preview URL, then localhost, so
+// previews and local dev still resolve to a valid absolute URL.
+export function getAppUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000')
+  );
+}
+
 export function assertEnvValid(): void {
   const { valid, errors } = validateEnv();
   if (!valid) {

--- a/frontend/locales/en/common.json
+++ b/frontend/locales/en/common.json
@@ -111,6 +111,8 @@
     "noTokens": "No tokens configured",
     "amountLabel": "Amount ({token})",
     "available": "Available: {amount} {token}",
+    "poolLiquidity": "Pool liquidity: {amount} {token} available to withdraw",
+    "exceedsLiquidity": "Exceeds available pool liquidity of {amount} {token}",
     "processing": "Processing...",
     "retry": "Retry transaction",
     "notes": {

--- a/frontend/locales/es/common.json
+++ b/frontend/locales/es/common.json
@@ -94,6 +94,8 @@
     "noTokens": "No hay tokens configurados",
     "amountLabel": "Importe ({token})",
     "available": "Disponible: {amount} {token}",
+    "poolLiquidity": "Liquidez del pool: {amount} {token} disponible para retirar",
+    "exceedsLiquidity": "Excede la liquidez disponible del pool de {amount} {token}",
     "processing": "Procesando...",
     "retry": "Reintentar transaccion",
     "notes": {

--- a/frontend/locales/fr/common.json
+++ b/frontend/locales/fr/common.json
@@ -111,6 +111,8 @@
     "noTokens": "Aucun jeton configuré",
     "amountLabel": "Montant ({token})",
     "available": "Disponible: {amount} {token}",
+    "poolLiquidity": "Liquidité du pool : {amount} {token} disponible au retrait",
+    "exceedsLiquidity": "Dépasse la liquidité disponible du pool de {amount} {token}",
     "processing": "Traitement...",
     "retry": "Réessayer la transaction",
     "notes": {

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Allow: /
+Allow: /analytics
+Allow: /glossary
+Disallow: /admin
+Disallow: /api
+Disallow: /settings
+Disallow: /portfolio
+Disallow: /dashboard
+
+Sitemap: https://astera.finance/sitemap.xml


### PR DESCRIPTION
## Summary

- **#782** — `withdraw()` already computed `available_liquidity = pool_value - total_deployed` and rejected *before* burning shares, but returned `InvalidAmount` on that path instead of the more specific `InsufficientLiquidity`. Fixed the error variant and added an integration test that deploys 90% of the pool into a funded invoice, then asserts a withdrawal of the investor's full share balance is rejected with `InsufficientLiquidity` — and that no shares are burned and `pool_value` is untouched — before confirming a smaller, in-liquidity withdrawal still succeeds. Also added a "pool liquidity available" hint (with a red warning when the entered amount exceeds it) next to the existing "available to withdraw" share-balance display on the invest page, addressing the UI acceptance criterion.
- **#774** — `contracts/tests/tests/integration_tests.rs` already used `Address::generate(&env)` for every one of its ~180 test addresses; there were no hardcoded address literals to remove. Added the `TestActors` helper the issue proposes and converted `test_complete_invoice_lifecycle` to use it end-to-end as a worked example. Left the other ~30 tests as-is rather than mechanically rewriting a large, already-passing test file in one pass — a couple of them interleave a non-test helper function (`setup_pool`) between test bodies, which makes a blind global find/replace across the file genuinely risky.
- **#783** — added `frontend/public/robots.txt`, a dynamic `frontend/app/sitemap.ts` (Next.js App Router `MetadataRoute.Sitemap`), and canonical tags on the public-facing pages: `/` and `/glossary` directly, `/analytics` and `/invoice/[id]` via a sibling `layout.tsx` (both pages are client components, which can't export `metadata` themselves). A private invoice (`#775`'s owner opt-out) gets `robots: { index: false }` instead of a canonical tag, so a direct link still works but search engines don't index it.
- **#781** — added `cargo-llvm-cov` to the contracts CI job and `next test -- --coverage` to the frontend job, both uploading to Codecov under separate `contracts`/`frontend` flags via `codecov/codecov-action@v4`. Added `codecov.yml` with per-flag PR status checks (80% / 70% targets, 1% threshold) and a coverage badge + baseline note in the README. Upload steps use `fail_ci_if_error: false` so CI doesn't break before a `CODECOV_TOKEN` secret is actually configured on the repo.

## Test plan

- [x] `cargo test -p pool` — new `test_withdraw_insufficient_liquidity_rejected_before_burning_shares` passes; existing withdraw tests (`test_withdraw_more_than_balance_panics`, etc.) still assert `InvalidAmount` for the share-balance case, which is unchanged
- [x] `cargo test -p integration-tests --test integration_tests` — `test_complete_invoice_lifecycle` passes using `TestActors`
- [x] `npx tsc --noEmit` (frontend) — clean, including the new `layout.tsx`/`sitemap.ts` files
- [x] Verified `codecov.yml` and `.github/workflows/ci.yml` parse as valid YAML, and all three edited locale JSON files parse as valid JSON


closes #774 
closes #782
closes #783 
closes #781