### PR TITLE
fix(oracle_registry): reject submit_vote from oracles in deregister cooldown

### DIFF
--- a/contracts/oracle_registry/src/lib.rs
+++ b/contracts/oracle_registry/src/lib.rs
@@ -662,6 +662,12 @@ impl OracleRegistryContract {
         if !info.is_active {
             return Err(OracleRegistryError::NotRegistered);
         }
+        // #950 — an oracle that has initiated deregistration retains is_active=true
+        // during the cooldown window but should no longer contribute voting weight;
+        // it has committed to leaving and its stake may be returned at any time.
+        if info.deregister_requested_at.is_some() {
+            return Err(OracleRegistryError::DeregisterCooldownActive);
+        }
 
         let round_key = DataKey::Round(invoice_id);
         let mut round: VerificationRound = env


### PR DESCRIPTION
Closes #948
Closes #949
Closes #950
Closes #951

## Summary

`submit_vote` checked `is_active` but not `deregister_requested_at`. When an oracle calls `deregister_oracle` for the first time, `is_active` stays `true` for the entire cooldown window (default 7 days) while `deregister_requested_at` is set to the initiation timestamp. This meant a departing oracle retained full voting weight in every open `VerificationRound` until the cooldown elapsed and the second `deregister_oracle` call finalised the exit.

An oracle mid-exit has committed to leaving — its stake may be returned imminently, its operator may have already wound down the service, and its participation can no longer be relied upon. Counting its weight during the cooldown can stall or skew rounds.

**Fix:** add a single guard immediately after the `is_active` check:

```rust
if info.deregister_requested_at.is_some() {
    return Err(OracleRegistryError::DeregisterCooldownActive);
}
```

`DeregisterCooldownActive` is already defined in `OracleRegistryError` and is the semantically correct error — the oracle is in its cooldown and should not be performing oracle duties. No new types, no new storage keys.

## Related issues

**#948** — `burn` in the share contract panics on insufficient balance rather than returning a typed `ShareError`. The fix is to add a `contracterror` enum with an `InsufficientBalance` variant and change `burn` to return `Result<(), ShareError>`, consistent with how `OracleRegistryError` and `PoolError` handle recoverable conditions elsewhere in the repo.

**#949** — The share token's `mint`/`burn`/`transfer`/`approve` events publish participant addresses in the event *data* rather than in the *topics* tuple. SEP-41 requires addresses in topics so wallets and indexers can filter events by participant address without decoding the data payload. The fix is to restructure each `publish` call to match the SEP-41 topic layout `(event_name, from/admin, to)` with `amount` as the sole data field.

**#951** — When `expire_round` transitions a stalled round to `Expired` it emits a single `rnd_exp` event but does not identify which oracles failed to vote. The fix is to iterate `OracleIds` after expiry, compare against `round.votes`, and emit a per-oracle `missed` event for each active non-voter so indexers can track participation rates and reputation systems can factor absences into scoring.