### PR TITLE
fix(oracle_registry): value-tiered quorum, verification gate, evidence-backed slashing, admin fallback hardening

### DIFF
--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -2558,6 +2558,17 @@ impl InvoiceContract {
         load_invoice(&env, id)
     }
 
+    /// Cross-contract check for the oracle registry (#953): confirms `id` is
+    /// actually awaiting oracle verification before a `VerificationRound` is
+    /// opened for it, and returns the invoice's principal so the registry can
+    /// apply a value-based quorum tier (#957). Returns primitives rather than
+    /// `Invoice`/`InvoiceStatus` directly so the two contracts' deployed
+    /// interfaces don't need to share Rust types.
+    pub fn get_invoice_verification_state(env: Env, id: u64) -> (bool, i128) {
+        let invoice = load_invoice(&env, id);
+        (invoice.status == InvoiceStatus::AwaitingVerification, invoice.amount)
+    }
+
     pub fn get_funded_amount(env: Env, id: u64) -> i128 {
         env.storage()
             .persistent()

--- a/contracts/oracle_registry/src/lib.rs
+++ b/contracts/oracle_registry/src/lib.rs
@@ -30,6 +30,11 @@ pub trait InvoiceContract {
         reason: String,
         oracle_hash: String,
     );
+
+    /// #953/#957: returns `(is_awaiting_verification, invoice_amount)` so the
+    /// registry can refuse to open a round for an invoice that isn't actually
+    /// awaiting verification, and pick a value-appropriate quorum tier.
+    fn get_invoice_verification_state(env: Env, id: u64) -> (bool, i128);
 }
 
 const LEDGERS_PER_DAY: u32 = 17_280;
@@ -64,6 +69,14 @@ pub enum OracleRegistryError {
     InvoiceContractNotSet = 18,
     InvoiceCallFailed = 19,
     InvalidConfig = 20,
+    // #953: the invoice referenced by open_verification_round isn't actually
+    // awaiting oracle verification.
+    InvoiceNotAwaitingVerification = 21,
+    // #957: malformed quorum tier list (unsorted thresholds, out-of-range bps).
+    InvalidQuorumTiers = 22,
+    // #954: slash_oracle's on-chain evidence requirement.
+    InvalidEvidence = 23,
+    SlashRoundNotFound = 24,
 }
 
 #[contracttype]
@@ -123,6 +136,18 @@ pub struct RegistryConfig {
     pub treasury: Option<Address>,
 }
 
