### PR TITLE
feat/fix: batch status, cancel proposal guard, voting power, review r…

### DIFF
--- a/contracts/compliance/src/lib.rs
+++ b/contracts/compliance/src/lib.rs
@@ -28,6 +28,9 @@ const MAX_HISTORY_ENTRIES: u32 = 64;
 const MAX_FLAGGED_LIST: u32 = 256;
 const MAX_PENDING_LIST: u32 = 256;
 const MAX_SCREENER_LIST: u32 = 64;
+/// #927: minimum seconds between request_review calls for the same address
+/// from the same caller. Prevents unbounded growth of the pending-review list.
+const REVIEW_REQUEST_COOLDOWN_SECS: u64 = 24 * 60 * 60; // 24 hours
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -46,6 +49,8 @@ pub enum ComplianceError {
     AddressNotFound = 10,
     ListFull = 11,
     InvalidReason = 12,
+    // #927: caller has already requested review for this address within the cooldown window.
+    ReviewRequestTooSoon = 13,
 }
 
 #[contracttype]
@@ -113,6 +118,8 @@ pub enum DataKey {
     PendingScreener(Address),
     FlaggedIds,
     PendingReviewIds,
+    // #927: last request_review timestamp keyed by (caller, target address).
+    ReviewRequestedAt(Address, Address),
 }
 
 const EVT: Symbol = symbol_short!("COMPLY");
@@ -437,6 +444,7 @@ impl ComplianceContract {
     /// Permissionless flagging: moves a Cleared address to PendingReview so
     /// privileged actions pause until a screener re-clears them. Callable by
     /// the off-chain monitoring service without screener privileges.
+    /// #927: rate-limited per (caller, address) pair to prevent list spam.
     pub fn request_review(
         env: Env,
         caller: Address,
@@ -447,6 +455,20 @@ impl ComplianceContract {
         require_not_paused(&env);
 
         let now = env.ledger().timestamp();
+
+        // #927: enforce cooldown — same caller cannot re-request review for the
+        // same address within REVIEW_REQUEST_COOLDOWN_SECS.
+        let cooldown_key = DataKey::ReviewRequestedAt(caller.clone(), address.clone());
+        if let Some(last_at) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&cooldown_key)
+        {
+            if now < last_at.saturating_add(REVIEW_REQUEST_COOLDOWN_SECS) {
+                return Err(ComplianceError::ReviewRequestTooSoon);
+            }
+        }
+        env.storage().instance().set(&cooldown_key, &now);
         let existing: Option<ComplianceRecord> = env
             .storage()
             .persistent()
@@ -541,6 +563,39 @@ impl ComplianceContract {
             }
             None => ComplianceStatus::Unscreened,
         }
+    }
+
+    /// #928: Batch variant of get_effective_status. Returns statuses in the
+    /// same order as the input addresses, reducing cross-contract calls for
+    /// flows that touch multiple addresses (e.g. fund_multiple_invoices).
+    pub fn get_effective_status_batch(
+        env: Env,
+        addresses: Vec<Address>,
+    ) -> Vec<ComplianceStatus> {
+        let now = env.ledger().timestamp();
+        let mut results = Vec::new(&env);
+        for i in 0..addresses.len() {
+            let addr = addresses.get(i).unwrap();
+            let status = match env
+                .storage()
+                .persistent()
+                .get::<DataKey, ComplianceRecord>(&DataKey::Record(addr))
+            {
+                Some(r) => {
+                    if matches!(r.status, ComplianceStatus::Cleared)
+                        && r.expires_at != 0
+                        && now >= r.expires_at
+                    {
+                        ComplianceStatus::Unscreened
+                    } else {
+                        r.status
+                    }
+                }
+                None => ComplianceStatus::Unscreened,
+            };
+            results.push_back(status);
+        }
+        results
     }
 
     pub fn get_compliance_record(env: Env, address: Address) -> Option<ComplianceRecord> {

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -399,10 +399,16 @@ impl Governance {
         if caller != proposal.proposer && caller != config.admin {
             return Err(GovernanceError::Unauthorized);
         }
-        if proposal.status == ProposalStatus::Cancelled
-            || proposal.status == ProposalStatus::Executed
-        {
-            return Err(GovernanceError::ProposalInactive);
+        // #929: also reject Expired and Rejected — only Active/Passed proposals
+        // can be cancelled; everything else is already in a terminal state.
+        match proposal.status {
+            ProposalStatus::Cancelled
+            | ProposalStatus::Executed
+            | ProposalStatus::Expired
+            | ProposalStatus::Rejected => {
+                return Err(GovernanceError::InvalidProposalState);
+            }
+            ProposalStatus::Active | ProposalStatus::Passed => {}
         }
 
         proposal.status = ProposalStatus::Cancelled;
@@ -456,6 +462,26 @@ impl Governance {
 
     pub fn get_config(env: Env) -> Result<GovernanceConfig, GovernanceError> {
         load_config(&env)
+    }
+
+    /// #930: Read-only preview of a voter's current voting weight for a given
+    /// proposal. Uses the same snapshot-based weight as `vote()` so callers see
+    /// exactly how much their vote will count before submitting a transaction.
+    /// Returns 0 when the proposal does not exist or the voter held no shares
+    /// at the snapshot timestamp.
+    pub fn get_voting_power(
+        env: Env,
+        proposal_id: u64,
+        voter: Address,
+    ) -> Result<i128, GovernanceError> {
+        let config = load_config(&env)?;
+        let proposal: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(GovernanceError::ProposalNotFound)?;
+        let weight = proposal_weight(&env, &config.share_token, &voter, proposal.created_at);
+        Ok(weight)
     }
 
     /// Updates the quorum and pass-threshold, gated to the address holding


### PR DESCRIPTION

- feat(compliance): add get_effective_status_batch for multi-address lookups (#928) Reduces cross-contract calls for flows touching multiple addresses such as fund_multiple_invoices by returning statuses in a single read.

- fix(governance): cancel_proposal now rejects already-executed/expired proposals (#929) Prevents list_proposals from showing a proposal as both executed and cancelled by returning InvalidProposalState for any terminal status.

- feat(governance): add get_voting_power read-only call (#930) Allows callers to preview their voting weight for a proposal before submitting a vote transaction, using the same snapshot logic as vote().

- fix(compliance): add per-caller rate limit to request_review (#927) Enforces a 24-hour cooldown per (caller, address) pair so list_pending_review cannot grow without bound from repeated calls on the same flagged address.

Closes #928
Closes #929
Closes #930
Closes #927