+/// #957: one tier of the value-based quorum schedule. Invoices with a
+/// principal >= `min_invoice_amount` use `quorum_bps` instead of the
+/// registry's flat default — a $500k invoice can require a stricter quorum
+/// than a $500 one. Tiers are stored sorted ascending by `min_invoice_amount`;
+/// the highest tier whose threshold the invoice amount clears wins.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct QuorumTier {
+    pub min_invoice_amount: i128,
+    pub quorum_bps: u32,
+}
+
 #[contracttype]
 pub enum DataKey {
     Admin,
@@ -134,6 +159,7 @@ pub enum DataKey {
     OracleIds,
     Round(u64),
     OpenRounds,
+    QuorumTiers,
 }
 
 const EVT: Symbol = symbol_short!("ORACLE");
@@ -252,6 +278,46 @@ impl OracleRegistryContract {
 
     pub fn get_registry_config(env: Env) -> Result<RegistryConfig, OracleRegistryError> {
         Self::load_config(&env)
+    }
+
+    /// #957: replaces the value-based quorum schedule wholesale. `tiers` must
+    /// be sorted strictly ascending by `min_invoice_amount` (non-negative,
+    /// unique thresholds) with each `quorum_bps` in `1..=10_000` — this keeps
+    /// `resolve_quorum_bps`'s single ascending pass correct and lets admins
+    /// reason about the schedule without the contract silently reordering it.
+    /// An empty vec restores the flat `config.quorum_bps` for every invoice.
+    pub fn set_quorum_tiers(
+        env: Env,
+        admin: Address,
+        tiers: Vec<QuorumTier>,
+    ) -> Result<(), OracleRegistryError> {
+        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
+
+        let mut prev_threshold: Option<i128> = None;
+        for tier in tiers.iter() {
+            if tier.min_invoice_amount < 0 || tier.quorum_bps == 0 || tier.quorum_bps > 10_000 {
+                return Err(OracleRegistryError::InvalidQuorumTiers);
+            }
+            if let Some(prev) = prev_threshold {
+                if tier.min_invoice_amount <= prev {
+                    return Err(OracleRegistryError::InvalidQuorumTiers);
+                }
+            }
+            prev_threshold = Some(tier.min_invoice_amount);
+        }
+
+        env.storage().instance().set(&DataKey::QuorumTiers, &tiers);
+        env.events()
+            .publish((EVT, symbol_short!("tiers_upd")), admin);
+        Ok(())
+    }
+
+    pub fn get_quorum_tiers(env: Env) -> Vec<QuorumTier> {
+        env.storage()
+            .instance()
+            .get(&DataKey::QuorumTiers)
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     pub fn pause(env: Env, admin: Address) -> Result<(), OracleRegistryError> {
@@ -419,16 +485,32 @@ impl OracleRegistryContract {
     /// treasury address is configured, forwards the slashed amount there;
     /// otherwise it remains in the registry's own balance (unrecoverable by
     /// the oracle, since their tracked `stake_amount` has already been cut).
+    #[allow(clippy::too_many_arguments)]
     pub fn slash_oracle(
         env: Env,
         admin: Address,
         operator: Address,
         bps: u32,
+        round_id: u64,
+        evidence: String,
     ) -> Result<(), OracleRegistryError> {
         admin.require_auth();
         Self::require_admin(&env, &admin)?;
         if bps == 0 || bps > 10_000 {
             return Err(OracleRegistryError::InvalidBps);
+        }
+        if evidence.is_empty() {
+            return Err(OracleRegistryError::InvalidEvidence);
+        }
+        // #954: every slash must cite the specific verification round it's
+        // punishing behavior from — otherwise a slash is an unaccountable
+        // admin fiat with no on-chain trail to audit after the fact.
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::Round(round_id))
+        {
+            return Err(OracleRegistryError::SlashRoundNotFound);
         }
         let key = DataKey::Oracle(operator.clone());
         let mut info: OracleInfo = env
@@ -450,7 +532,7 @@ impl OracleRegistryContract {
 
         env.events().publish(
             (EVT, symbol_short!("slashed")),
-            (operator, bps, slash_amount, admin),
+            (operator, bps, slash_amount, admin, round_id, evidence),
         );
         Ok(())
     }
@@ -480,6 +562,20 @@ impl OracleRegistryContract {
             }
         }
 
+        let invoice_contract: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::InvoiceContract)
+            .ok_or(OracleRegistryError::InvoiceContractNotSet)?;
+        let invoice_client = InvoiceContractClient::new(&env, &invoice_contract);
+        let (awaiting_verification, invoice_amount) = invoice_client
+            .try_get_invoice_verification_state(&invoice_id)
+            .map_err(|_| OracleRegistryError::InvoiceCallFailed)?
+            .map_err(|_| OracleRegistryError::InvoiceCallFailed)?;
+        if !awaiting_verification {
+            return Err(OracleRegistryError::InvoiceNotAwaitingVerification);
+        }
+
         let config = Self::load_config(&env)?;
         let ids: Vec<Address> = env
             .storage()
@@ -504,6 +600,8 @@ impl OracleRegistryContract {
             return Err(OracleRegistryError::NoActiveOracles);
         }
 
+        let quorum_bps = Self::resolve_quorum_bps(&env, config.quorum_bps, invoice_amount);
+
         let now = env.ledger().timestamp();
         let round = VerificationRound {
             invoice_id,
@@ -513,7 +611,7 @@ impl OracleRegistryContract {
             weight_for: 0,
             weight_against: 0,
             total_stake_snapshot: total_stake,
-            quorum_bps: config.quorum_bps,
+            quorum_bps,
             status: RoundStatus::Open,
             opened_at: now,
             deadline: now.saturating_add(config.round_duration_secs),
@@ -687,7 +785,14 @@ impl OracleRegistryContract {
             .persistent()
             .get(&round_key)
             .ok_or(OracleRegistryError::RoundNotFound)?;
-        if round.status != RoundStatus::Expired {
+        // #956: defer to the exact same condition `expire_round` uses (deadline
+        // passed) rather than trusting the stored `status` field alone — an
+        // admin must never be able to short-circuit oracle consensus on a
+        // round still within its normal voting window. Checking both the
+        // status *and* re-deriving the deadline condition means this can't
+        // silently regress if a future code path ever sets `Expired` without
+        // going through `expire_round`.
+        if round.status != RoundStatus::Expired || env.ledger().timestamp() <= round.deadline {
             return Err(OracleRegistryError::RoundNotExpired);
         }
         round.status = if approved {
@@ -763,6 +868,28 @@ impl OracleRegistryContract {
             .instance()
             .get(&DataKey::Config)
             .ok_or(OracleRegistryError::NotInitialized)
+    }
+
+    /// #957: picks the quorum_bps for `invoice_amount` from the configured
+    /// tier schedule. Tiers are stored sorted ascending, so the highest
+    /// threshold the amount clears wins; falls back to `default_bps` (the
+    /// registry's flat `config.quorum_bps`) if no tiers are configured or the
+    /// amount is below every tier's threshold.
+    fn resolve_quorum_bps(env: &Env, default_bps: u32, invoice_amount: i128) -> u32 {
+        let tiers: Vec<QuorumTier> = env
+            .storage()
+            .instance()
+            .get(&DataKey::QuorumTiers)
+            .unwrap_or_else(|| Vec::new(env));
+        let mut resolved = default_bps;
+        for tier in tiers.iter() {
+            if invoice_amount >= tier.min_invoice_amount {
+                resolved = tier.quorum_bps;
+            } else {
+                break;
+            }
+        }
+        resolved
     }
 
     fn remove_open_round(env: &Env, invoice_id: u64) {

--- a/contracts/oracle_registry/tests/consensus_tests.rs
+++ b/contracts/oracle_registry/tests/consensus_tests.rs
@@ -40,6 +40,33 @@ impl DummyInvoice {
             .get(&Symbol::new(&env, "calls"))
             .unwrap_or_else(|| Vec::new(&env))
     }
+
+    /// Lets tests flip what `get_invoice_verification_state` reports (#953:
+    /// not-awaiting rejection, #957: value-tiered quorum). Defaults to
+    /// `(true, 0)` so existing tests that never call this keep working
+    /// unchanged.
+    pub fn set_verification_state(env: Env, awaiting: bool, amount: i128) {
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "awaiting"), &awaiting);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "amount"), &amount);
+    }
+
+    pub fn get_invoice_verification_state(env: Env, _id: u64) -> (bool, i128) {
+        let awaiting: bool = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "awaiting"))
+            .unwrap_or(true);
+        let amount: i128 = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "amount"))
+            .unwrap_or(0);
+        (awaiting, amount)
+    }
 }
 
 fn setup(
@@ -409,4 +436,136 @@ fn test_no_active_oracles_blocks_round_open() {
     let hash = String::from_str(&env, "h1");
     let result = client.try_open_verification_round(&caller, &7u64, &hash);
     assert_eq!(result, Err(Ok(OracleRegistryError::NoActiveOracles)));
+}
+
+// #953: `open_verification_round` must confirm with the invoice contract that
+// the invoice is actually awaiting verification before wasting registry
+// storage on a round for it.
+#[test]
+fn test_open_round_rejects_invoice_not_awaiting_verification() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, stake_token, invoice) = setup(&env, 1_000);
+    register_n_equal(&env, &client, &stake_token, 3, 1_000);
+    invoice.set_verification_state(&false, &0);
+
+    let caller = Address::generate(&env);
+    let hash = String::from_str(&env, "h1");
+    let result = client.try_open_verification_round(&caller, &7u64, &hash);
+    assert_eq!(
+        result,
+        Err(Ok(OracleRegistryError::InvoiceNotAwaitingVerification))
+    );
+}
+
+// #957: a configured quorum tier overrides the flat default for invoices at
+// or above its threshold, so a high-value invoice can demand a stricter
+// quorum than a low-value one.
+#[test]
+fn test_open_round_applies_quorum_tier_by_invoice_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, stake_token, invoice) = setup(&env, 1_000);
+    register_n_equal(&env, &client, &stake_token, 3, 1_000);
+
+    client.set_quorum_tiers(
+        &admin,
+        &Vec::from_array(
+            &env,
+            [
+                oracle_registry::QuorumTier {
+                    min_invoice_amount: 0,
+                    quorum_bps: 5_000,
+                },
+                oracle_registry::QuorumTier {
+                    min_invoice_amount: 1_000_000,
+                    quorum_bps: 9_000,
+                },
+            ],
+        ),
+    );
+
+    // A small invoice lands in the 0-threshold tier.
+    invoice.set_verification_state(&true, &500);
+    let caller = Address::generate(&env);
+    client.open_verification_round(&caller, &7u64, &String::from_str(&env, "h1"));
+    assert_eq!(
+        client.get_verification_round(&7u64).unwrap().quorum_bps,
+        5_000
+    );
+
+    // A large invoice clears the higher tier's threshold.
+    invoice.set_verification_state(&true, &2_000_000);
+    client.open_verification_round(&caller, &8u64, &String::from_str(&env, "h2"));
+    assert_eq!(
+        client.get_verification_round(&8u64).unwrap().quorum_bps,
+        9_000
+    );
+}
+
+#[test]
+fn test_set_quorum_tiers_rejects_unsorted_thresholds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _stake_token, _invoice) = setup(&env, 1_000);
+
+    let result = client.try_set_quorum_tiers(
+        &admin,
+        &Vec::from_array(
+            &env,
+            [
+                oracle_registry::QuorumTier {
+                    min_invoice_amount: 1_000_000,
+                    quorum_bps: 9_000,
+                },
+                oracle_registry::QuorumTier {
+                    min_invoice_amount: 0,
+                    quorum_bps: 5_000,
+                },
+            ],
+        ),
+    );
+    assert_eq!(result, Err(Ok(OracleRegistryError::InvalidQuorumTiers)));
+}
+
+// #954: slash_oracle must cite a real, existing round as evidence — an
+// admin can't slash on a fabricated reference or with no justification text.
+#[test]
+fn test_slash_oracle_requires_existing_round_reference() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, stake_token, _invoice) = setup(&env, 1_000);
+    let operator = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &stake_token).mint(&operator, &1_000);
+    client.register_oracle(&operator, &1_000);
+
+    let result = client.try_slash_oracle(
+        &admin,
+        &operator,
+        &5_000u32,
+        &999u64, // no round ever opened for this invoice id
+        &String::from_str(&env, "evidence"),
+    );
+    assert_eq!(result, Err(Ok(OracleRegistryError::SlashRoundNotFound)));
+}
+
+#[test]
+fn test_slash_oracle_requires_non_empty_evidence() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, stake_token, _invoice) = setup(&env, 1_000);
+    let operator = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &stake_token).mint(&operator, &1_000);
+    client.register_oracle(&operator, &1_000);
+    let caller = Address::generate(&env);
+    client.open_verification_round(&caller, &7u64, &String::from_str(&env, "h1"));
+
+    let result = client.try_slash_oracle(
+        &admin,
+        &operator,
+        &5_000u32,
+        &7u64,
+        &String::from_str(&env, ""),
+    );
+    assert_eq!(result, Err(Ok(OracleRegistryError::InvalidEvidence)));
 }

--- a/contracts/oracle_registry/tests/fuzz_tests.rs
+++ b/contracts/oracle_registry/tests/fuzz_tests.rs
@@ -46,6 +46,10 @@ impl DummyInvoice {
             .get(&Symbol::new(&env, "calls"))
             .unwrap_or_else(|| Vec::new(&env))
     }
+
+    pub fn get_invoice_verification_state(_env: Env, _id: u64) -> (bool, i128) {
+        (true, 0)
+    }
 }
 
 const QUORUM_BPS: i128 = 6_600;

--- a/contracts/oracle_registry/tests/registration_tests.rs
+++ b/contracts/oracle_registry/tests/registration_tests.rs
@@ -2,9 +2,35 @@
 
 use oracle_registry::{OracleRegistryContract, OracleRegistryContractClient, OracleRegistryError};
 use soroban_sdk::{
+    contract, contractimpl,
     testutils::{Address as _, Ledger},
     token, Address, Env, String,
 };
+
+/// Minimal invoice-contract stand-in so `open_verification_round`'s
+/// cross-contract awaiting-verification check (#953) has something to call
+/// into. Always reports the invoice as awaiting verification — none of these
+/// tests exercise that rejection path (see consensus_tests.rs for that).
+#[contract]
+pub struct DummyInvoice;
+
+#[contractimpl]
+impl DummyInvoice {
+    pub fn consensus_verify(
+        _env: Env,
+        _id: u64,
+        registry: Address,
+        _approved: bool,
+        _reason: String,
+        _oracle_hash: String,
+    ) {
+        registry.require_auth();
+    }
+
+    pub fn get_invoice_verification_state(_env: Env, _id: u64) -> (bool, i128) {
+        (true, 0)
+    }
+}
 
 fn setup(env: &Env) -> (OracleRegistryContractClient<'_>, Address, Address, i128) {
     env.ledger().with_mut(|l| l.timestamp = 1_000_000);
@@ -17,6 +43,8 @@ fn setup(env: &Env) -> (OracleRegistryContractClient<'_>, Address, Address, i128
         .address();
     let min_stake = 1_000i128;
     client.initialize(&admin, &stake_token, &min_stake);
+    let invoice_id = env.register(DummyInvoice, ());
+    client.set_invoice_contract(&admin, &invoice_id);
     (client, admin, stake_token, min_stake)
 }
 
@@ -150,8 +178,18 @@ fn test_slash_oracle_reduces_stake_and_forwards_to_treasury() {
     client.register_oracle(&operator, &min_stake);
     client.set_treasury(&admin, &Some(treasury.clone()));
 
+    // #954: slash_oracle must cite a real round + evidence as justification.
+    let caller = Address::generate(&env);
+    client.open_verification_round(&caller, &1u64, &String::from_str(&env, "hash-1"));
+
     // Slash 50% (5000 bps).
-    client.slash_oracle(&admin, &operator, &5_000u32);
+    client.slash_oracle(
+        &admin,
+        &operator,
+        &5_000u32,
+        &1u64,
+        &String::from_str(&env, "colluded with debtor per dispute #12"),
+    );
 
     let info = client.get_oracle_info(&operator).unwrap();
     assert_eq!(info.stake_amount, min_stake / 2);
@@ -170,7 +208,16 @@ fn test_slash_without_treasury_keeps_funds_in_registry() {
     mint(&env, &stake_token, &operator, min_stake);
     client.register_oracle(&operator, &min_stake);
 
-    client.slash_oracle(&admin, &operator, &10_000u32); // full slash
+    let caller = Address::generate(&env);
+    client.open_verification_round(&caller, &1u64, &String::from_str(&env, "hash-1"));
+
+    client.slash_oracle(
+        &admin,
+        &operator,
+        &10_000u32, // full slash
+        &1u64,
+        &String::from_str(&env, "colluded with debtor per dispute #12"),
+    );
 
     let info = client.get_oracle_info(&operator).unwrap();
     assert_eq!(info.stake_amount, 0);
@@ -189,7 +236,13 @@ fn test_slash_unauthorized_caller_rejected() {
     mint(&env, &stake_token, &operator, min_stake);
     client.register_oracle(&operator, &min_stake);
 
-    let result = client.try_slash_oracle(&not_admin, &operator, &5_000u32);
+    let result = client.try_slash_oracle(
+        &not_admin,
+        &operator,
+        &5_000u32,
+        &1u64,
+        &String::from_str(&env, "evidence"),
+    );
     assert_eq!(result, Err(Ok(OracleRegistryError::Unauthorized)));
 }
 


### PR DESCRIPTION
## Summary
- **#953**: `open_verification_round` now calls into the invoice contract's new `get_invoice_verification_state` view before opening a round, rejecting invoices that aren't actually `AwaitingVerification` instead of wasting registry storage or conflicting with the invoice contract's own oracle flow.
- **#957**: added a configurable value-based quorum tier schedule (`set_quorum_tiers`/`get_quorum_tiers`) so a high-principal invoice can require a stricter `quorum_bps` than a low-value one, reusing the invoice amount already fetched for the #953 check.
- **#956**: `admin_resolve_round` now re-derives `expire_round`'s exact deadline condition instead of trusting the stored `status` field alone, so the admin fallback can never short-circuit oracle consensus on a round still within its normal voting window.
- **#954**: `slash_oracle` now requires a `round_id` referencing a real `VerificationRound` plus a non-empty `evidence` string, both included in the emitted event, so a slash can always be traced back to the behavior it's punishing.

## Test plan
- [ ] `cargo test -p oracle_registry` (new coverage: `test_open_round_rejects_invoice_not_awaiting_verification`, `test_open_round_applies_quorum_tier_by_invoice_value`, `test_set_quorum_tiers_rejects_unsorted_thresholds`, `test_slash_oracle_requires_existing_round_reference`, `test_slash_oracle_requires_non_empty_evidence`)
- [ ] `cargo test -p invoice`
- [ ] `cargo test -p integration-tests`

Closes #953
Closes #954
Closes #956
Closes #957