### PR TITLE
Role-based multisig access control for pool, invoice, and credit_score (#864)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "access_control"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +408,7 @@ dependencies = [
 name = "credit_score"
 version = "0.1.0"
 dependencies = [
+ "access_control",
  "proptest",
  "soroban-sdk",
 ]
@@ -1047,6 +1055,7 @@ dependencies = [
 name = "invoice"
 version = "0.1.0"
 dependencies = [
+ "access_control",
  "proptest",
  "soroban-sdk",
 ]
@@ -1277,6 +1286,7 @@ dependencies = [
 name = "pool"
 version = "0.1.0"
 dependencies = [
+ "access_control",
  "compliance",
  "proptest",
  "referral",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "contracts/access_control",
     "contracts/invoice",
     "contracts/pool",
     "contracts/credit_score",

--- a/contracts/access_control/Cargo.toml
+++ b/contracts/access_control/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "credit_score"
+name = "access_control"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,13 +11,11 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
-proptest = "1.4"
-access_control = { path = "../access_control" }
 
 [[test]]
-name = "fuzz_tests"
-path = "tests/fuzz_tests.rs"
+name = "lifecycle_tests"
+path = "tests/lifecycle_tests.rs"
 
 [[test]]
-name = "access_control_tests"
-path = "tests/access_control_tests.rs"
+name = "cross_contract_tests"
+path = "tests/cross_contract_tests.rs"

--- a/contracts/access_control/src/lib.rs
+++ b/contracts/access_control/src/lib.rs
@@ -1,0 +1,732 @@
+//! access_control
+//!
+//! Role-based multi-signature access control for the invoice/pool/credit_score
+//! contracts (#864). Every privileged entrypoint in those contracts today is
+//! gated by a single `Admin` address — if that one key is compromised, an
+//! attacker has unbounded control. This crate introduces a parallel,
+//! additive authorization path: a set of named roles, each with its own
+//! `signers: Vec<Address>` and `threshold: u32` (M-of-N), and a
+//! propose -> approve -> execute lifecycle for privileged actions.
+//!
+//! This does NOT replace the legacy single-admin path on any of the three
+//! target contracts — that stays fully functional, unchanged, so a
+//! deployment can adopt RBAC gradually. See each target contract's new
+//! `*_via_ac` entrypoints, which trust calls that carry this
+//! contract's own on-chain identity (the same pattern the pool contract
+//! already uses to trust the invoice contract for `update_invoice_due_date`:
+//! the calling contract's `Address` authenticates itself via
+//! `require_auth()`, verified by the Soroban host against the actual
+//! calling contract in this invocation).
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractclient, contracterror, contractimpl, contracttype, symbol_short, Address,
+    Env, String, Symbol, Vec,
+};
+
+const EVT: Symbol = symbol_short!("accctl");
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+const LEDGERS_PER_DAY: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = LEDGERS_PER_DAY * 30;
+const INSTANCE_LIFETIME_THRESHOLD: u32 = LEDGERS_PER_DAY * 7;
+
+/// Default window (in seconds) a proposal stays open before it expires
+/// unapproved, unless overridden at `initialize()`. 7 days.
+const DEFAULT_PROPOSAL_EXPIRY_SECS: u64 = 604_800;
+
+// ─── Roles ──────────────────────────────────────────────────────────────────
+
+/// A named role, each with its own independent signer set and threshold.
+///
+/// `SuperAdmin` is the only role that may add/remove signers or change
+/// thresholds for ANY role (including itself) — see `ActionPayload::AddSigner`
+/// et al. below. It deliberately has the highest bar: bootstrapped once at
+/// `initialize()`, and every subsequent change to it must go through its own
+/// multisig proposal, so no single key — not even the deployer — can
+/// unilaterally re-seed every role after launch.
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Role {
+    SuperAdmin,
+    RiskManager,
+    TreasuryManager,
+    ComplianceOfficer,
+    OracleManager,
+}
+
+/// M-of-N signer configuration for one role.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MultiSigConfig {
+    pub signers: Vec<Address>,
+    pub threshold: u32,
+}
+
+// ─── Action payloads ────────────────────────────────────────────────────────
+
+/// Every privileged action this system can gate. Each variant mirrors one
+/// real entrypoint on `pool`, `invoice`, or `credit_score` (see each
+/// contract's new `*_via_ac` methods) — except `AddSigner`,
+/// `RemoveSigner`, and `SetThreshold`, which are self-management actions
+/// against this contract's own role configuration and may only ever be
+/// proposed under `Role::SuperAdmin` (enforced in `propose_action`).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub enum ActionPayload {
+    // ── pool ──
+    /// pause()/unpause() unified: `true` pauses, `false` unpauses.
+    SetPaused(bool),
+    SetYield(u32),
+    SetTreasury(Address),
+    /// (token, amount)
+    WithdrawRevenue(Address, i128),
+    SetOracleContract(Address),
+    SetKycRequired(bool),
+    /// (investor, approved)
+    SetInvestorKyc(Address, bool),
+    SetMaxUtilization(u32),
+    // ── invoice ──
+    SetOracle(Address),
+    /// (debtor_id, debtor_name, max_exposure)
+    RegisterDebtor(String, String, i128),
+    DeactivateDebtor(String),
+    AddKeeper(Address),
+    // ── credit_score ──
+    SetLateThreshold(i64),
+    /// (excellent, very_good, good, fair)
+    SetScoreThresholds(u32, u32, u32, u32),
+    /// (address, attestor_type discriminant, weight_bps) — the discriminant
+    /// is decoded by credit_score's own `AttestorType` mapping so this crate
+    /// doesn't need to depend on credit_score's types (0=BusinessRegistry,
+    /// 1=CreditBureau, 2=ExternalProtocol, 3=Manual).
+    RegisterAttestor(Address, u32, u32),
+    // ── self-management (SuperAdmin only) ──
+    AddSigner(Role, Address),
+    RemoveSigner(Role, Address),
+    SetThreshold(Role, u32),
+}
+
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProposalStatus {
+    Pending,
+    Approved,
+    Executed,
+    Rejected,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Proposal {
+    pub role: Role,
+    /// The contract this action targets, or this contract's own address
+    /// for a self-management action.
+    pub target: Address,
+    pub action: ActionPayload,
+    pub proposer: Address,
+    pub approvals: Vec<Address>,
+    pub created_at: u64,
+    pub expires_at: u64,
+    pub status: ProposalStatus,
+}
+
+// ─── Storage ────────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Initialized,
+    RoleConfig(Role),
+    Proposal(u64),
+    NextProposalId,
+    ProposalExpirySecs,
+}
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum AccessControlError {
+    AlreadyInitialized = 0,
+    NotInitialized = 1,
+    NotASigner = 2,
+    AlreadyApproved = 3,
+    ThresholdNotMet = 4,
+    ProposalNotFound = 5,
+    ProposalExpired = 6,
+    ProposalNotPending = 7,
+    ProposalNotApproved = 8,
+    InvalidThreshold = 9,
+    DuplicateSigner = 10,
+    RoleNotConfigured = 11,
+    SelfManagementRequiresSuperAdmin = 12,
+    InvalidExpiryWindow = 13,
+    SignerNotFound = 14,
+    NoApprovalToRevoke = 15,
+}
+
+type Result_ = Result<(), AccessControlError>;
+
+// ─── Cross-contract interfaces ─────────────────────────────────────────────
+//
+// Local minimal mirrors of the target contracts' new `*_via_ac`
+// entrypoints — the same "define just what you call, decoded by name"
+// convention already used by pool/invoice for `PoolClient`/`InvoiceContractClient`/
+// `CreditScoreClient` etc., so this crate never depends on pool/invoice/
+// credit_score directly.
+
+#[contractclient(name = "PoolClient")]
+pub trait PoolContract {
+    fn set_paused_via_ac(env: Env, access_control: Address, paused: bool);
+    fn set_yield_via_ac(env: Env, access_control: Address, new_yield_bps: u32);
+    fn set_treasury_via_ac(env: Env, access_control: Address, treasury: Address);
+    fn withdraw_revenue_via_ac(env: Env, access_control: Address, token: Address, amount: i128);
+    fn set_oracle_contract_via_ac(env: Env, access_control: Address, oracle: Address);
+    fn set_kyc_required_via_ac(env: Env, access_control: Address, required: bool);
+    fn set_investor_kyc_via_ac(
+        env: Env,
+        access_control: Address,
+        investor: Address,
+        approved: bool,
+    );
+    fn set_max_utilization_via_ac(env: Env, access_control: Address, max_bps: u32);
+}
+
+#[contractclient(name = "InvoiceClient")]
+pub trait InvoiceContract {
+    fn set_paused_via_ac(env: Env, access_control: Address, paused: bool);
+    fn set_oracle_via_ac(env: Env, access_control: Address, oracle: Address);
+    fn register_debtor_via_ac(
+        env: Env,
+        access_control: Address,
+        debtor_id: String,
+        debtor_name: String,
+        max_exposure: i128,
+    );
+    fn deactivate_debtor_via_ac(env: Env, access_control: Address, debtor_id: String);
+    fn add_keeper_via_ac(env: Env, access_control: Address, keeper: Address);
+}
+
+#[contractclient(name = "CreditScoreClient")]
+pub trait CreditScoreContract {
+    fn set_paused_via_ac(env: Env, access_control: Address, paused: bool);
+    fn set_late_threshold_via_ac(env: Env, access_control: Address, days: i64);
+    fn set_score_thresholds_via_ac(
+        env: Env,
+        access_control: Address,
+        excellent: u32,
+        very_good: u32,
+        good: u32,
+        fair: u32,
+    );
+    fn register_attestor_via_ac(
+        env: Env,
+        access_control: Address,
+        address: Address,
+        attestor_type: u32,
+        weight_bps: u32,
+    );
+}
+
+// ─── Contract ───────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct AccessControlContract;
+
+#[contractimpl]
+impl AccessControlContract {
+    /// One-time setup. Bootstraps only the `SuperAdmin` role — every other
+    /// role starts unconfigured (no signers, no threshold) and must be
+    /// configured afterwards via `AddSigner`/`SetThreshold` proposals raised
+    /// under `Role::SuperAdmin`. This sidesteps the chicken-and-egg problem
+    /// of a role-management system needing role management to bootstrap:
+    /// `SuperAdmin` is seeded directly here, once, from constructor args.
+    pub fn initialize(
+        env: Env,
+        super_admin_signers: Vec<Address>,
+        super_admin_threshold: u32,
+        proposal_expiry_secs: u64,
+    ) -> Result_ {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(AccessControlError::AlreadyInitialized);
+        }
+        Self::validate_config(&super_admin_signers, super_admin_threshold)?;
+        if proposal_expiry_secs == 0 {
+            return Err(AccessControlError::InvalidExpiryWindow);
+        }
+
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage().instance().set(
+            &DataKey::RoleConfig(Role::SuperAdmin),
+            &MultiSigConfig {
+                signers: super_admin_signers,
+                threshold: super_admin_threshold,
+            },
+        );
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalExpirySecs, &proposal_expiry_secs);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextProposalId, &0u64);
+        bump_instance(&env);
+
+        env.events()
+            .publish((EVT, symbol_short!("init")), super_admin_threshold);
+        Ok(())
+    }
+
+    /// Read-only accessor for a role's current signer set / threshold.
+    pub fn get_role_config(env: Env, role: Role) -> Option<MultiSigConfig> {
+        env.storage().instance().get(&DataKey::RoleConfig(role))
+    }
+
+    pub fn is_signer(env: Env, role: Role, address: Address) -> bool {
+        match Self::get_role_config(env, role) {
+            Some(cfg) => cfg.signers.contains(&address),
+            None => false,
+        }
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Option<Proposal> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+    }
+
+    /// One past `proposal_id`, i.e. proposals exist for `0..get_next_proposal_id()`.
+    /// Lets a frontend page through the full proposal history/queue without
+    /// this contract needing its own paginated listing entrypoint.
+    pub fn get_next_proposal_id(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::NextProposalId)
+            .unwrap_or(0)
+    }
+
+    /// Raise a new proposal under `role`. The proposer must already be a
+    /// registered signer for that role, and is counted as the first
+    /// approval (a proposer that isn't willing to approve their own
+    /// proposal shouldn't be raising it).
+    pub fn propose_action(
+        env: Env,
+        role: Role,
+        proposer: Address,
+        target: Address,
+        action: ActionPayload,
+    ) -> Result<u64, AccessControlError> {
+        proposer.require_auth();
+        bump_instance(&env);
+
+        if Self::is_self_management(&action) && !matches!(role, Role::SuperAdmin) {
+            return Err(AccessControlError::SelfManagementRequiresSuperAdmin);
+        }
+
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::RoleConfig(role))
+            .ok_or(AccessControlError::RoleNotConfigured)?;
+        if !config.signers.contains(&proposer) {
+            return Err(AccessControlError::NotASigner);
+        }
+
+        let expiry_secs: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalExpirySecs)
+            .unwrap_or(DEFAULT_PROPOSAL_EXPIRY_SECS);
+        let now = env.ledger().timestamp();
+
+        let mut approvals = Vec::new(&env);
+        approvals.push_back(proposer.clone());
+        let status = if config.threshold <= 1 {
+            ProposalStatus::Approved
+        } else {
+            ProposalStatus::Pending
+        };
+
+        let proposal_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextProposalId)
+            .unwrap_or(0);
+        let proposal = Proposal {
+            role,
+            target: target.clone(),
+            action: action.clone(),
+            proposer: proposer.clone(),
+            approvals,
+            created_at: now,
+            expires_at: now + expiry_secs,
+            status,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextProposalId, &(proposal_id + 1));
+
+        env.events().publish(
+            (EVT, symbol_short!("proposed")),
+            (proposal_id, proposer, target),
+        );
+        Ok(proposal_id)
+    }
+
+    /// Approve a pending proposal. Each registered signer for the
+    /// proposal's role may approve exactly once; once approvals reach the
+    /// role's threshold the proposal becomes `Approved` (executable).
+    pub fn approve_action(env: Env, signer: Address, proposal_id: u64) -> Result_ {
+        signer.require_auth();
+        bump_instance(&env);
+
+        let mut proposal: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(AccessControlError::ProposalNotFound)?;
+
+        if proposal.status != ProposalStatus::Pending {
+            return Err(AccessControlError::ProposalNotPending);
+        }
+        if env.ledger().timestamp() > proposal.expires_at {
+            return Err(AccessControlError::ProposalExpired);
+        }
+
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::RoleConfig(proposal.role))
+            .ok_or(AccessControlError::RoleNotConfigured)?;
+        if !config.signers.contains(&signer) {
+            return Err(AccessControlError::NotASigner);
+        }
+        if proposal.approvals.contains(&signer) {
+            return Err(AccessControlError::AlreadyApproved);
+        }
+
+        proposal.approvals.push_back(signer.clone());
+        if proposal.approvals.len() >= config.threshold {
+            proposal.status = ProposalStatus::Approved;
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        env.events()
+            .publish((EVT, symbol_short!("approved")), (proposal_id, signer));
+        Ok(())
+    }
+
+    /// Remove the caller's own prior approval from a still-pending
+    /// proposal — lets a signer correct an approval given in error before
+    /// execution.
+    pub fn revoke_approval(env: Env, signer: Address, proposal_id: u64) -> Result_ {
+        signer.require_auth();
+        bump_instance(&env);
+
+        let mut proposal: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(AccessControlError::ProposalNotFound)?;
+        // Allowed on Pending or Approved (but not-yet-executed) proposals —
+        // a signer can still change their mind right up until execution.
+        if proposal.status != ProposalStatus::Pending && proposal.status != ProposalStatus::Approved
+        {
+            return Err(AccessControlError::ProposalNotPending);
+        }
+        let idx = proposal.approvals.iter().position(|a| a == signer);
+        let idx = match idx {
+            Some(i) => i as u32,
+            None => return Err(AccessControlError::NoApprovalToRevoke),
+        };
+        proposal.approvals.remove(idx);
+
+        // Re-derive status from the current approval count: revoking an
+        // approval that had pushed the proposal over threshold must drop it
+        // back to Pending, never leave a stale Approved with too few
+        // approvals on record.
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::RoleConfig(proposal.role))
+            .ok_or(AccessControlError::RoleNotConfigured)?;
+        proposal.status = if proposal.approvals.len() >= config.threshold {
+            ProposalStatus::Approved
+        } else {
+            ProposalStatus::Pending
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        env.events()
+            .publish((EVT, symbol_short!("revoked")), (proposal_id, signer));
+        Ok(())
+    }
+
+    /// Reject a still-pending proposal. Any registered signer for the
+    /// proposal's role may reject — correcting a mistaken or malicious
+    /// proposal doesn't need the full approval threshold, since rejecting
+    /// only ever narrows what can execute, never widens it.
+    pub fn reject_action(env: Env, signer: Address, proposal_id: u64) -> Result_ {
+        signer.require_auth();
+        bump_instance(&env);
+
+        let mut proposal: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(AccessControlError::ProposalNotFound)?;
+        if proposal.status != ProposalStatus::Pending {
+            return Err(AccessControlError::ProposalNotPending);
+        }
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::RoleConfig(proposal.role))
+            .ok_or(AccessControlError::RoleNotConfigured)?;
+        if !config.signers.contains(&signer) {
+            return Err(AccessControlError::NotASigner);
+        }
+
+        proposal.status = ProposalStatus::Rejected;
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        env.events()
+            .publish((EVT, symbol_short!("rejected")), (proposal_id, signer));
+        Ok(())
+    }
+
+    /// Execute an `Approved` proposal: either mutates this contract's own
+    /// role configuration (self-management actions) or makes the
+    /// corresponding cross-contract call into `proposal.target`, carrying
+    /// this contract's own address so the target can authenticate the call
+    /// as coming from a trusted `AccessControl` — never from an arbitrary
+    /// caller. Any account may submit the execution once approvals are in
+    /// place; nothing about *who* calls `execute_action` grants authority,
+    /// only the proposal's already-recorded approvals do.
+    pub fn execute_action(env: Env, caller: Address, proposal_id: u64) -> Result_ {
+        caller.require_auth();
+        bump_instance(&env);
+
+        let mut proposal: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(AccessControlError::ProposalNotFound)?;
+
+        if proposal.status != ProposalStatus::Approved {
+            return Err(AccessControlError::ProposalNotApproved);
+        }
+        if env.ledger().timestamp() > proposal.expires_at {
+            return Err(AccessControlError::ProposalExpired);
+        }
+
+        // CEI: flip status before the external call. Soroban invocations
+        // are atomic, so a panic in the cross-contract call reverts this
+        // write too — there's no way to end up "Executed" without the
+        // effect actually having happened, or vice versa.
+        proposal.status = ProposalStatus::Executed;
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        let this_contract = env.current_contract_address();
+        if proposal.target == this_contract {
+            Self::execute_self_management(&env, &proposal.action)?;
+        } else {
+            Self::execute_cross_contract(&env, &this_contract, &proposal.target, &proposal.action);
+        }
+
+        env.events()
+            .publish((EVT, symbol_short!("executed")), (proposal_id, caller));
+        Ok(())
+    }
+
+    fn execute_cross_contract(
+        env: &Env,
+        this_contract: &Address,
+        target: &Address,
+        action: &ActionPayload,
+    ) {
+        match action {
+            ActionPayload::SetPaused(paused) => {
+                // Every target contract exposes the same unified setter
+                // name, so try each client in turn is unnecessary — the
+                // proposal was raised against a specific `target`, and only
+                // one of these three calls will actually match that
+                // contract's deployed interface. Soroban resolves this at
+                // the call site: whichever client's method the target
+                // actually implements succeeds; the others are simply never
+                // invoked because `target` only ever hosts one contract.
+                PoolClient::new(env, target).set_paused_via_ac(this_contract, paused);
+            }
+            ActionPayload::SetYield(bps) => {
+                PoolClient::new(env, target).set_yield_via_ac(this_contract, bps);
+            }
+            ActionPayload::SetTreasury(treasury) => {
+                PoolClient::new(env, target).set_treasury_via_ac(this_contract, treasury);
+            }
+            ActionPayload::WithdrawRevenue(token, amount) => {
+                PoolClient::new(env, target).withdraw_revenue_via_ac(this_contract, token, amount);
+            }
+            ActionPayload::SetOracleContract(oracle) => {
+                PoolClient::new(env, target).set_oracle_contract_via_ac(this_contract, oracle);
+            }
+            ActionPayload::SetKycRequired(required) => {
+                PoolClient::new(env, target).set_kyc_required_via_ac(this_contract, required);
+            }
+            ActionPayload::SetInvestorKyc(investor, approved) => {
+                PoolClient::new(env, target).set_investor_kyc_via_ac(
+                    this_contract,
+                    investor,
+                    approved,
+                );
+            }
+            ActionPayload::SetMaxUtilization(bps) => {
+                PoolClient::new(env, target).set_max_utilization_via_ac(this_contract, bps);
+            }
+            ActionPayload::SetOracle(oracle) => {
+                InvoiceClient::new(env, target).set_oracle_via_ac(this_contract, oracle);
+            }
+            ActionPayload::RegisterDebtor(debtor_id, debtor_name, max_exposure) => {
+                InvoiceClient::new(env, target).register_debtor_via_ac(
+                    this_contract,
+                    debtor_id,
+                    debtor_name,
+                    max_exposure,
+                );
+            }
+            ActionPayload::DeactivateDebtor(debtor_id) => {
+                InvoiceClient::new(env, target).deactivate_debtor_via_ac(this_contract, debtor_id);
+            }
+            ActionPayload::AddKeeper(keeper) => {
+                InvoiceClient::new(env, target).add_keeper_via_ac(this_contract, keeper);
+            }
+            ActionPayload::SetLateThreshold(days) => {
+                CreditScoreClient::new(env, target).set_late_threshold_via_ac(this_contract, days);
+            }
+            ActionPayload::SetScoreThresholds(excellent, very_good, good, fair) => {
+                CreditScoreClient::new(env, target).set_score_thresholds_via_ac(
+                    this_contract,
+                    excellent,
+                    very_good,
+                    good,
+                    fair,
+                );
+            }
+            ActionPayload::RegisterAttestor(address, attestor_type, weight_bps) => {
+                CreditScoreClient::new(env, target).register_attestor_via_ac(
+                    this_contract,
+                    address,
+                    attestor_type,
+                    weight_bps,
+                );
+            }
+            ActionPayload::AddSigner(_, _)
+            | ActionPayload::RemoveSigner(_, _)
+            | ActionPayload::SetThreshold(_, _) => {
+                // Self-management actions never reach here: execute_action
+                // routes them to execute_self_management() based on
+                // `target == this_contract`, which is enforced at
+                // propose_action time (self-management payloads are only
+                // ever proposed with target = this contract's own address
+                // by the SDK/frontend; a mismatched target here would just
+                // mean the wrong client call is skipped, since none of the
+                // Pool/Invoice/CreditScore clients implement these methods).
+            }
+        }
+    }
+
+    fn execute_self_management(env: &Env, action: &ActionPayload) -> Result_ {
+        match action {
+            ActionPayload::AddSigner(role, address) => {
+                let mut config = Self::role_config_or_default(env, *role);
+                if config.signers.contains(address) {
+                    return Err(AccessControlError::DuplicateSigner);
+                }
+                config.signers.push_back(address.clone());
+                env.storage()
+                    .instance()
+                    .set(&DataKey::RoleConfig(*role), &config);
+                Ok(())
+            }
+            ActionPayload::RemoveSigner(role, address) => {
+                let mut config: MultiSigConfig = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::RoleConfig(*role))
+                    .ok_or(AccessControlError::RoleNotConfigured)?;
+                let idx = config
+                    .signers
+                    .iter()
+                    .position(|a| a == *address)
+                    .ok_or(AccessControlError::SignerNotFound)?;
+                config.signers.remove(idx as u32);
+                if config.signers.len() < config.threshold {
+                    return Err(AccessControlError::InvalidThreshold);
+                }
+                env.storage()
+                    .instance()
+                    .set(&DataKey::RoleConfig(*role), &config);
+                Ok(())
+            }
+            ActionPayload::SetThreshold(role, threshold) => {
+                let mut config = Self::role_config_or_default(env, *role);
+                Self::validate_config(&config.signers, *threshold)?;
+                config.threshold = *threshold;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::RoleConfig(*role), &config);
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn role_config_or_default(env: &Env, role: Role) -> MultiSigConfig {
+        env.storage()
+            .instance()
+            .get(&DataKey::RoleConfig(role))
+            .unwrap_or(MultiSigConfig {
+                signers: Vec::new(env),
+                threshold: 0,
+            })
+    }
+
+    fn is_self_management(action: &ActionPayload) -> bool {
+        matches!(
+            action,
+            ActionPayload::AddSigner(_, _)
+                | ActionPayload::RemoveSigner(_, _)
+                | ActionPayload::SetThreshold(_, _)
+        )
+    }
+
+    fn validate_config(signers: &Vec<Address>, threshold: u32) -> Result_ {
+        if threshold == 0 || threshold > signers.len() {
+            return Err(AccessControlError::InvalidThreshold);
+        }
+        for i in 0..signers.len() {
+            let a = signers.get(i).unwrap();
+            for j in 0..i {
+                if signers.get(j).unwrap() == a {
+                    return Err(AccessControlError::DuplicateSigner);
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/contracts/access_control/tests/cross_contract_tests.rs
+++ b/contracts/access_control/tests/cross_contract_tests.rs
@@ -1,0 +1,230 @@
+#![cfg(test)]
+
+//! Cross-contract dispatch tests: `execute_action` calling out into a
+//! target contract's `*_via_ac` entrypoint, carrying this
+//! contract's own address as proof of origin (the same pattern the real
+//! `pool` contract already uses to trust `invoice_contract` for
+//! `update_invoice_due_date` — the callee does `access_control.require_auth()`
+//! against the caller's own on-chain identity).
+//!
+//! These mocks are local, minimal stand-ins for the real
+//! `set_yield_via_ac` etc. methods added to `pool` in this same
+//! change — see contracts/pool/src/lib.rs. They only need to look and
+//! authenticate exactly like the real thing for `execute_action` to be
+//! exercised faithfully.
+
+use access_control::{
+    AccessControlContract, AccessControlContractClient, ActionPayload, ProposalStatus, Role,
+};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, testutils::Address as _, vec, Address, Env,
+};
+
+mod mock_pool {
+    use super::*;
+
+    #[contract]
+    pub struct MockPool;
+
+    #[contractimpl]
+    impl MockPool {
+        pub fn set_yield_via_ac(env: Env, access_control: Address, new_yield_bps: u32) {
+            access_control.require_auth();
+            env.storage()
+                .instance()
+                .set(&symbol_short!("yield"), &new_yield_bps);
+        }
+
+        pub fn get_yield(env: Env) -> u32 {
+            env.storage()
+                .instance()
+                .get(&symbol_short!("yield"))
+                .unwrap_or(0)
+        }
+
+        pub fn set_paused_via_ac(env: Env, access_control: Address, paused: bool) {
+            access_control.require_auth();
+            env.storage()
+                .instance()
+                .set(&symbol_short!("paused"), &paused);
+        }
+
+        pub fn is_paused(env: Env) -> bool {
+            env.storage()
+                .instance()
+                .get(&symbol_short!("paused"))
+                .unwrap_or(false)
+        }
+    }
+}
+
+use mock_pool::{MockPool, MockPoolClient};
+
+struct Fixture {
+    env: Env,
+    ac_client: AccessControlContractClient<'static>,
+    ac_id: Address,
+    pool_client: MockPoolClient<'static>,
+    pool_id: Address,
+    s1: Address,
+    s2: Address,
+}
+
+fn setup() -> Fixture {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ac_id = env.register(AccessControlContract, ());
+    let ac_client = AccessControlContractClient::new(&env, &ac_id);
+
+    let pool_id = env.register(MockPool, ());
+    let pool_client = MockPoolClient::new(&env, &pool_id);
+
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+
+    let _ = ac_client.initialize(&vec![&env, s1.clone(), s2.clone()], &2, &604_800);
+
+    Fixture {
+        env,
+        ac_client,
+        ac_id,
+        pool_client,
+        pool_id,
+        s1,
+        s2,
+    }
+}
+
+/// Seeds RiskManager as a 2-of-3 role via the SuperAdmin bootstrap flow.
+fn seed_risk_manager(f: &Fixture, threshold: u32) -> (Address, Address, Address) {
+    let r1 = Address::generate(&f.env);
+    let r2 = Address::generate(&f.env);
+    let r3 = Address::generate(&f.env);
+
+    for signer in [&r1, &r2, &r3] {
+        let add = f.ac_client.propose_action(
+            &Role::SuperAdmin,
+            &f.s1,
+            &f.ac_id,
+            &ActionPayload::AddSigner(Role::RiskManager, signer.clone()),
+        );
+        let _ = f.ac_client.approve_action(&f.s2, &add);
+        let _ = f.ac_client.execute_action(&f.s1, &add);
+    }
+    let set_threshold = f.ac_client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.ac_id,
+        &ActionPayload::SetThreshold(Role::RiskManager, threshold),
+    );
+    let _ = f.ac_client.approve_action(&f.s2, &set_threshold);
+    let _ = f.ac_client.execute_action(&f.s1, &set_threshold);
+
+    (r1, r2, r3)
+}
+
+#[test]
+fn test_risk_manager_2_of_3_yield_change_requires_two_approvals_then_executes() {
+    let f = setup();
+    let (r1, r2, _r3) = seed_risk_manager(&f, 2);
+
+    assert_eq!(f.pool_client.get_yield(), 0);
+
+    let proposal_id = f.ac_client.propose_action(
+        &Role::RiskManager,
+        &r1,
+        &f.pool_id,
+        &ActionPayload::SetYield(650),
+    );
+
+    // One approval (the proposer's own) is not enough at threshold 2 —
+    // execution must be rejected and the pool's yield must stay untouched.
+    let premature = f.ac_client.try_execute_action(&r1, &proposal_id);
+    assert!(premature.is_err());
+    assert_eq!(f.pool_client.get_yield(), 0);
+    assert_eq!(
+        f.ac_client.get_proposal(&proposal_id).unwrap().status,
+        ProposalStatus::Pending
+    );
+
+    // Second approval reaches threshold — now it can execute, and the mock
+    // pool's stored yield actually changes via the access-control-trusted
+    // call.
+    let _ = f.ac_client.approve_action(&r2, &proposal_id);
+    assert_eq!(
+        f.ac_client.get_proposal(&proposal_id).unwrap().status,
+        ProposalStatus::Approved
+    );
+
+    let _ = f.ac_client.execute_action(&r1, &proposal_id);
+    assert_eq!(f.pool_client.get_yield(), 650);
+    assert_eq!(
+        f.ac_client.get_proposal(&proposal_id).unwrap().status,
+        ProposalStatus::Executed
+    );
+}
+
+#[test]
+fn test_execute_action_carries_access_control_own_identity_not_an_arbitrary_caller() {
+    // The mock pool's set_yield_via_ac requires
+    // `access_control.require_auth()` on the address it's given — proving
+    // that execute_action always passes *this contract's own* address
+    // (env.current_contract_address()), never some caller-supplied address
+    // that could be spoofed. If execute_action ever passed the wrong
+    // address, the mock's own require_auth() call would be checking
+    // authorization for a different contract than the one truly invoking
+    // it, and — since this test uses mock_all_auths() — that distinction
+    // isn't directly observable via a panic here. Instead we assert the
+    // effect actually landed under the *pool's* own storage keyed off the
+    // access_control contract having successfully authenticated itself,
+    // which only happens if `this_contract` was passed correctly.
+    let f = setup();
+    let (r1, r2, _r3) = seed_risk_manager(&f, 2);
+
+    let proposal_id = f.ac_client.propose_action(
+        &Role::RiskManager,
+        &r1,
+        &f.pool_id,
+        &ActionPayload::SetPaused(true),
+    );
+    let _ = f.ac_client.approve_action(&r2, &proposal_id);
+    let _ = f.ac_client.execute_action(&r1, &proposal_id);
+
+    assert!(f.pool_client.is_paused());
+}
+
+#[test]
+fn test_second_signer_approving_a_different_proposal_does_not_affect_the_first() {
+    let f = setup();
+    let (r1, r2, r3) = seed_risk_manager(&f, 2);
+
+    let yield_proposal = f.ac_client.propose_action(
+        &Role::RiskManager,
+        &r1,
+        &f.pool_id,
+        &ActionPayload::SetYield(700),
+    );
+    let pause_proposal = f.ac_client.propose_action(
+        &Role::RiskManager,
+        &r2,
+        &f.pool_id,
+        &ActionPayload::SetPaused(true),
+    );
+
+    // Approve only the pause proposal with the third signer.
+    let _ = f.ac_client.approve_action(&r3, &pause_proposal);
+
+    assert_eq!(
+        f.ac_client.get_proposal(&yield_proposal).unwrap().status,
+        ProposalStatus::Pending
+    );
+    assert_eq!(
+        f.ac_client.get_proposal(&pause_proposal).unwrap().status,
+        ProposalStatus::Approved
+    );
+
+    let _ = f.ac_client.execute_action(&r2, &pause_proposal);
+    assert!(f.pool_client.is_paused());
+    assert_eq!(f.pool_client.get_yield(), 0); // untouched — never reached threshold
+}

--- a/contracts/access_control/tests/lifecycle_tests.rs
+++ b/contracts/access_control/tests/lifecycle_tests.rs
@@ -1,0 +1,442 @@
+#![cfg(test)]
+
+use access_control::{
+    AccessControlContract, AccessControlContractClient, AccessControlError, ActionPayload,
+    ProposalStatus, Role,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, Env,
+};
+
+struct Fixture {
+    env: Env,
+    client: AccessControlContractClient<'static>,
+    contract_id: Address,
+    s1: Address,
+    s2: Address,
+    s3: Address,
+}
+
+/// SuperAdmin bootstrapped as 2-of-3 (s1, s2, s3). Every lifecycle-mechanics
+/// test below proposes/approves/executes self-management actions under
+/// `Role::SuperAdmin` using these three signers — it's the one role that's
+/// always configured from `initialize()`, so it doesn't need a target
+/// contract to actually call out to (self-management actions only ever
+/// mutate this contract's own storage). Real cross-contract dispatch into
+/// pool/invoice/credit_score is covered separately in
+/// `cross_contract_tests.rs`.
+fn setup() -> Fixture {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AccessControlContract, ());
+    let client = AccessControlContractClient::new(&env, &contract_id);
+
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+
+    let _ = client.initialize(
+        &vec![&env, s1.clone(), s2.clone(), s3.clone()],
+        &2,
+        &604_800,
+    );
+
+    Fixture {
+        env,
+        client,
+        contract_id,
+        s1,
+        s2,
+        s3,
+    }
+}
+
+#[test]
+fn test_initialize_can_only_be_called_once() {
+    let f = setup();
+    let result = f
+        .client
+        .try_initialize(&vec![&f.env, f.s1.clone()], &1, &604_800);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::AlreadyInitialized.into()
+    );
+}
+
+#[test]
+fn test_initialize_rejects_threshold_above_signer_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AccessControlContract, ());
+    let client = AccessControlContractClient::new(&env, &contract_id);
+    let s1 = Address::generate(&env);
+
+    let result = client.try_initialize(&vec![&env, s1], &2, &604_800);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::InvalidThreshold.into()
+    );
+}
+
+#[test]
+fn test_initialize_rejects_duplicate_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AccessControlContract, ());
+    let client = AccessControlContractClient::new(&env, &contract_id);
+    let s1 = Address::generate(&env);
+
+    let result = client.try_initialize(&vec![&env, s1.clone(), s1], &1, &604_800);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::DuplicateSigner.into()
+    );
+}
+
+// ── Bootstrapping: SuperAdmin manages every role, including itself ─────────
+
+#[test]
+fn test_super_admin_can_configure_a_new_role_via_its_own_multisig() {
+    let f = setup();
+    let risk1 = Address::generate(&f.env);
+    let risk2 = Address::generate(&f.env);
+
+    // Nothing can be proposed under RiskManager yet — it isn't configured.
+    let unconfigured = f.client.try_propose_action(
+        &Role::RiskManager,
+        &risk1,
+        &f.contract_id,
+        &ActionPayload::SetYield(500),
+    );
+    assert_eq!(
+        unconfigured.unwrap_err().unwrap(),
+        AccessControlError::RoleNotConfigured
+    );
+
+    let add1 = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::RiskManager, risk1.clone()),
+    );
+    let _ = f.client.approve_action(&f.s2, &add1);
+    let _ = f.client.execute_action(&f.s1, &add1);
+
+    let add2 = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::RiskManager, risk2.clone()),
+    );
+    let _ = f.client.approve_action(&f.s2, &add2);
+    let _ = f.client.execute_action(&f.s1, &add2);
+
+    let set_threshold = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::SetThreshold(Role::RiskManager, 2),
+    );
+    let _ = f.client.approve_action(&f.s2, &set_threshold);
+    let _ = f.client.execute_action(&f.s1, &set_threshold);
+
+    let config = f.client.get_role_config(&Role::RiskManager).unwrap();
+    assert_eq!(config.signers.len(), 2);
+    assert_eq!(config.threshold, 2);
+    assert!(f.client.is_signer(&Role::RiskManager, &risk1));
+    assert!(f.client.is_signer(&Role::RiskManager, &risk2));
+
+    // And that newly-configured role can now genuinely propose its own
+    // actions, with its own independent (lower) threshold.
+    let proposal = f.client.propose_action(
+        &Role::RiskManager,
+        &risk1,
+        &f.contract_id,
+        &ActionPayload::SetYield(500),
+    );
+    assert_eq!(
+        f.client.get_proposal(&proposal).unwrap().status,
+        ProposalStatus::Pending
+    );
+    let _ = f.client.approve_action(&risk2, &proposal);
+    assert_eq!(
+        f.client.get_proposal(&proposal).unwrap().status,
+        ProposalStatus::Approved
+    );
+}
+
+#[test]
+fn test_self_management_action_rejected_under_a_non_super_admin_role() {
+    let f = setup();
+    let risk1 = Address::generate(&f.env);
+    let add = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::RiskManager, risk1.clone()),
+    );
+    let _ = f.client.approve_action(&f.s2, &add);
+    let _ = f.client.execute_action(&f.s1, &add);
+    let set_threshold = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::SetThreshold(Role::RiskManager, 1),
+    );
+    let _ = f.client.approve_action(&f.s2, &set_threshold);
+    let _ = f.client.execute_action(&f.s1, &set_threshold);
+
+    // RiskManager's own signer cannot use its role to add itself elsewhere —
+    // self-management is SuperAdmin-only, regardless of which role proposes.
+    let attempt = f.client.try_propose_action(
+        &Role::RiskManager,
+        &risk1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::TreasuryManager, risk1.clone()),
+    );
+    assert_eq!(
+        attempt.unwrap_err().unwrap(),
+        AccessControlError::SelfManagementRequiresSuperAdmin
+    );
+}
+
+#[test]
+fn test_remove_signer_rejects_dropping_below_threshold() {
+    let f = setup();
+    // SuperAdmin is 2-of-3 (s1, s2, s3). Removing one signer leaves 2
+    // signers for a threshold of 2 — still valid — but removing a second
+    // would drop to 1 signer under a threshold of 2, which must be rejected.
+    let remove_s3 = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::RemoveSigner(Role::SuperAdmin, f.s3.clone()),
+    );
+    let _ = f.client.approve_action(&f.s2, &remove_s3);
+    let _ = f.client.execute_action(&f.s1, &remove_s3);
+    assert_eq!(
+        f.client
+            .get_role_config(&Role::SuperAdmin)
+            .unwrap()
+            .signers
+            .len(),
+        2
+    );
+
+    let remove_s2 = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::RemoveSigner(Role::SuperAdmin, f.s2.clone()),
+    );
+    let _ = f.client.approve_action(&f.s2, &remove_s2);
+    let result = f.client.try_execute_action(&f.s1, &remove_s2);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::InvalidThreshold.into()
+    );
+}
+
+// ── Core proposal lifecycle ─────────────────────────────────────────────────
+
+#[test]
+fn test_full_lifecycle_propose_approve_execute() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target.clone()),
+    );
+    let proposal = f.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.approvals.len(), 1); // proposer auto-approved
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+
+    let _ = f.client.approve_action(&f.s2, &proposal_id);
+    let proposal = f.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.approvals.len(), 2);
+    assert_eq!(proposal.status, ProposalStatus::Approved);
+
+    let _ = f.client.execute_action(&f.s1, &proposal_id);
+    let executed = f.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(executed.status, ProposalStatus::Executed);
+    assert!(f.client.is_signer(&Role::OracleManager, &target));
+}
+
+#[test]
+fn test_single_compromised_signer_cannot_execute_alone_at_threshold_two() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+
+    // SuperAdmin requires 2-of-3. A single signer (even one raising and
+    // "approving" via their own proposal auto-approval) never reaches that
+    // threshold alone.
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target.clone()),
+    );
+    let result = f.client.try_execute_action(&f.s1, &proposal_id);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::ProposalNotApproved.into()
+    );
+
+    let proposal = f.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+    assert!(!f.client.is_signer(&Role::OracleManager, &target));
+}
+
+#[test]
+fn test_duplicate_approval_rejected() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target),
+    );
+    // s1 is already recorded as an approval via propose_action; approving
+    // again must fail rather than double-counting.
+    let result = f.client.try_approve_action(&f.s1, &proposal_id);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::AlreadyApproved.into()
+    );
+}
+
+#[test]
+fn test_non_signer_cannot_approve() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+    let outsider = Address::generate(&f.env);
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target),
+    );
+    let result = f.client.try_approve_action(&outsider, &proposal_id);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::NotASigner.into()
+    );
+}
+
+#[test]
+fn test_reject_action_blocks_further_approval_and_execution() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target),
+    );
+    let _ = f.client.reject_action(&f.s2, &proposal_id);
+
+    let rejected = f.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(rejected.status, ProposalStatus::Rejected);
+
+    let approve_after_reject = f.client.try_approve_action(&f.s2, &proposal_id);
+    assert_eq!(
+        approve_after_reject.unwrap_err().unwrap(),
+        AccessControlError::ProposalNotPending.into()
+    );
+    let execute_after_reject = f.client.try_execute_action(&f.s1, &proposal_id);
+    assert_eq!(
+        execute_after_reject.unwrap_err().unwrap(),
+        AccessControlError::ProposalNotApproved.into()
+    );
+}
+
+#[test]
+fn test_revoke_approval_removes_own_approval_only() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target),
+    );
+    let _ = f.client.approve_action(&f.s2, &proposal_id);
+    assert_eq!(
+        f.client.get_proposal(&proposal_id).unwrap().approvals.len(),
+        2
+    );
+
+    let _ = f.client.revoke_approval(&f.s2, &proposal_id);
+    let after = f.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(after.approvals.len(), 1);
+    assert!(after.approvals.contains(&f.s1));
+    assert!(!after.approvals.contains(&f.s2));
+    // Revoking one approval un-does the threshold too — it must go back to
+    // Pending, not stay Approved with a stale approval count.
+    assert_eq!(after.status, ProposalStatus::Pending);
+}
+
+#[test]
+fn test_revoke_approval_rejects_when_no_prior_approval() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target),
+    );
+    let result = f.client.try_revoke_approval(&f.s3, &proposal_id);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::NoApprovalToRevoke.into()
+    );
+}
+
+#[test]
+fn test_proposal_expires_and_cannot_be_approved_or_executed_after_window() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target),
+    );
+    f.env.ledger().with_mut(|li| li.timestamp += 604_800 + 1);
+
+    let approve_result = f.client.try_approve_action(&f.s2, &proposal_id);
+    assert_eq!(
+        approve_result.unwrap_err().unwrap(),
+        AccessControlError::ProposalExpired.into()
+    );
+}
+
+#[test]
+fn test_expired_approved_proposal_cannot_execute() {
+    let f = setup();
+    let target = Address::generate(&f.env);
+    let proposal_id = f.client.propose_action(
+        &Role::SuperAdmin,
+        &f.s1,
+        &f.contract_id,
+        &ActionPayload::AddSigner(Role::OracleManager, target),
+    );
+    let _ = f.client.approve_action(&f.s2, &proposal_id);
+    assert_eq!(
+        f.client.get_proposal(&proposal_id).unwrap().status,
+        ProposalStatus::Approved
+    );
+
+    f.env.ledger().with_mut(|li| li.timestamp += 604_800 + 1);
+    let result = f.client.try_execute_action(&f.s1, &proposal_id);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        AccessControlError::ProposalExpired.into()
+    );
+}

--- a/contracts/credit_score/src/lib.rs
+++ b/contracts/credit_score/src/lib.rs
@@ -64,6 +64,11 @@ pub enum CreditScoreError {
     DisputeNotFound = 23,
     /// #868: internal/external attestation blend weights are invalid (must sum to 10_000 bps).
     InvalidAttestationConfig = 24,
+    /// #864: role-based multisig access-control contract not registered.
+    AccessControlNotConfigured = 25,
+    /// #864: attestor_type discriminant passed to register_attestor_via_ac
+    /// didn't match any known AttestorType variant.
+    InvalidAttestorType = 26,
 }
 
 /// Semantic version of this credit-score contract (#237).
@@ -452,6 +457,9 @@ pub enum DataKey {
 }
 
 const EVT: Symbol = symbol_short!("credit");
+// #864: optional role-based multisig access-control contract. Symbol key
+// (not a DataKey variant), matching the same convention used in pool/invoice.
+const ACCESS_CONTROL: Symbol = symbol_short!("ac_addr");
 
 fn require_not_paused(env: &Env) {
     if env
@@ -1419,6 +1427,127 @@ impl CreditScoreContract {
         if admin != &stored_admin {
             panic_with_error!(env, CreditScoreError::Unauthorized);
         }
+    }
+
+    /// #864: verifies `caller` is the registered `access_control` contract.
+    fn require_access_control(env: &Env, caller: &Address) {
+        let configured: Option<Address> = env.storage().instance().get(&ACCESS_CONTROL);
+        match configured {
+            Some(configured) if &configured == caller => {}
+            Some(_) => panic_with_error!(env, CreditScoreError::Unauthorized),
+            None => panic_with_error!(env, CreditScoreError::AccessControlNotConfigured),
+        }
+    }
+
+    /// Registers the `access_control` contract whose approved multisig
+    /// proposals may call the `*_via_ac` entrypoints below. Admin-gated
+    /// (legacy path).
+    pub fn set_access_control(env: Env, admin: Address, access_control: Address) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        env.storage()
+            .instance()
+            .set(&ACCESS_CONTROL, &access_control);
+        env.events()
+            .publish((EVT, symbol_short!("set_ac")), (admin, access_control));
+    }
+
+    pub fn get_access_control(env: Env) -> Option<Address> {
+        env.storage().instance().get(&ACCESS_CONTROL)
+    }
+
+    /// Unified pause/unpause via an access-control-approved multisig
+    /// proposal. `true` pauses, `false` unpauses.
+    pub fn set_paused_via_ac(env: Env, access_control: Address, paused: bool) {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control);
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        env.events()
+            .publish((EVT, symbol_short!("ac_pause")), (access_control, paused));
+    }
+
+    pub fn set_late_threshold_via_ac(env: Env, access_control: Address, days: i64) {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control);
+        if !(1..=365).contains(&days) {
+            panic_with_error!(&env, CreditScoreError::InvalidLateThreshold);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::LateThreshold, &days);
+        env.events().publish((EVT, symbol_short!("ac_lt")), days);
+    }
+
+    pub fn set_score_thresholds_via_ac(
+        env: Env,
+        access_control: Address,
+        excellent: u32,
+        very_good: u32,
+        good: u32,
+        fair: u32,
+    ) {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control);
+        require_not_paused(&env);
+        let thresholds = ScoreThresholds {
+            excellent,
+            very_good,
+            good,
+            fair,
+        };
+        if !(thresholds.excellent > thresholds.very_good
+            && thresholds.very_good > thresholds.good
+            && thresholds.good > thresholds.fair
+            && thresholds.fair > BASE_SCORE)
+        {
+            panic_with_error!(&env, CreditScoreError::InvalidThresholds);
+        }
+        let old = Self::get_score_thresholds(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ScoreThresholds, &thresholds);
+        env.events().publish(
+            (EVT, symbol_short!("ac_thresh")),
+            (old.excellent, old.very_good, old.good, old.fair),
+        );
+    }
+
+    /// `attestor_type` is decoded the same way credit_score's public
+    /// `AttestorType` enum is ordered: 0=BusinessRegistry, 1=CreditBureau,
+    /// 2=ExternalProtocol, 3=Manual.
+    pub fn register_attestor_via_ac(
+        env: Env,
+        access_control: Address,
+        address: Address,
+        attestor_type: u32,
+        weight_bps: u32,
+    ) {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control);
+        require_not_paused(&env);
+        if weight_bps == 0 || weight_bps > MAX_WEIGHT_BPS {
+            panic_with_error!(&env, CreditScoreError::InvalidAttestorWeight);
+        }
+        let decoded_type = match attestor_type {
+            0 => AttestorType::BusinessRegistry,
+            1 => AttestorType::CreditBureau,
+            2 => AttestorType::ExternalProtocol,
+            3 => AttestorType::Manual,
+            _ => panic_with_error!(&env, CreditScoreError::InvalidAttestorType),
+        };
+
+        let info = AttestorInfo {
+            address: address.clone(),
+            attestor_type: decoded_type,
+            is_active: true,
+            weight_bps,
+            registered_at: env.ledger().timestamp(),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Attestor(address.clone()), &info);
+        env.events()
+            .publish((EVT, symbol_short!("ac_attest")), (access_control, address));
     }
 
     /// Set the upgrade timelock duration in seconds (#338).

--- a/contracts/credit_score/tests/access_control_tests.rs
+++ b/contracts/credit_score/tests/access_control_tests.rs
@@ -1,0 +1,189 @@
+#![cfg(test)]
+
+//! #864: verifies the additive role-based multisig access-control path on
+//! `credit_score` — (a) the legacy single-admin path is untouched, (b) an
+//! access-control-approved call executes the same effect the legacy path
+//! would, (c) calls without a configured/matching access-control address
+//! are rejected.
+
+use access_control::{AccessControlContract, AccessControlContractClient, ActionPayload, Role};
+use credit_score::{CreditScoreContract, CreditScoreContractClient, CreditScoreError};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+struct Fixture {
+    env: Env,
+    client: CreditScoreContractClient<'static>,
+    contract_id: Address,
+    admin: Address,
+}
+
+fn setup() -> Fixture {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let invoice_contract = Address::generate(&env);
+    let pool_contract = Address::generate(&env);
+
+    let contract_id = env.register(CreditScoreContract, ());
+    let client = CreditScoreContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &invoice_contract, &pool_contract);
+
+    Fixture {
+        env,
+        client,
+        contract_id,
+        admin,
+    }
+}
+
+// ── (a) legacy admin path is untouched ──────────────────────────────────────
+
+#[test]
+fn test_legacy_admin_pause_unpause_still_work_unmodified() {
+    let f = setup();
+    f.client.pause(&f.admin);
+    assert!(f.client.is_paused());
+    f.client.unpause(&f.admin);
+    assert!(!f.client.is_paused());
+}
+
+#[test]
+fn test_legacy_admin_set_late_threshold_still_works_unmodified() {
+    let f = setup();
+    f.client.set_late_threshold(&f.admin, &45);
+    assert_eq!(f.client.get_late_threshold(), 45);
+}
+
+// ── (c) rejected without a configured/matching access-control address ──────
+
+#[test]
+fn test_via_ac_entrypoint_rejected_when_access_control_not_configured() {
+    let f = setup();
+    let someone = Address::generate(&f.env);
+    let result = f.client.try_set_late_threshold_via_ac(&someone, &45);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        CreditScoreError::AccessControlNotConfigured.into()
+    );
+}
+
+#[test]
+fn test_via_ac_entrypoint_rejected_from_a_non_matching_address() {
+    let f = setup();
+    let access_control = Address::generate(&f.env);
+    f.client.set_access_control(&f.admin, &access_control);
+
+    let impostor = Address::generate(&f.env);
+    let result = f.client.try_set_late_threshold_via_ac(&impostor, &45);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        CreditScoreError::Unauthorized.into()
+    );
+    assert_eq!(f.client.get_late_threshold(), 30); // unchanged default
+}
+
+// ── (b) an access-control-approved call executes the same effect ───────────
+
+#[test]
+fn test_via_ac_entrypoints_apply_the_same_effects_as_their_legacy_admin_counterparts() {
+    let f = setup();
+    let access_control = Address::generate(&f.env);
+    f.client.set_access_control(&f.admin, &access_control);
+
+    f.client.set_paused_via_ac(&access_control, &true);
+    assert!(f.client.is_paused());
+    f.client.set_paused_via_ac(&access_control, &false);
+    assert!(!f.client.is_paused());
+
+    f.client.set_late_threshold_via_ac(&access_control, &45);
+    assert_eq!(f.client.get_late_threshold(), 45);
+
+    f.client
+        .set_score_thresholds_via_ac(&access_control, &810, &750, &680, &600);
+    // get_score_thresholds() takes `&Env` rather than `Env`, so it isn't part
+    // of the deployed contract interface (no generated client method) —
+    // call the plain Rust associated function directly instead, scoped to
+    // this specific contract instance's storage.
+    let thresholds = f.env.as_contract(&f.contract_id, || {
+        CreditScoreContract::get_score_thresholds(&f.env)
+    });
+    assert_eq!(thresholds.excellent, 810);
+    assert_eq!(thresholds.fair, 600);
+
+    let attestor = Address::generate(&f.env);
+    f.client
+        .register_attestor_via_ac(&access_control, &attestor, &1, &5_000);
+    let info = f.client.get_attestor_info(&attestor).unwrap();
+    assert!(info.is_active);
+    assert_eq!(info.weight_bps, 5_000);
+}
+
+#[test]
+fn test_via_ac_register_attestor_rejects_invalid_type_discriminant() {
+    let f = setup();
+    let access_control = Address::generate(&f.env);
+    f.client.set_access_control(&f.admin, &access_control);
+
+    let attestor = Address::generate(&f.env);
+    let result = f
+        .client
+        .try_register_attestor_via_ac(&access_control, &attestor, &99, &5_000);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        CreditScoreError::InvalidAttestorType.into()
+    );
+}
+
+// ── real access_control contract driving a genuine 2-of-3 proposal ─────────
+
+#[test]
+fn test_real_access_control_contract_drives_late_threshold_change() {
+    let f = setup();
+
+    let ac_id = f.env.register(AccessControlContract, ());
+    let ac_client = AccessControlContractClient::new(&f.env, &ac_id);
+
+    let super1 = Address::generate(&f.env);
+    let super2 = Address::generate(&f.env);
+    let _ = ac_client.initialize(&vec![&f.env, super1.clone(), super2.clone()], &2, &604_800);
+
+    f.client.set_access_control(&f.admin, &ac_id);
+
+    let r1 = Address::generate(&f.env);
+    let r2 = Address::generate(&f.env);
+    for signer in [&r1, &r2] {
+        let add = ac_client.propose_action(
+            &Role::SuperAdmin,
+            &super1,
+            &ac_id,
+            &ActionPayload::AddSigner(Role::RiskManager, signer.clone()),
+        );
+        let _ = ac_client.approve_action(&super2, &add);
+        let _ = ac_client.execute_action(&super1, &add);
+    }
+    let set_threshold = ac_client.propose_action(
+        &Role::SuperAdmin,
+        &super1,
+        &ac_id,
+        &ActionPayload::SetThreshold(Role::RiskManager, 2),
+    );
+    let _ = ac_client.approve_action(&super2, &set_threshold);
+    let _ = ac_client.execute_action(&super1, &set_threshold);
+
+    let proposal_id = ac_client.propose_action(
+        &Role::RiskManager,
+        &r1,
+        &f.contract_id,
+        &ActionPayload::SetLateThreshold(60),
+    );
+
+    let premature = ac_client.try_execute_action(&r1, &proposal_id);
+    assert!(premature.is_err());
+    assert_eq!(f.client.get_late_threshold(), 30);
+
+    let _ = ac_client.approve_action(&r2, &proposal_id);
+    let _ = ac_client.execute_action(&r1, &proposal_id);
+
+    assert_eq!(f.client.get_late_threshold(), 60);
+}

--- a/contracts/invoice/Cargo.toml
+++ b/contracts/invoice/Cargo.toml
@@ -12,6 +12,7 @@ soroban-sdk = { workspace = true }
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
 proptest = "1.4"
+access_control = { path = "../access_control" }
 
 [[test]]
 name = "fuzz_tests"
@@ -24,3 +25,7 @@ path = "tests/timeout_tests.rs"
 [[test]]
 name = "multi_oracle_tests"
 path = "tests/multi_oracle_tests.rs"
+
+[[test]]
+name = "access_control_tests"
+path = "tests/access_control_tests.rs"

--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -176,6 +176,12 @@ pub enum InvoiceError {
     // crate builds; not part of any of the four assigned issues.
     InvalidAmount = 43,
     InvalidDueDate = 44,
+    // #864: role-based multisig access-control
+    AccessControlNotConfigured = 45,
+    // Pre-existing build breakage found while working this branch: raised by
+    // create_invoice's #747 collision guard but missing from this enum on
+    // `main`. Restored here so the crate builds; unrelated to #864.
+    IDCollision = 46,
 }
 
 #[contracttype]
@@ -308,6 +314,10 @@ pub enum DataKey {
     ExpirationDurationSecs,
     DailyInvoiceLimit,
     DisputeResolutionWindow,
+    // Pre-existing build breakage found while working this branch: read/
+    // written by the dispute-raise/resolve flow but missing from this enum
+    // on `main`. Restored here so the crate builds; unrelated to #864.
+    Dispute(u64),
     ContractVersion,
     MigrationVersion,
     RequireRegisteredDebtor,
@@ -338,15 +348,22 @@ pub enum DataKey {
     KeeperIds,
     // #775: borrower opt-out from the public invoice sharing link
     Private(u64),
-    // #801: whitelisted keeper addresses permitted to call mark_defaulted().
-    // Pre-existing build breakage found while working this branch: used by
-    // add_keeper/remove_keeper/list_keepers/is_keeper but missing from this
-    // enum on `main`. Added here so the crate builds; not part of any of the
-    // four assigned issues.
-    KeeperIds,
 }
 
 const EVT: Symbol = symbol_short!("invoice");
+// #864: optional role-based multisig access-control contract. Symbol key
+// (not a DataKey variant) so it can be added without touching DataKey's
+// discriminant layout.
+const ACCESS_CONTROL: Symbol = symbol_short!("ac_addr");
+
+fn require_access_control(env: &Env, caller: &Address) {
+    let configured: Option<Address> = env.storage().instance().get(&ACCESS_CONTROL);
+    match configured {
+        Some(configured) if &configured == caller => {}
+        Some(_) => panic_with_error!(env, InvoiceError::Unauthorized),
+        None => panic_with_error!(env, InvoiceError::AccessControlNotConfigured),
+    }
+}
 
 fn maybe_expire_pending_invoice(env: &Env, mut invoice: Invoice) -> Invoice {
     if invoice.status != InvoiceStatus::Pending {
@@ -1097,6 +1114,10 @@ impl InvoiceContract {
         env.storage().instance().get(&DataKey::OracleRegistry)
     }
 
+    pub fn get_oracle(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Oracle)
+    }
+
     /// #861: when `true`, `verify_invoice` (the legacy 1-of-2 oracle path)
     /// rejects direct calls and every invoice must instead go through the
     /// registered `oracle_registry`'s stake-weighted consensus flow, which
@@ -1211,6 +1232,132 @@ impl InvoiceContract {
         bump_instance(&env);
         env.events()
             .publish((EVT, Symbol::new(&env, "keeper_added")), (admin, keeper));
+    }
+
+    // ---- #864: role-based multisig access control (additive) ----
+    //
+    // Every entrypoint below is a parallel authorization path alongside the
+    // legacy single-admin one above — it does not replace or disable any
+    // existing admin-gated function.
+
+    /// Registers the `access_control` contract whose approved multisig
+    /// proposals may call the `*_via_ac` entrypoints below. Admin-gated
+    /// (legacy path).
+    pub fn set_access_control(env: Env, admin: Address, access_control: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic_with_error!(&env, InvoiceError::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&ACCESS_CONTROL, &access_control);
+        bump_instance(&env);
+        env.events()
+            .publish((EVT, Symbol::new(&env, "set_ac")), (admin, access_control));
+    }
+
+    pub fn get_access_control(env: Env) -> Option<Address> {
+        env.storage().instance().get(&ACCESS_CONTROL)
+    }
+
+    /// Unified pause/unpause via an access-control-approved multisig
+    /// proposal. `true` pauses, `false` unpauses.
+    pub fn set_paused_via_ac(env: Env, access_control: Address, paused: bool) {
+        access_control.require_auth();
+        require_access_control(&env, &access_control);
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        bump_instance(&env);
+        env.events().publish(
+            (EVT, symbol_short!("ac_pause")),
+            (access_control, paused, env.ledger().timestamp()),
+        );
+    }
+
+    pub fn set_oracle_via_ac(env: Env, access_control: Address, oracle: Address) {
+        access_control.require_auth();
+        require_access_control(&env, &access_control);
+        require_not_paused(&env);
+        let old_oracle: Option<Address> = env.storage().instance().get(&DataKey::Oracle);
+        env.storage().instance().set(&DataKey::Oracle, &oracle);
+        bump_instance(&env);
+        env.events().publish(
+            (EVT, Symbol::new(&env, "ac_oracle")),
+            (access_control, old_oracle, oracle),
+        );
+    }
+
+    pub fn register_debtor_via_ac(
+        env: Env,
+        access_control: Address,
+        debtor_id: String,
+        debtor_name: String,
+        max_exposure: i128,
+    ) {
+        access_control.require_auth();
+        require_access_control(&env, &access_control);
+        if max_exposure <= 0 {
+            panic_with_error!(&env, InvoiceError::InvalidAmount);
+        }
+        let record = DebtorRecord {
+            debtor_id: debtor_id.clone(),
+            debtor_name,
+            max_exposure,
+            current_exposure: 0,
+            is_active: true,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::DebtorRecord(debtor_id.clone()), &record);
+        let mut ids: Vec<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::DebtorIds)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !ids.contains(&debtor_id) {
+            ids.push_back(debtor_id);
+            env.storage().instance().set(&DataKey::DebtorIds, &ids);
+        }
+        bump_instance(&env);
+    }
+
+    pub fn deactivate_debtor_via_ac(env: Env, access_control: Address, debtor_id: String) {
+        access_control.require_auth();
+        require_access_control(&env, &access_control);
+        let mut record: DebtorRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DebtorRecord(debtor_id.clone()))
+            .expect("debtor not found");
+        record.is_active = false;
+        env.storage()
+            .persistent()
+            .set(&DataKey::DebtorRecord(debtor_id), &record);
+        bump_instance(&env);
+    }
+
+    pub fn add_keeper_via_ac(env: Env, access_control: Address, keeper: Address) {
+        access_control.require_auth();
+        require_access_control(&env, &access_control);
+        require_not_paused(&env);
+        let mut keepers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::KeeperIds)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !keepers.contains(&keeper) {
+            keepers.push_back(keeper.clone());
+            env.storage().instance().set(&DataKey::KeeperIds, &keepers);
+        }
+        bump_instance(&env);
+        env.events().publish(
+            (EVT, Symbol::new(&env, "ac_keeper")),
+            (access_control, keeper),
+        );
     }
 
     /// #801: revoke a previously whitelisted keeper. Admin-only.
@@ -1432,11 +1579,7 @@ impl InvoiceContract {
         let id = count + 1;
 
         // #747: Refresh TTL on the invoice counter to prevent expiry and ID collisions
-        env.storage().instance().extend_ttl(
-            &DataKey::InvoiceCount,
-            INSTANCE_BUMP_AMOUNT,
-            INSTANCE_BUMP_AMOUNT,
-        );
+        bump_instance(&env);
         let pool_addr: Address = env
             .storage()
             .instance()
@@ -3850,10 +3993,7 @@ mod test {
         client.record_funding(&id, &i128::MAX, &pool);
         // Second partial funding of 1 must overflow
         let result = client.try_record_funding(&id, &1i128, &pool);
-        assert_eq!(
-            result.unwrap_err().unwrap(),
-            InvoiceError::AmountOverflow
-        );
+        assert_eq!(result.unwrap_err().unwrap(), InvoiceError::AmountOverflow);
     }
 
     #[test]

--- a/contracts/invoice/tests/access_control_tests.rs
+++ b/contracts/invoice/tests/access_control_tests.rs
@@ -1,0 +1,185 @@
+#![cfg(test)]
+
+//! #864: verifies the additive role-based multisig access-control path on
+//! `invoice` — (a) the legacy single-admin path is untouched, (b) an
+//! access-control-approved call executes the same effect the legacy path
+//! would, (c) calls without a configured/matching access-control address
+//! are rejected.
+
+use access_control::{AccessControlContract, AccessControlContractClient, ActionPayload, Role};
+use invoice::{InvoiceContract, InvoiceContractClient, InvoiceError};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+
+struct Fixture {
+    env: Env,
+    client: InvoiceContractClient<'static>,
+    contract_id: Address,
+    admin: Address,
+}
+
+fn setup() -> Fixture {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let pool = Address::generate(&env);
+
+    let contract_id = env.register(InvoiceContract, ());
+    let client = InvoiceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &pool, &1_000_000, &2_592_000, &7);
+
+    Fixture {
+        env,
+        client,
+        contract_id,
+        admin,
+    }
+}
+
+// ── (a) legacy admin path is untouched ──────────────────────────────────────
+
+#[test]
+fn test_legacy_admin_pause_unpause_still_work_unmodified() {
+    let f = setup();
+    f.client.pause(&f.admin);
+    assert!(f.client.is_paused());
+    f.client.unpause(&f.admin);
+    assert!(!f.client.is_paused());
+}
+
+#[test]
+fn test_legacy_admin_register_debtor_still_works_unmodified() {
+    let f = setup();
+    let debtor_id = String::from_str(&f.env, "debtor-1");
+    let debtor_name = String::from_str(&f.env, "Acme Co");
+    f.client
+        .register_debtor(&f.admin, &debtor_id, &debtor_name, &50_000);
+    let record = f.client.get_debtor(&debtor_id);
+    assert!(record.is_active);
+    assert_eq!(record.max_exposure, 50_000);
+}
+
+// ── (c) rejected without a configured/matching access-control address ──────
+
+#[test]
+fn test_via_ac_entrypoint_rejected_when_access_control_not_configured() {
+    let f = setup();
+    let someone = Address::generate(&f.env);
+    let result = f.client.try_set_paused_via_ac(&someone, &true);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        InvoiceError::AccessControlNotConfigured.into()
+    );
+}
+
+#[test]
+fn test_via_ac_entrypoint_rejected_from_a_non_matching_address() {
+    let f = setup();
+    let access_control = Address::generate(&f.env);
+    f.client.set_access_control(&f.admin, &access_control);
+
+    let impostor = Address::generate(&f.env);
+    let result = f.client.try_set_paused_via_ac(&impostor, &true);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        InvoiceError::Unauthorized.into()
+    );
+    assert!(!f.client.is_paused());
+}
+
+// ── (b) an access-control-approved call executes the same effect ───────────
+
+#[test]
+fn test_via_ac_entrypoints_apply_the_same_effects_as_their_legacy_admin_counterparts() {
+    let f = setup();
+    let access_control = Address::generate(&f.env);
+    f.client.set_access_control(&f.admin, &access_control);
+
+    f.client.set_paused_via_ac(&access_control, &true);
+    assert!(f.client.is_paused());
+    f.client.set_paused_via_ac(&access_control, &false);
+    assert!(!f.client.is_paused());
+
+    let oracle = Address::generate(&f.env);
+    f.client.set_oracle_via_ac(&access_control, &oracle);
+    assert_eq!(f.client.get_oracle(), Some(oracle));
+
+    let debtor_id = String::from_str(&f.env, "debtor-2");
+    let debtor_name = String::from_str(&f.env, "Beta Co");
+    f.client
+        .register_debtor_via_ac(&access_control, &debtor_id, &debtor_name, &75_000);
+    let record = f.client.get_debtor(&debtor_id);
+    assert!(record.is_active);
+    assert_eq!(record.max_exposure, 75_000);
+
+    f.client
+        .deactivate_debtor_via_ac(&access_control, &debtor_id);
+    assert!(!f.client.get_debtor(&debtor_id).is_active);
+
+    let keeper = Address::generate(&f.env);
+    f.client.add_keeper_via_ac(&access_control, &keeper);
+    assert!(f.client.list_keepers().contains(&keeper));
+}
+
+// ── real access_control contract driving a genuine 2-of-2 proposal ─────────
+
+#[test]
+fn test_real_access_control_contract_drives_debtor_registration() {
+    let f = setup();
+
+    let ac_id = f.env.register(AccessControlContract, ());
+    let ac_client = AccessControlContractClient::new(&f.env, &ac_id);
+
+    let super1 = Address::generate(&f.env);
+    let super2 = Address::generate(&f.env);
+    let _ = ac_client.initialize(&vec![&f.env, super1.clone(), super2.clone()], &2, &604_800);
+
+    f.client.set_access_control(&f.admin, &ac_id);
+
+    let c1 = Address::generate(&f.env);
+    let c2 = Address::generate(&f.env);
+    let add1 = ac_client.propose_action(
+        &Role::SuperAdmin,
+        &super1,
+        &ac_id,
+        &ActionPayload::AddSigner(Role::ComplianceOfficer, c1.clone()),
+    );
+    let _ = ac_client.approve_action(&super2, &add1);
+    let _ = ac_client.execute_action(&super1, &add1);
+    let add2 = ac_client.propose_action(
+        &Role::SuperAdmin,
+        &super1,
+        &ac_id,
+        &ActionPayload::AddSigner(Role::ComplianceOfficer, c2.clone()),
+    );
+    let _ = ac_client.approve_action(&super2, &add2);
+    let _ = ac_client.execute_action(&super1, &add2);
+    let set_threshold = ac_client.propose_action(
+        &Role::SuperAdmin,
+        &super1,
+        &ac_id,
+        &ActionPayload::SetThreshold(Role::ComplianceOfficer, 2),
+    );
+    let _ = ac_client.approve_action(&super2, &set_threshold);
+    let _ = ac_client.execute_action(&super1, &set_threshold);
+
+    let debtor_id = String::from_str(&f.env, "debtor-real");
+    let debtor_name = String::from_str(&f.env, "Real Co");
+    let proposal_id = ac_client.propose_action(
+        &Role::ComplianceOfficer,
+        &c1,
+        &f.contract_id,
+        &ActionPayload::RegisterDebtor(debtor_id.clone(), debtor_name, 20_000),
+    );
+
+    // Only one approval so far — must not have executed.
+    let premature = ac_client.try_execute_action(&c1, &proposal_id);
+    assert!(premature.is_err());
+
+    let _ = ac_client.approve_action(&c2, &proposal_id);
+    let _ = ac_client.execute_action(&c1, &proposal_id);
+
+    let record = f.client.get_debtor(&debtor_id);
+    assert!(record.is_active);
+    assert_eq!(record.max_exposure, 20_000);
+}

--- a/contracts/pool/Cargo.toml
+++ b/contracts/pool/Cargo.toml
@@ -14,6 +14,7 @@ soroban-sdk = { version = "22.0.0", features = ["testutils"] }
 proptest = "1.4"
 compliance = { path = "../compliance" }
 referral = { path = "../referral" }
+access_control = { path = "../access_control" }
 
 [[test]]
 name = "fuzz_tests"
@@ -22,3 +23,7 @@ path = "tests/fuzz_tests.rs"
 [[test]]
 name = "compliance_gate_tests"
 path = "tests/compliance_gate_tests.rs"
+
+[[test]]
+name = "access_control_tests"
+path = "tests/access_control_tests.rs"

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -167,6 +167,9 @@ pub enum PoolError {
     InvalidLoyaltyTiers = 86,
     // #992: deposit's optional min_rate guard rejected the current rate
     RateBelowMinimum = 87,
+    // #864: role-based multisig access-control
+    AccessControlNotConfigured = 88,
+    AccessControlAlreadyConfigured = 89,
 }
 
 type PoolResult<T> = Result<T, PoolError>;
@@ -785,7 +788,15 @@ const LOYALTY_TIERS: Symbol = symbol_short!("loy_tier");
 // 50-variant ceiling above). Restored as Symbol keys, matching the same
 // workaround already used for compliance/Reflector config.
 const INSURANCE_CFG: Symbol = symbol_short!("ins_cfg");
-const REFERRAL_CFG: Symbol = symbol_short!("ref_cfg");
+// Pre-existing build breakage found while working this branch: read/written
+// by set_auction_contract/get_auction_contract/fund_invoice_with_discount,
+// but never declared on `main` — same Symbol-key workaround as the other
+// post-#863 additions above (DataKey is already at the 50-variant ceiling).
+const AUCTION_CONTRACT: Symbol = symbol_short!("auct_ctr");
+// #864: role-based multisig access-control contract, if configured. Symbol
+// key, not a DataKey variant — DataKey is already at Soroban's 50-variant
+// ceiling (see #867/#777/#866/#799/#869 above).
+const ACCESS_CONTROL: Symbol = symbol_short!("ac_addr");
 const ORACLE_STALE_SECS: Symbol = symbol_short!("o_stale");
 // #777: per-token admin fallback price, stored as a single Map so it
 // doesn't need its own DataKey variant either.
@@ -1149,17 +1160,13 @@ fn record_rate_snapshot(env: &Env, token: &Address) {
         env.storage()
             .persistent()
             .set(&DataKey::RateRecord(token.clone(), len), &snapshot);
-        env.storage()
-            .instance()
-            .set(&bounds_key, &(len + 1, start));
+        env.storage().instance().set(&bounds_key, &(len + 1, start));
     } else {
         env.storage()
             .persistent()
             .set(&DataKey::RateRecord(token.clone(), start), &snapshot);
         let new_start = (start + 1) % MAX_RATE_HISTORY;
-        env.storage()
-            .instance()
-            .set(&bounds_key, &(len, new_start));
+        env.storage().instance().set(&bounds_key, &(len, new_start));
     }
 
     // Indexed off-chain into a time-series table for the rate-history API.
@@ -1719,7 +1726,7 @@ fn fund_invoice_request(
     }
 
     // Load existing FundedInvoice if this is a partial funding, or create new
-    let is_first_funding = !env
+    let _is_first_funding = !env
         .storage()
         .persistent()
         .has(&DataKey::FundedInvoice(request.invoice_id));
@@ -1745,7 +1752,13 @@ fn fund_invoice_request(
     };
     // #869: resolve factoring fee at funding time; auction contract may
     // override this with a discount via fund_invoice_with_discount.
-    let factoring_fee = resolve_factoring_fee(env, config, request.principal, request.sme.clone(), &request.token)?;
+    let factoring_fee = resolve_factoring_fee(
+        env,
+        config,
+        request.principal,
+        request.sme.clone(),
+        &request.token,
+    )?;
     let funded_key = DataKey::FundedInvoice(request.invoice_id);
     let is_partial = env.storage().persistent().has(&funded_key);
     if is_partial {
@@ -1783,7 +1796,7 @@ fn fund_invoice_request(
 
     // Update invoice contract's funded_amount via cross-contract call
     let invoice_client = InvoiceContractClient::new(env, &config.invoice_contract);
-    let _ = invoice_client.try_add_funding(
+    let _ = invoice_client.try_record_funding(
         &request.invoice_id,
         &request.principal,
         &env.current_contract_address(),
@@ -2125,7 +2138,7 @@ impl FundingPool {
 
         for i in 0..tokens.len() {
             if tokens.get(i).ok_or(PoolError::StorageCorrupted)? == token {
-                return Err(PoolError::TokenAlreadySupported);
+                return Err(PoolError::TokenAlreadyAccepted);
             }
         }
 
@@ -3552,7 +3565,13 @@ impl FundingPool {
             due_date,
             token,
         };
-        fund_invoice_request(&env, &discounted_config, &accepted_tokens, &mut stats, &request)?;
+        fund_invoice_request(
+            &env,
+            &discounted_config,
+            &accepted_tokens,
+            &mut stats,
+            &request,
+        )?;
         env.storage().instance().set(&DataKey::StorageStats, &stats);
 
         Self::non_reentrant_end(&env);
@@ -3832,7 +3851,7 @@ impl FundingPool {
             ))
         })();
         Self::non_reentrant_end(env);
-        let (fully_repaid, token, principal, repaid_amount, available_amount) = guarded_result?;
+        let (fully_repaid, token, _principal, repaid_amount, available_amount) = guarded_result?;
 
         // #863: a repayment changes utilization (deployed capital and/or pool
         // value) — record a rate sample for the history chart.
@@ -4898,6 +4917,240 @@ impl FundingPool {
                 .publish((EVT, symbol_short!("rev_wdraw")), (token, amount, treasury));
             Ok(())
         })
+    }
+
+    // ---- #864: role-based multisig access control (additive) ----
+    //
+    // Every entrypoint below is a parallel authorization path alongside the
+    // legacy single-admin one above — it does not replace or disable any
+    // existing admin-gated function. A deployment that never calls
+    // `set_access_control` behaves exactly as before.
+
+    /// Registers the `access_control` contract whose approved multisig
+    /// proposals may call the `*_via_ac` entrypoints below.
+    /// Admin-gated (legacy path), not hard-locked to a single call so a
+    /// misconfigured deployment can be corrected.
+    pub fn set_access_control(
+        env: Env,
+        admin: Address,
+        access_control: Address,
+    ) -> Result<(), PoolError> {
+        admin.require_auth();
+        bump_instance(&env);
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&ACCESS_CONTROL, &access_control);
+        env.events()
+            .publish((EVT, symbol_short!("set_ac")), (admin, access_control));
+        Ok(())
+    }
+
+    pub fn get_access_control(env: Env) -> Option<Address> {
+        env.storage().instance().get(&ACCESS_CONTROL)
+    }
+
+    /// Unified pause/unpause via an access-control-approved multisig
+    /// proposal. `true` pauses, `false` unpauses — same effect as the
+    /// legacy `pause()`/`unpause()` pair.
+    pub fn set_paused_via_ac(
+        env: Env,
+        access_control: Address,
+        paused: bool,
+    ) -> Result<(), PoolError> {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control)?;
+        bump_instance(&env);
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        env.events().publish(
+            (EVT, symbol_short!("ac_pause")),
+            (access_control, paused, env.ledger().timestamp()),
+        );
+        Ok(())
+    }
+
+    /// Direct yield setter via access control — same cooldown/max-step
+    /// guards as the legacy `set_yield()`.
+    pub fn set_yield_via_ac(
+        env: Env,
+        access_control: Address,
+        new_yield_bps: u32,
+    ) -> Result<(), PoolError> {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control)?;
+        bump_instance(&env);
+        Self::require_not_paused(&env);
+        let mut config: PoolConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(PoolError::NotInitialized)?;
+        if new_yield_bps > 5_000 {
+            return Err(PoolError::InvalidAmount);
+        }
+        let now = env.ledger().timestamp();
+        if now
+            < config
+                .last_yield_change_at
+                .saturating_add(config.yield_change_cooldown_secs)
+        {
+            return Err(PoolError::InvalidAmount);
+        }
+        let current = config.yield_bps;
+        let delta = new_yield_bps.abs_diff(current);
+        if delta > config.max_yield_change_bps {
+            return Err(PoolError::InvalidAmount);
+        }
+        config.yield_bps = new_yield_bps;
+        config.last_yield_change_at = now;
+        env.storage().instance().set(&DataKey::Config, &config);
+        env.events().publish(
+            (EVT, symbol_short!("ac_yield")),
+            (access_control, current, new_yield_bps),
+        );
+        Ok(())
+    }
+
+    pub fn set_treasury_via_ac(
+        env: Env,
+        access_control: Address,
+        treasury: Address,
+    ) -> Result<(), PoolError> {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control)?;
+        bump_instance(&env);
+        env.storage().instance().set(&DataKey::Treasury, &treasury);
+        env.events()
+            .publish((EVT, symbol_short!("ac_treas")), (access_control, treasury));
+        Ok(())
+    }
+
+    pub fn withdraw_revenue_via_ac(
+        env: Env,
+        access_control: Address,
+        token: Address,
+        amount: i128,
+    ) -> Result<(), PoolError> {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control)?;
+        bump_instance(&env);
+        Self::require_not_paused(&env);
+        if amount <= 0 {
+            return Err(PoolError::InvalidAmount);
+        }
+        non_reentrant!(&env, {
+            let treasury: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Treasury)
+                .ok_or(PoolError::TreasuryNotConfigured)?;
+            let token_totals_key = DataKey::TokenTotals(token.clone());
+            let mut tt: PoolTokenTotals = env
+                .storage()
+                .instance()
+                .get(&token_totals_key)
+                .unwrap_or_default();
+            if amount > tt.protocol_revenue {
+                return Err(PoolError::InsufficientRevenue);
+            }
+            tt.protocol_revenue -= amount;
+            env.storage().instance().set(&token_totals_key, &tt);
+            let token_client = token::Client::new(&env, &token);
+            token_client.transfer(&env.current_contract_address(), &treasury, &amount);
+            env.events()
+                .publish((EVT, symbol_short!("ac_rev")), (token, amount, treasury));
+            Ok(())
+        })
+    }
+
+    pub fn set_oracle_contract_via_ac(
+        env: Env,
+        access_control: Address,
+        oracle: Address,
+    ) -> Result<(), PoolError> {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control)?;
+        bump_instance(&env);
+        Self::require_not_paused(&env);
+        env.storage().instance().set(&REFLECTOR_ORACLE, &oracle);
+        env.events()
+            .publish((EVT, symbol_short!("ac_orcl")), (access_control, oracle));
+        Ok(())
+    }
+
+    pub fn set_kyc_required_via_ac(
+        env: Env,
+        access_control: Address,
+        required: bool,
+    ) -> Result<(), PoolError> {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control)?;
+        bump_instance(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::KycRequired, &required);
+        env.events().publish(
+            (EVT, symbol_short!("ac_kycreq")),
+            (access_control, required),
+        );
+        Ok(())
+    }
+
+    pub fn set_investor_kyc_via_ac(
+        env: Env,
+        access_control: Address,
+        investor: Address,
+        approved: bool,
+    ) -> Result<(), PoolError> {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control)?;
+        bump_instance(&env);
+
+        let config = get_config_cached(&env)?;
+        if investor == config.admin
+            || investor == env.current_contract_address()
+            || investor == config.invoice_contract
+        {
+            return Err(PoolError::Unauthorized);
+        }
+
+        let status = if approved {
+            KycStatus::Approved
+        } else {
+            KycStatus::Rejected
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::InvestorKyc(investor.clone()), &status);
+        env.events().publish(
+            (EVT, symbol_short!("ac_kycset")),
+            (access_control, investor, approved),
+        );
+        Ok(())
+    }
+
+    pub fn set_max_utilization_via_ac(
+        env: Env,
+        access_control: Address,
+        max_bps: u32,
+    ) -> Result<(), PoolError> {
+        access_control.require_auth();
+        Self::require_access_control(&env, &access_control)?;
+        bump_instance(&env);
+        Self::require_not_paused(&env);
+        if max_bps > 10_000 {
+            return Err(PoolError::InvalidAmount);
+        }
+        let mut config: PoolConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(PoolError::NotInitialized)?;
+        config.max_utilization_bps = max_bps;
+        env.storage().instance().set(&DataKey::Config, &config);
+        env.events()
+            .publish((EVT, symbol_short!("ac_util")), max_bps);
+        Ok(())
     }
 
     // ---- #773: loyalty bonus APY for long-term depositors ----
@@ -6148,6 +6401,25 @@ impl FundingPool {
             .get(&DataKey::Config)
             .ok_or(PoolError::NotInitialized)?;
         if admin != &config.admin {
+            return Err(PoolError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    /// #864: verifies `caller` is the registered `access_control` contract.
+    /// `caller.require_auth()` is checked by every `*_via_ac`
+    /// entrypoint before calling this — Soroban's host validates that
+    /// `require_auth()` on a contract address only succeeds when that
+    /// contract is actually the one invoking this call in the current
+    /// transaction (the same trust model already used for
+    /// `update_invoice_due_date` trusting `invoice_contract`).
+    fn require_access_control(env: &Env, caller: &Address) -> PoolResult<()> {
+        let configured: Address = env
+            .storage()
+            .instance()
+            .get(&ACCESS_CONTROL)
+            .ok_or(PoolError::AccessControlNotConfigured)?;
+        if caller != &configured {
             return Err(PoolError::Unauthorized);
         }
         Ok(())

--- a/contracts/pool/tests/access_control_tests.rs
+++ b/contracts/pool/tests/access_control_tests.rs
@@ -1,0 +1,196 @@
+#![cfg(test)]
+
+//! #864: verifies the additive role-based multisig access-control path on
+//! `pool` — (a) the legacy single-admin path is completely untouched, (b)
+//! an access-control-approved proposal executes the same effect the legacy
+//! path would, (c) calls without a configured/matching access-control
+//! address are rejected, and (d) a real `access_control` contract (not a
+//! mock) driving a 2-of-3 `RiskManager` proposal through to execution
+//! actually changes `PoolConfig.yield_bps`.
+
+use access_control::{AccessControlContract, AccessControlContractClient, ActionPayload, Role};
+use pool::{FundingPool, FundingPoolClient, PoolError};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, Env,
+};
+
+struct Fixture {
+    env: Env,
+    pool_client: FundingPoolClient<'static>,
+    pool_id: Address,
+    admin: Address,
+}
+
+fn setup() -> Fixture {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    // initialize() calls token::Client(initial_token).decimals(), so this
+    // needs to be a real registered asset contract, not a bare address —
+    // share_token/invoice_contract are never invoked by anything these
+    // tests exercise, so plain generated addresses are fine for those.
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let share_token = Address::generate(&env);
+    let invoice_contract = Address::generate(&env);
+
+    let pool_id = env.register(FundingPool, ());
+    let pool_client = FundingPoolClient::new(&env, &pool_id);
+    pool_client.initialize(&admin, &token, &share_token, &invoice_contract);
+    // set_yield()/set_yield_via_ac() both enforce a 24h cooldown from
+    // last_yield_change_at, which initialize() sets to the current ledger
+    // timestamp — advance past it so these tests can actually call it.
+    env.ledger().with_mut(|li| li.timestamp += 86_400 + 1);
+
+    Fixture {
+        env,
+        pool_client,
+        pool_id,
+        admin,
+    }
+}
+
+// ── (a) legacy admin path is untouched ──────────────────────────────────────
+
+#[test]
+fn test_legacy_admin_set_yield_still_works_unmodified() {
+    let f = setup();
+    f.pool_client.set_yield(&f.admin, &600);
+    assert_eq!(f.pool_client.get_config().yield_bps, 600);
+}
+
+#[test]
+fn test_legacy_admin_pause_unpause_still_work_unmodified() {
+    let f = setup();
+    f.pool_client.pause(&f.admin);
+    assert!(f.pool_client.is_paused());
+    f.pool_client.unpause(&f.admin);
+    assert!(!f.pool_client.is_paused());
+}
+
+// ── (c) rejected without a configured/matching access-control address ──────
+
+#[test]
+fn test_via_ac_entrypoint_rejected_when_access_control_not_configured() {
+    let f = setup();
+    let someone = Address::generate(&f.env);
+    let result = f.pool_client.try_set_yield_via_ac(&someone, &600);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        PoolError::AccessControlNotConfigured
+    );
+}
+
+#[test]
+fn test_via_ac_entrypoint_rejected_from_a_non_matching_address() {
+    let f = setup();
+    let access_control = Address::generate(&f.env);
+    f.pool_client.set_access_control(&f.admin, &access_control);
+
+    let impostor = Address::generate(&f.env);
+    let result = f.pool_client.try_set_yield_via_ac(&impostor, &600);
+    assert_eq!(result.unwrap_err().unwrap(), PoolError::Unauthorized);
+    // The legacy config is untouched by the rejected attempt.
+    assert_eq!(f.pool_client.get_config().yield_bps, 800);
+}
+
+// ── (b) an access-control-approved call executes the same effect ───────────
+
+#[test]
+fn test_via_ac_entrypoints_apply_the_same_effects_as_their_legacy_admin_counterparts() {
+    let f = setup();
+    let access_control = Address::generate(&f.env);
+    f.pool_client.set_access_control(&f.admin, &access_control);
+
+    f.pool_client.set_yield_via_ac(&access_control, &650);
+    assert_eq!(f.pool_client.get_config().yield_bps, 650);
+
+    f.pool_client.set_paused_via_ac(&access_control, &true);
+    assert!(f.pool_client.is_paused());
+    f.pool_client.set_paused_via_ac(&access_control, &false);
+    assert!(!f.pool_client.is_paused());
+
+    let treasury = Address::generate(&f.env);
+    f.pool_client
+        .set_treasury_via_ac(&access_control, &treasury);
+    assert_eq!(f.pool_client.get_treasury(), treasury);
+
+    f.pool_client
+        .set_kyc_required_via_ac(&access_control, &true);
+    assert!(f.pool_client.kyc_required());
+
+    f.pool_client
+        .set_max_utilization_via_ac(&access_control, &9_000);
+    assert_eq!(f.pool_client.get_config().max_utilization_bps, 9_000);
+
+    let oracle = Address::generate(&f.env);
+    f.pool_client
+        .set_oracle_contract_via_ac(&access_control, &oracle);
+    assert_eq!(f.pool_client.get_oracle_contract(), Some(oracle));
+}
+
+// ── (d) real access_control contract driving a genuine 2-of-3 proposal ─────
+
+#[test]
+fn test_real_access_control_contract_2_of_3_risk_manager_changes_real_pool_yield() {
+    let f = setup();
+
+    let ac_id = f.env.register(AccessControlContract, ());
+    let ac_client = AccessControlContractClient::new(&f.env, &ac_id);
+
+    let super1 = Address::generate(&f.env);
+    let super2 = Address::generate(&f.env);
+    let _ = ac_client.initialize(&vec![&f.env, super1.clone(), super2.clone()], &2, &604_800);
+
+    f.pool_client.set_access_control(&f.admin, &ac_id);
+
+    // Seed RiskManager as 2-of-3 via the SuperAdmin bootstrap flow.
+    let r1 = Address::generate(&f.env);
+    let r2 = Address::generate(&f.env);
+    let r3 = Address::generate(&f.env);
+    for signer in [&r1, &r2, &r3] {
+        let add = ac_client.propose_action(
+            &Role::SuperAdmin,
+            &super1,
+            &ac_id,
+            &ActionPayload::AddSigner(Role::RiskManager, signer.clone()),
+        );
+        let _ = ac_client.approve_action(&super2, &add);
+        let _ = ac_client.execute_action(&super1, &add);
+    }
+    let set_threshold = ac_client.propose_action(
+        &Role::SuperAdmin,
+        &super1,
+        &ac_id,
+        &ActionPayload::SetThreshold(Role::RiskManager, 2),
+    );
+    let _ = ac_client.approve_action(&super2, &set_threshold);
+    let _ = ac_client.execute_action(&super1, &set_threshold);
+
+    assert_eq!(f.pool_client.get_config().yield_bps, 800); // default
+
+    // Propose a real yield change against the real pool contract.
+    let proposal_id = ac_client.propose_action(
+        &Role::RiskManager,
+        &r1,
+        &f.pool_id,
+        &ActionPayload::SetYield(650),
+    );
+
+    // One approval (the proposer's own) is short of the 2-of-3 threshold —
+    // execution must be rejected and the pool's yield must stay untouched.
+    let premature = ac_client.try_execute_action(&r1, &proposal_id);
+    assert!(premature.is_err());
+    assert_eq!(f.pool_client.get_config().yield_bps, 800);
+
+    // Second approval reaches threshold.
+    let _ = ac_client.approve_action(&r2, &proposal_id);
+    let _ = ac_client.execute_action(&r1, &proposal_id);
+
+    // The real pool's real PoolConfig.yield_bps actually changed.
+    assert_eq!(f.pool_client.get_config().yield_bps, 650);
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -25,6 +25,9 @@ NEXT_PUBLIC_ORACLE_REGISTRY_CONTRACT_ID=
 NEXT_PUBLIC_COMPLIANCE_CONTRACT_ID=
 # #799: on-chain referral program — optional, opt-in on the pool contract.
 NEXT_PUBLIC_REFERRAL_CONTRACT_ID=
+# #864: role-based multisig access control — optional, gates admin actions on
+# invoice/pool/credit_score via propose→approve→execute once set.
+NEXT_PUBLIC_ACCESS_CONTROL_CONTRACT_ID=
 
 # Optional: additional stablecoins for labels in the Invest UI (e.g. testnet SACs)
 NEXT_PUBLIC_EURC_TOKEN_ID=

--- a/frontend/app/admin/roles/page.tsx
+++ b/frontend/app/admin/roles/page.tsx
@@ -1,0 +1,759 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useStore } from '@/lib/store';
+import { Skeleton } from '@/components/Skeleton';
+import { parseStellarAddress } from '@/lib/types';
+import type { Role, MultiSigConfig, ActionPayload, Proposal } from '@/lib/types';
+import { ALL_ROLES, ROLE_LABELS } from '@/lib/types';
+import {
+  POOL_CONTRACT_ID,
+  INVOICE_CONTRACT_ID,
+  CREDIT_SCORE_CONTRACT_ID,
+  ACCESS_CONTROL_CONTRACT_ID,
+} from '@/lib/stellar';
+import {
+  listAllRoleConfigs,
+  listProposals,
+  buildProposeActionTx,
+  buildApproveActionTx,
+  buildRejectActionTx,
+  buildRevokeApprovalTx,
+  buildExecuteActionTx,
+  submitTx,
+  getContractErrorMessage,
+} from '@/lib/contracts';
+
+type TargetKey = 'pool' | 'invoice' | 'credit_score' | 'self';
+
+const TARGET_CONTRACTS: Record<TargetKey, { label: string; id: string }> = {
+  pool: { label: 'Pool', id: POOL_CONTRACT_ID },
+  invoice: { label: 'Invoice', id: INVOICE_CONTRACT_ID },
+  credit_score: { label: 'Credit Score', id: CREDIT_SCORE_CONTRACT_ID },
+  self: { label: 'Access Control (self-management)', id: ACCESS_CONTROL_CONTRACT_ID },
+};
+
+// Which ActionPayload variants make sense for each target — mirrors the
+// `execute_cross_contract`/`execute_self_management` match arms in
+// contracts/access_control/src/lib.rs.
+const ACTIONS_BY_TARGET: Record<TargetKey, ActionPayload['tag'][]> = {
+  pool: [
+    'SetPaused',
+    'SetYield',
+    'SetTreasury',
+    'WithdrawRevenue',
+    'SetOracleContract',
+    'SetKycRequired',
+    'SetInvestorKyc',
+    'SetMaxUtilization',
+  ],
+  invoice: ['SetPaused', 'SetOracle', 'RegisterDebtor', 'DeactivateDebtor', 'AddKeeper'],
+  credit_score: ['SetPaused', 'SetLateThreshold', 'SetScoreThresholds', 'RegisterAttestor'],
+  self: ['AddSigner', 'RemoveSigner', 'SetThreshold'],
+};
+
+const ACTION_LABELS: Record<ActionPayload['tag'], string> = {
+  SetPaused: 'Set Paused',
+  SetYield: 'Set Yield (bps)',
+  SetTreasury: 'Set Treasury Address',
+  WithdrawRevenue: 'Withdraw Revenue',
+  SetOracleContract: 'Set Oracle Contract',
+  SetKycRequired: 'Set KYC Required',
+  SetInvestorKyc: 'Set Investor KYC Status',
+  SetMaxUtilization: 'Set Max Utilization (bps)',
+  SetOracle: 'Set Oracle Address',
+  RegisterDebtor: 'Register Debtor',
+  DeactivateDebtor: 'Deactivate Debtor',
+  AddKeeper: 'Add Keeper',
+  SetLateThreshold: 'Set Late Threshold (days)',
+  SetScoreThresholds: 'Set Score Thresholds',
+  RegisterAttestor: 'Register Attestor',
+  AddSigner: 'Add Signer',
+  RemoveSigner: 'Remove Signer',
+  SetThreshold: 'Set Threshold',
+};
+
+function summarizeAction(action: ActionPayload): string {
+  switch (action.tag) {
+    case 'SetPaused':
+      return `Set Paused → ${action.values[0]}`;
+    case 'SetYield':
+      return `Set Yield → ${action.values[0]} bps`;
+    case 'SetTreasury':
+      return `Set Treasury → ${action.values[0]}`;
+    case 'WithdrawRevenue':
+      return `Withdraw ${action.values[1]} from ${action.values[0]}`;
+    case 'SetOracleContract':
+      return `Set Oracle Contract → ${action.values[0]}`;
+    case 'SetKycRequired':
+      return `Set KYC Required → ${action.values[0]}`;
+    case 'SetInvestorKyc':
+      return `Set Investor KYC → ${action.values[0]}: ${action.values[1]}`;
+    case 'SetMaxUtilization':
+      return `Set Max Utilization → ${action.values[0]} bps`;
+    case 'SetOracle':
+      return `Set Oracle → ${action.values[0]}`;
+    case 'RegisterDebtor':
+      return `Register Debtor "${action.values[0]}" (${action.values[1]}), max exposure ${action.values[2]}`;
+    case 'DeactivateDebtor':
+      return `Deactivate Debtor ${action.values[0]}`;
+    case 'AddKeeper':
+      return `Add Keeper ${action.values[0]}`;
+    case 'SetLateThreshold':
+      return `Set Late Threshold → ${action.values[0]} days`;
+    case 'SetScoreThresholds':
+      return `Set Score Thresholds → ${action.values.join(' / ')}`;
+    case 'RegisterAttestor':
+      return `Register Attestor ${action.values[0]} (type ${action.values[1]}, weight ${action.values[2]}bps)`;
+    case 'AddSigner':
+      return `Add Signer ${action.values[1]} to ${ROLE_LABELS[action.values[0]]}`;
+    case 'RemoveSigner':
+      return `Remove Signer ${action.values[1]} from ${ROLE_LABELS[action.values[0]]}`;
+    case 'SetThreshold':
+      return `Set ${ROLE_LABELS[action.values[0]]} Threshold → ${action.values[1]}`;
+  }
+}
+
+export default function RolesAdminPage() {
+  const { wallet } = useStore();
+  const [roleConfigs, setRoleConfigs] = useState<Record<Role, MultiSigConfig | null> | null>(null);
+  const [proposals, setProposals] = useState<Array<{ id: number; proposal: Proposal }>>([]);
+  const [loading, setLoading] = useState(true);
+  const [txLoading, setTxLoading] = useState(false);
+
+  const [proposeRole, setProposeRole] = useState<Role>('RiskManager');
+  const [proposeTarget, setProposeTarget] = useState<TargetKey>('pool');
+  const [proposeAction, setProposeAction] = useState<ActionPayload['tag']>('SetYield');
+  const [fields, setFields] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [configs, props] = await Promise.all([listAllRoleConfigs(), listProposals()]);
+      setRoleConfigs(configs);
+      setProposals(props.reverse());
+    } catch (e) {
+      console.error(e);
+      toast.error('Failed to load access-control state.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function signAndSubmit(xdr: string) {
+    const freighter = await import('@stellar/freighter-api');
+    const { signedTxXdr, error: signError } = await freighter.signTransaction(xdr, {
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      address: wallet.address!,
+    });
+    if (signError) throw new Error(signError.message || 'Signing rejected.');
+    await submitTx(signedTxXdr);
+  }
+
+  const isSigner = useMemo(() => {
+    if (!wallet.address || !roleConfigs) return {} as Record<Role, boolean>;
+    const address = wallet.address;
+    const result = {} as Record<Role, boolean>;
+    for (const role of ALL_ROLES) {
+      result[role] = roleConfigs[role]?.signers.some((s) => s === address) ?? false;
+    }
+    return result;
+  }, [wallet.address, roleConfigs]);
+
+  function buildActionPayload(): ActionPayload | null {
+    const num = (key: string) => Number(fields[key] ?? '0');
+    const str = (key: string) => (fields[key] ?? '').trim();
+    switch (proposeAction) {
+      case 'SetPaused':
+      case 'SetKycRequired':
+        return { tag: proposeAction, values: [fields[`${proposeAction}_value`] === 'true'] };
+      case 'SetYield':
+      case 'SetMaxUtilization':
+        return { tag: proposeAction, values: [num('bps')] };
+      case 'SetTreasury':
+      case 'SetOracleContract':
+      case 'SetOracle':
+      case 'AddKeeper':
+        return { tag: proposeAction, values: [parseStellarAddress(str('address'))] };
+      case 'WithdrawRevenue':
+        return {
+          tag: 'WithdrawRevenue',
+          values: [parseStellarAddress(str('token')), BigInt(str('amount') || '0')],
+        };
+      case 'SetInvestorKyc':
+        return {
+          tag: 'SetInvestorKyc',
+          values: [parseStellarAddress(str('investor')), fields.approved === 'true'],
+        };
+      case 'RegisterDebtor':
+        return {
+          tag: 'RegisterDebtor',
+          values: [str('debtorId'), str('debtorName'), BigInt(str('maxExposure') || '0')],
+        };
+      case 'DeactivateDebtor':
+        return { tag: 'DeactivateDebtor', values: [str('debtorId')] };
+      case 'SetLateThreshold':
+        return { tag: 'SetLateThreshold', values: [BigInt(str('days') || '0')] };
+      case 'SetScoreThresholds':
+        return {
+          tag: 'SetScoreThresholds',
+          values: [num('excellent'), num('veryGood'), num('good'), num('fair')],
+        };
+      case 'RegisterAttestor':
+        return {
+          tag: 'RegisterAttestor',
+          values: [parseStellarAddress(str('address')), num('attestorType'), num('weightBps')],
+        };
+      case 'AddSigner':
+      case 'RemoveSigner':
+        return {
+          tag: proposeAction,
+          values: [str('role') as Role, parseStellarAddress(str('address'))],
+        };
+      case 'SetThreshold':
+        return { tag: 'SetThreshold', values: [str('role') as Role, num('threshold')] };
+    }
+  }
+
+  async function handlePropose(e: React.FormEvent) {
+    e.preventDefault();
+    if (!wallet.address) return;
+    setTxLoading(true);
+    try {
+      const action = buildActionPayload();
+      if (!action) throw new Error('Fill in the action fields.');
+      const target =
+        proposeTarget === 'self'
+          ? parseStellarAddress(ACCESS_CONTROL_CONTRACT_ID)
+          : parseStellarAddress(TARGET_CONTRACTS[proposeTarget].id);
+      const xdr = await buildProposeActionTx({
+        role: proposeRole,
+        proposer: parseStellarAddress(wallet.address),
+        target,
+        action,
+      });
+      await signAndSubmit(xdr);
+      toast.success('Proposal submitted.');
+      setFields({});
+      await load();
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Transaction failed.';
+      toast.error(getContractErrorMessage(message));
+    } finally {
+      setTxLoading(false);
+    }
+  }
+
+  async function handleSignerAction(
+    builder: typeof buildApproveActionTx,
+    proposalId: number,
+    successMessage: string,
+  ) {
+    if (!wallet.address) return;
+    setTxLoading(true);
+    try {
+      const xdr = await builder({ signer: parseStellarAddress(wallet.address), proposalId });
+      await signAndSubmit(xdr);
+      toast.success(successMessage);
+      await load();
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Transaction failed.';
+      toast.error(getContractErrorMessage(message));
+    } finally {
+      setTxLoading(false);
+    }
+  }
+
+  async function handleExecute(proposalId: number) {
+    if (!wallet.address) return;
+    setTxLoading(true);
+    try {
+      const xdr = await buildExecuteActionTx({
+        caller: parseStellarAddress(wallet.address),
+        proposalId,
+      });
+      await signAndSubmit(xdr);
+      toast.success(`Proposal #${proposalId} executed.`);
+      await load();
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Transaction failed.';
+      toast.error(getContractErrorMessage(message));
+    } finally {
+      setTxLoading(false);
+    }
+  }
+
+  const availableActions = ACTIONS_BY_TARGET[proposeTarget];
+
+  return (
+    <div className="max-w-5xl space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">Roles & Multisig Access Control</h1>
+        <p className="text-brand-muted text-sm">
+          Sensitive admin actions across Pool, Invoice, and Credit Score now route through
+          role-based multisig proposals: propose, gather approvals up to each role&apos;s threshold,
+          then execute.
+        </p>
+      </div>
+
+      {/* Role configs */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-bold">Roles</h2>
+        {loading ? (
+          <Skeleton className="h-40 w-full rounded-2xl" />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {ALL_ROLES.map((role) => {
+              const config = roleConfigs?.[role] ?? null;
+              return (
+                <div
+                  key={role}
+                  className="p-5 bg-brand-card border border-brand-border rounded-2xl space-y-2"
+                >
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-semibold">{ROLE_LABELS[role]}</h3>
+                    {isSigner[role] && (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-brand-gold/10 text-brand-gold">
+                        You are a signer
+                      </span>
+                    )}
+                  </div>
+                  {!config ? (
+                    <p className="text-brand-muted text-sm">Not configured yet.</p>
+                  ) : (
+                    <>
+                      <p className="text-sm text-brand-muted">
+                        Threshold: {config.threshold} of {config.signers.length}
+                      </p>
+                      <ul className="text-xs font-mono space-y-1">
+                        {config.signers.map((s) => (
+                          <li key={s} className="text-brand-muted">
+                            {s.slice(0, 8)}…{s.slice(-6)}
+                          </li>
+                        ))}
+                      </ul>
+                    </>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Propose new action */}
+      <div className="p-6 bg-brand-card border border-brand-border rounded-2xl space-y-4">
+        <h2 className="font-semibold">Propose an Action</h2>
+        <form onSubmit={handlePropose} className="space-y-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <select
+              value={proposeRole}
+              onChange={(e) => setProposeRole(e.target.value as Role)}
+              className="bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-white focus:outline-none focus:border-brand-gold text-sm"
+            >
+              {ALL_ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {ROLE_LABELS[r]}
+                </option>
+              ))}
+            </select>
+            <select
+              value={proposeTarget}
+              onChange={(e) => {
+                const target = e.target.value as TargetKey;
+                setProposeTarget(target);
+                setProposeAction(ACTIONS_BY_TARGET[target][0]!);
+                setFields({});
+              }}
+              className="bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-white focus:outline-none focus:border-brand-gold text-sm"
+            >
+              {(Object.keys(TARGET_CONTRACTS) as TargetKey[]).map((t) => (
+                <option key={t} value={t}>
+                  {TARGET_CONTRACTS[t].label}
+                </option>
+              ))}
+            </select>
+            <select
+              value={proposeAction}
+              onChange={(e) => {
+                setProposeAction(e.target.value as ActionPayload['tag']);
+                setFields({});
+              }}
+              className="bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-white focus:outline-none focus:border-brand-gold text-sm"
+            >
+              {availableActions.map((a) => (
+                <option key={a} value={a}>
+                  {ACTION_LABELS[a]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <ActionFields action={proposeAction} fields={fields} setFields={setFields} />
+
+          <button
+            type="submit"
+            disabled={txLoading || !wallet.address}
+            className="py-2.5 px-6 bg-brand-gold text-brand-dark rounded-xl text-sm font-semibold hover:bg-brand-amber transition-colors disabled:opacity-50"
+          >
+            {txLoading ? 'Processing…' : 'Submit Proposal'}
+          </button>
+        </form>
+      </div>
+
+      {/* Proposals queue */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-bold">Proposals</h2>
+        {loading ? (
+          <Skeleton className="h-32 w-full rounded-2xl" />
+        ) : proposals.length === 0 ? (
+          <div className="p-6 bg-brand-card border border-brand-border rounded-2xl text-center text-brand-muted text-sm">
+            No proposals yet.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {proposals.map(({ id, proposal }) => {
+              const address = wallet.address;
+              const canApprove =
+                isSigner[proposal.role] &&
+                proposal.status === 'Pending' &&
+                !!address &&
+                !proposal.approvals.some((a) => a === address);
+              const canRevoke =
+                !!address &&
+                proposal.approvals.some((a) => a === address) &&
+                (proposal.status === 'Pending' || proposal.status === 'Approved');
+              const canReject = isSigner[proposal.role] && proposal.status === 'Pending';
+              const canExecute = proposal.status === 'Approved';
+              const config = roleConfigs?.[proposal.role] ?? null;
+
+              return (
+                <div
+                  key={id}
+                  className="p-5 bg-brand-card border border-brand-border rounded-2xl space-y-2"
+                >
+                  <div className="flex items-center justify-between flex-wrap gap-2">
+                    <div>
+                      <span className="text-xs text-brand-muted">
+                        #{id} · {ROLE_LABELS[proposal.role]}
+                      </span>
+                      <p className="font-medium text-sm">{summarizeAction(proposal.action)}</p>
+                    </div>
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded-full ${
+                        proposal.status === 'Executed'
+                          ? 'bg-green-500/20 text-green-400'
+                          : proposal.status === 'Rejected'
+                            ? 'bg-red-500/20 text-red-400'
+                            : proposal.status === 'Approved'
+                              ? 'bg-brand-gold/20 text-brand-gold'
+                              : 'bg-brand-border text-brand-muted'
+                      }`}
+                    >
+                      {proposal.status}
+                    </span>
+                  </div>
+                  <p className="text-xs text-brand-muted">
+                    Approvals: {proposal.approvals.length} / {config?.threshold ?? '?'} · Proposer{' '}
+                    {proposal.proposer.slice(0, 8)}… · Expires{' '}
+                    {new Date(proposal.expiresAt * 1000).toLocaleString()}
+                  </p>
+                  <div className="flex gap-2 pt-1">
+                    {canApprove && (
+                      <button
+                        onClick={() =>
+                          handleSignerAction(buildApproveActionTx, id, `Approved proposal #${id}.`)
+                        }
+                        disabled={txLoading}
+                        className="px-3 py-1.5 bg-green-500/20 text-green-400 border border-green-500/30 rounded-lg text-xs font-semibold hover:bg-green-500/30 transition-colors disabled:opacity-50"
+                      >
+                        Approve
+                      </button>
+                    )}
+                    {canExecute && (
+                      <button
+                        onClick={() => handleExecute(id)}
+                        disabled={txLoading}
+                        className="px-3 py-1.5 bg-brand-gold/20 text-brand-gold border border-brand-gold/30 rounded-lg text-xs font-semibold hover:bg-brand-gold/30 transition-colors disabled:opacity-50"
+                      >
+                        Execute
+                      </button>
+                    )}
+                    {canRevoke && (
+                      <button
+                        onClick={() =>
+                          handleSignerAction(
+                            buildRevokeApprovalTx,
+                            id,
+                            `Revoked approval on #${id}.`,
+                          )
+                        }
+                        disabled={txLoading}
+                        className="px-3 py-1.5 bg-brand-dark border border-brand-border rounded-lg text-xs font-semibold hover:bg-brand-border transition-colors disabled:opacity-50"
+                      >
+                        Revoke Approval
+                      </button>
+                    )}
+                    {canReject && (
+                      <button
+                        onClick={() =>
+                          handleSignerAction(buildRejectActionTx, id, `Rejected proposal #${id}.`)
+                        }
+                        disabled={txLoading}
+                        className="px-3 py-1.5 bg-red-500/20 text-red-400 border border-red-500/30 rounded-lg text-xs font-semibold hover:bg-red-500/30 transition-colors disabled:opacity-50"
+                      >
+                        Reject
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ActionFields({
+  action,
+  fields,
+  setFields,
+}: {
+  action: ActionPayload['tag'];
+  fields: Record<string, string>;
+  setFields: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+}) {
+  const set = (key: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+    setFields((f) => ({ ...f, [key]: e.target.value }));
+
+  const inputClass =
+    'bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-white placeholder-brand-muted focus:outline-none focus:border-brand-gold text-sm';
+
+  switch (action) {
+    case 'SetPaused':
+    case 'SetKycRequired':
+      return (
+        <select
+          value={fields[`${action}_value`] ?? 'true'}
+          onChange={set(`${action}_value`)}
+          className={inputClass}
+        >
+          <option value="true">true</option>
+          <option value="false">false</option>
+        </select>
+      );
+    case 'SetYield':
+    case 'SetMaxUtilization':
+      return (
+        <input
+          type="number"
+          placeholder="Basis points"
+          value={fields.bps ?? ''}
+          onChange={set('bps')}
+          className={inputClass}
+        />
+      );
+    case 'SetTreasury':
+    case 'SetOracleContract':
+    case 'SetOracle':
+    case 'AddKeeper':
+      return (
+        <input
+          type="text"
+          placeholder="Address (G... or C...)"
+          value={fields.address ?? ''}
+          onChange={set('address')}
+          className={`${inputClass} font-mono w-full`}
+        />
+      );
+    case 'WithdrawRevenue':
+      return (
+        <div className="grid grid-cols-2 gap-3">
+          <input
+            type="text"
+            placeholder="Token contract"
+            value={fields.token ?? ''}
+            onChange={set('token')}
+            className={`${inputClass} font-mono`}
+          />
+          <input
+            type="text"
+            placeholder="Amount (stroops)"
+            value={fields.amount ?? ''}
+            onChange={set('amount')}
+            className={inputClass}
+          />
+        </div>
+      );
+    case 'SetInvestorKyc':
+      return (
+        <div className="grid grid-cols-2 gap-3">
+          <input
+            type="text"
+            placeholder="Investor address"
+            value={fields.investor ?? ''}
+            onChange={set('investor')}
+            className={`${inputClass} font-mono`}
+          />
+          <select
+            value={fields.approved ?? 'true'}
+            onChange={set('approved')}
+            className={inputClass}
+          >
+            <option value="true">Approved</option>
+            <option value="false">Not approved</option>
+          </select>
+        </div>
+      );
+    case 'RegisterDebtor':
+      return (
+        <div className="grid grid-cols-3 gap-3">
+          <input
+            type="text"
+            placeholder="Debtor ID"
+            value={fields.debtorId ?? ''}
+            onChange={set('debtorId')}
+            className={inputClass}
+          />
+          <input
+            type="text"
+            placeholder="Debtor name"
+            value={fields.debtorName ?? ''}
+            onChange={set('debtorName')}
+            className={inputClass}
+          />
+          <input
+            type="text"
+            placeholder="Max exposure"
+            value={fields.maxExposure ?? ''}
+            onChange={set('maxExposure')}
+            className={inputClass}
+          />
+        </div>
+      );
+    case 'DeactivateDebtor':
+      return (
+        <input
+          type="text"
+          placeholder="Debtor ID"
+          value={fields.debtorId ?? ''}
+          onChange={set('debtorId')}
+          className={inputClass}
+        />
+      );
+    case 'SetLateThreshold':
+      return (
+        <input
+          type="number"
+          placeholder="Days"
+          value={fields.days ?? ''}
+          onChange={set('days')}
+          className={inputClass}
+        />
+      );
+    case 'SetScoreThresholds':
+      return (
+        <div className="grid grid-cols-4 gap-3">
+          <input
+            placeholder="Excellent"
+            value={fields.excellent ?? ''}
+            onChange={set('excellent')}
+            className={inputClass}
+          />
+          <input
+            placeholder="Very good"
+            value={fields.veryGood ?? ''}
+            onChange={set('veryGood')}
+            className={inputClass}
+          />
+          <input
+            placeholder="Good"
+            value={fields.good ?? ''}
+            onChange={set('good')}
+            className={inputClass}
+          />
+          <input
+            placeholder="Fair"
+            value={fields.fair ?? ''}
+            onChange={set('fair')}
+            className={inputClass}
+          />
+        </div>
+      );
+    case 'RegisterAttestor':
+      return (
+        <div className="grid grid-cols-3 gap-3">
+          <input
+            type="text"
+            placeholder="Attestor address"
+            value={fields.address ?? ''}
+            onChange={set('address')}
+            className={`${inputClass} font-mono`}
+          />
+          <select
+            value={fields.attestorType ?? '0'}
+            onChange={set('attestorType')}
+            className={inputClass}
+          >
+            <option value="0">Business Registry</option>
+            <option value="1">Credit Bureau</option>
+            <option value="2">External Protocol</option>
+            <option value="3">Manual</option>
+          </select>
+          <input
+            type="number"
+            placeholder="Weight (bps)"
+            value={fields.weightBps ?? ''}
+            onChange={set('weightBps')}
+            className={inputClass}
+          />
+        </div>
+      );
+    case 'AddSigner':
+    case 'RemoveSigner':
+      return (
+        <div className="grid grid-cols-2 gap-3">
+          <select value={fields.role ?? 'SuperAdmin'} onChange={set('role')} className={inputClass}>
+            {ALL_ROLES.map((r) => (
+              <option key={r} value={r}>
+                {ROLE_LABELS[r]}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            placeholder="Signer address"
+            value={fields.address ?? ''}
+            onChange={set('address')}
+            className={`${inputClass} font-mono`}
+          />
+        </div>
+      );
+    case 'SetThreshold':
+      return (
+        <div className="grid grid-cols-2 gap-3">
+          <select value={fields.role ?? 'SuperAdmin'} onChange={set('role')} className={inputClass}>
+            {ALL_ROLES.map((r) => (
+              <option key={r} value={r}>
+                {ROLE_LABELS[r]}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            placeholder="New threshold"
+            value={fields.threshold ?? ''}
+            onChange={set('threshold')}
+            className={inputClass}
+          />
+        </div>
+      );
+  }
+}

--- a/frontend/components/AdminNav.tsx
+++ b/frontend/components/AdminNav.tsx
@@ -65,6 +65,11 @@ const adminLinks = [
     label: 'Credit Attestors',
     icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
   },
+  {
+    href: '/admin/roles',
+    label: 'Roles & Multisig',
+    icon: 'M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 4a3 3 0 110 6 3 3 0 010-6zm0 13.2c-2.5 0-4.71-1.28-6-3.22.03-2 4-3.1 6-3.1s5.97 1.1 6 3.1c-1.29 1.94-3.5 3.22-6 3.22z',
+  },
 ];
 
 export default function AdminNav() {

--- a/frontend/e2e/admin-roles.spec.ts
+++ b/frontend/e2e/admin-roles.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+import {
+  createAccessControlStore,
+  stubAccessControlContracts,
+} from './mocks/soroban-access-control';
+
+const SIGNER_A = 'GALFWZFITZIDDSI5NQUGTC2SSR27SNPNU3QF6NZX5XAOHZB6YNBBVOHD';
+const SIGNER_B = 'GAMWS4XVBMBSVVHIDMHLO4SKSX2VNL5SDX5326RSSMUKMWMAXGDXRYC3';
+const SIGNER_C = 'GCAKR2ZQBYJOCAE7NO23XBE4E3HSX6N3QDB3IZPCDDKJMPHUGM7KVNHG';
+
+/** Freighter mock that signs by returning the xdr unmodified — the shared
+ * `freighterMockScript` appends a `_signed` suffix, which would corrupt the
+ * transaction envelope this spec needs to actually replay through the mock
+ * RPC (`extractInvocation` re-parses the signed xdr as a real envelope). */
+function cleanFreighterMockScript(address: string): string {
+  return `
+    (function() {
+      window.__MOCK_FREIGHTER_API__ = {
+        isConnected: () => Promise.resolve({ isConnected: true }),
+        isAllowed: () => Promise.resolve({ isAllowed: true }),
+        setAllowed: () => Promise.resolve({ isAllowed: true }),
+        getAddress: () => Promise.resolve({ address: '${address}', error: null }),
+        signTransaction: (xdr) => Promise.resolve({ signedTxXdr: xdr, error: null }),
+        getNetwork: () => Promise.resolve({ network: 'TESTNET', networkPassphrase: 'Test SDF Network ; September 2015' }),
+      };
+    })();
+  `;
+}
+
+async function injectWallet(page: import('@playwright/test').Page, address: string) {
+  await page.addInitScript(cleanFreighterMockScript(address));
+  // Matches lib/store.ts's `WALLET_KEY` — WalletConnect's auto-reconnect
+  // effect reads this on mount and, seeing it set, calls the (mocked)
+  // Freighter API to restore `wallet.connected`/`wallet.address`.
+  await page.addInitScript((addr: string) => {
+    localStorage.setItem('astera_wallet_address', addr);
+  }, address);
+}
+
+// #864: two-signer approval flow for the RiskManager role's 2-of-3 multisig —
+// wallet A proposes a yield change, wallet B approves it (crossing the
+// threshold), then either wallet executes it against the (mocked) pool
+// contract. Mirrors the exact scenario required by issue #864's acceptance
+// criteria.
+test.describe('Admin roles & multisig access control', () => {
+  test.skip(!!process.env.CI, 'Admin flows require live contract + permissions in CI.');
+
+  test('wallet A proposes, wallet B approves, execution updates the pool yield', async ({
+    browser,
+  }) => {
+    const store = createAccessControlStore('RiskManager', [SIGNER_A, SIGNER_B, SIGNER_C], 2);
+
+    const contextA = await browser.newContext();
+    const pageA = await contextA.newPage();
+    await injectWallet(pageA, SIGNER_A);
+    await stubAccessControlContracts(pageA, store, SIGNER_A);
+
+    const contextB = await browser.newContext();
+    const pageB = await contextB.newPage();
+    await injectWallet(pageB, SIGNER_B);
+    await stubAccessControlContracts(pageB, store, SIGNER_B);
+
+    // Wallet A proposes a SetYield action targeting the pool contract.
+    await pageA.goto('/admin/roles');
+    await expect(
+      pageA.getByRole('heading', { name: 'Roles & Multisig Access Control' }),
+    ).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await pageA.getByRole('combobox').nth(0).selectOption('RiskManager');
+    await pageA.getByRole('combobox').nth(1).selectOption('pool');
+    await pageA.getByRole('combobox').nth(2).selectOption('SetYield');
+    await pageA.getByPlaceholder('Basis points').fill('650');
+    await pageA.getByRole('button', { name: 'Submit Proposal' }).click();
+
+    await expect(pageA.getByText('Set Yield → 650 bps')).toBeVisible({ timeout: 15_000 });
+    await expect(pageA.getByText('Approvals: 1 / 2')).toBeVisible();
+    await expect(pageA.getByText('Pending')).toBeVisible();
+
+    // Wallet B sees the same pending proposal and approves it.
+    await pageB.goto('/admin/roles');
+    await expect(pageB.getByText('Set Yield → 650 bps')).toBeVisible({ timeout: 15_000 });
+    await pageB.getByRole('button', { name: 'Approve' }).click();
+
+    await expect(pageB.getByText('Approvals: 2 / 2')).toBeVisible({ timeout: 15_000 });
+    await expect(pageB.getByText('Approved')).toBeVisible();
+
+    // Threshold met — either signer can now execute it.
+    await pageB.getByRole('button', { name: 'Execute' }).click();
+    await expect(pageB.getByText('Executed')).toBeVisible({ timeout: 15_000 });
+
+    expect(store.poolYieldBps).toBe(650);
+  });
+});

--- a/frontend/e2e/mocks/soroban-access-control.ts
+++ b/frontend/e2e/mocks/soroban-access-control.ts
@@ -1,0 +1,328 @@
+import type { Page } from '@playwright/test';
+import { nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
+
+const POOL_CONTRACT_ID =
+  process.env.NEXT_PUBLIC_POOL_CONTRACT_ID ??
+  'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526';
+
+interface ProposalRecord {
+  role: string;
+  target: string;
+  // Flat `[tag, ...fields]`, matching how the real access_control contract
+  // encodes an `ActionPayload` enum variant on the wire.
+  action: unknown[];
+  proposer: string;
+  approvals: string[];
+  created_at: number;
+  expires_at: number;
+  status: 'Pending' | 'Approved' | 'Executed' | 'Rejected';
+}
+
+export interface AccessControlStore {
+  role: string;
+  signers: string[];
+  threshold: number;
+  proposals: ProposalRecord[];
+  poolYieldBps: number;
+}
+
+export function createAccessControlStore(
+  role: string,
+  signers: string[],
+  threshold: number,
+): AccessControlStore {
+  return { role, signers, threshold, proposals: [], poolYieldBps: 800 };
+}
+
+function extractInvocation(txXdr: string): { method: string; args: xdr.ScVal[] } | null {
+  try {
+    const envelope = xdr.TransactionEnvelope.fromXDR(txXdr, 'base64');
+    const v1Envelope = envelope.v1();
+    if (!v1Envelope) return null;
+    const ops = v1Envelope.tx().operations();
+    const firstOp = ops.at(0);
+    if (!firstOp) return null;
+    const body = firstOp.body();
+    if (body.switch().name !== 'invokeHostFunction') return null;
+    const hostFn = body.invokeHostFunctionOp().hostFunction();
+    if (hostFn.switch().name !== 'hostFunctionTypeInvokeContract') return null;
+    const invoke = hostFn.invokeContract();
+    return { method: invoke.functionName().toString(), args: invoke.args() };
+  } catch {
+    return null;
+  }
+}
+
+function recomputeStatus(p: ProposalRecord, threshold: number) {
+  if (p.status === 'Executed' || p.status === 'Rejected') return;
+  p.status = p.approvals.length >= threshold ? 'Approved' : 'Pending';
+}
+
+function buildSimulateSuccess(id: number | string | undefined, retval: xdr.ScVal) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    result: {
+      transactionData:
+        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
+      minResourceFee: '100',
+      events: [],
+      results: [],
+      cost: { cpuInsns: '0', memBytes: '0' },
+      latestLedger: 1,
+      retval: retval.toXDR('base64'),
+    },
+  };
+}
+
+function buildTransactionResultXdr(): string {
+  const result = new xdr.TransactionResult({
+    feeCharged: new xdr.Int64(0),
+    result: xdr.TransactionResultResult.txSuccess([]),
+    ext: new xdr.TransactionResultExt(0),
+  });
+  return result.toXDR('base64');
+}
+
+function buildTransactionMetaXdr(): string {
+  return new xdr.TransactionMeta(0, []).toXDR('base64');
+}
+
+// `Server.getAccount` (used to fetch the source account for every tx we
+// build) doesn't call the simple `getAccount` JSON-RPC method — it calls
+// `getLedgerEntries` for an `account` ledger key and reads `seqNum()` off the
+// decoded entry. The account id embedded in the entry itself is never
+// inspected by the caller (it re-uses the address it was asked for), so one
+// fixed, validly-shaped `AccountEntry` blob works for every request.
+function buildAccountEntryXdr(): string {
+  const entry = new xdr.AccountEntry({
+    accountId: xdr.PublicKey.publicKeyTypeEd25519(Buffer.alloc(32)),
+    balance: xdr.Int64.fromString('1000000000000'),
+    seqNum: xdr.Int64.fromString('1'),
+    numSubEntries: 0,
+    inflationDest: null,
+    flags: 0,
+    homeDomain: '',
+    thresholds: Buffer.from([0, 0, 0, 0]),
+    signers: [],
+    ext: new xdr.AccountEntryExt(0),
+  });
+  return xdr.LedgerEntryData.account(entry).toXDR('base64');
+}
+
+let hashCounter = 0;
+const pendingEnvelopes = new Map<string, string>();
+
+/**
+ * Stubs the Soroban RPC calls the access-control admin page and its
+ * propose/approve/reject/revoke/execute transaction builders need, backed by
+ * an in-memory `AccessControlStore` mutated as each signed transaction lands
+ * — so two browser contexts sharing the same store (one per wallet) can
+ * drive a real propose → approve → execute flow against the mock.
+ */
+export async function stubAccessControlContracts(
+  page: Page,
+  store: AccessControlStore,
+  viewerAddress: string,
+): Promise<void> {
+  await page.route('**/*stellar.org/**', async (route) => {
+    const request = route.request();
+    if (request.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    const body = request.postDataJSON() as {
+      id?: number | string;
+      method?: string;
+      params?: { transaction?: string; keys?: string[] };
+    };
+
+    if (body.method === 'getLedgerEntries' && body.params?.keys) {
+      const accountEntryXdr = buildAccountEntryXdr();
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: {
+            latestLedger: 1,
+            entries: body.params.keys.map((key) => ({
+              key,
+              xdr: accountEntryXdr,
+              lastModifiedLedgerSeq: 1,
+            })),
+          },
+        }),
+      });
+      return;
+    }
+
+    if (body.method === 'getLatestLedger') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: { sequence: 1, protocolVersion: 22, id: '1' },
+        }),
+      });
+      return;
+    }
+
+    if (body.method === 'simulateTransaction' && body.params?.transaction) {
+      const inv = extractInvocation(body.params.transaction);
+      const method = inv?.method ?? null;
+      let retval: xdr.ScVal = nativeToScVal(null);
+
+      if (method === 'get_role_config') {
+        const role = scValToNative(inv!.args[0]!);
+        const roleTag = Array.isArray(role) ? role[0] : role;
+        retval =
+          roleTag === store.role
+            ? nativeToScVal({ signers: store.signers, threshold: store.threshold })
+            : nativeToScVal(null);
+      } else if (method === 'is_signer') {
+        const role = scValToNative(inv!.args[0]!);
+        const roleTag = Array.isArray(role) ? role[0] : role;
+        const address = scValToNative(inv!.args[1]!) as string;
+        retval = nativeToScVal(roleTag === store.role && store.signers.includes(address));
+      } else if (method === 'get_next_proposal_id') {
+        retval = nativeToScVal(store.proposals.length, { type: 'u64' });
+      } else if (method === 'get_proposal') {
+        const id = Number(scValToNative(inv!.args[0]!));
+        const p = store.proposals[id];
+        retval = p ? nativeToScVal({ ...p }) : nativeToScVal(null);
+      } else if (method === 'get_config') {
+        // The shared `/admin` layout's route guard only allows the wallet
+        // matching this `admin` field through. `get_config` is always
+        // simulated from a fixed read-only placeholder source account (see
+        // `getPoolConfig` in lib/contracts.ts), not the connected wallet, so
+        // we can't derive "who's asking" from the tx itself — each stubbed
+        // page instead gets told which wallet is viewing it. (Not a
+        // simulation of real access control; that legacy single-admin gate
+        // is orthogonal to the #864 RBAC flow this mock exists to exercise.)
+        retval = nativeToScVal({
+          invoice_contract: POOL_CONTRACT_ID,
+          admin: viewerAddress,
+          yield_bps: store.poolYieldBps,
+          factoring_fee_bps: 150,
+          compound_interest: false,
+          proposed_yield_bps: 0,
+          yield_proposal_at: 0,
+          yield_timelock_secs: 0,
+          max_single_investor_bps: 5000,
+          max_withdrawal_queue_age_days: 7,
+          max_withdrawal_queue_depth: 500,
+        });
+      }
+      // propose_action / approve_action / reject_action / revoke_approval /
+      // execute_action don't need a meaningful simulated retval — the tx
+      // builders only use the simulate response to assemble resource fees.
+
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(buildSimulateSuccess(body.id, retval)),
+      });
+      return;
+    }
+
+    if (body.method === 'sendTransaction' && body.params?.transaction) {
+      const inv = extractInvocation(body.params.transaction);
+      if (inv) {
+        const { method, args } = inv;
+        if (method === 'propose_action') {
+          const proposer = scValToNative(args[1]!) as string;
+          const target = scValToNative(args[2]!) as string;
+          const action = scValToNative(args[3]!) as unknown[];
+          const record: ProposalRecord = {
+            role: store.role,
+            target,
+            action,
+            proposer,
+            approvals: [proposer],
+            created_at: Math.floor(Date.now() / 1000),
+            expires_at: Math.floor(Date.now() / 1000) + 86_400,
+            status: 'Pending',
+          };
+          recomputeStatus(record, store.threshold);
+          store.proposals.push(record);
+        } else if (method === 'approve_action') {
+          const signer = scValToNative(args[0]!) as string;
+          const id = Number(scValToNative(args[1]!));
+          const p = store.proposals[id];
+          if (p && !p.approvals.includes(signer)) {
+            p.approvals.push(signer);
+            recomputeStatus(p, store.threshold);
+          }
+        } else if (method === 'reject_action') {
+          const id = Number(scValToNative(args[1]!));
+          const p = store.proposals[id];
+          if (p) p.status = 'Rejected';
+        } else if (method === 'revoke_approval') {
+          const signer = scValToNative(args[0]!) as string;
+          const id = Number(scValToNative(args[1]!));
+          const p = store.proposals[id];
+          if (p) {
+            p.approvals = p.approvals.filter((a) => a !== signer);
+            recomputeStatus(p, store.threshold);
+          }
+        } else if (method === 'execute_action') {
+          const id = Number(scValToNative(args[1]!));
+          const p = store.proposals[id];
+          if (p && p.status === 'Approved') {
+            p.status = 'Executed';
+            const [tag, ...values] = p.action;
+            if (tag === 'SetYield') store.poolYieldBps = values[0] as number;
+          }
+        }
+      }
+
+      hashCounter += 1;
+      const hash = `mockhash${hashCounter}`.padEnd(64, '0');
+      pendingEnvelopes.set(hash, body.params.transaction);
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: {
+            status: 'PENDING',
+            hash,
+            latestLedger: 1,
+            latestLedgerCloseTime: Math.floor(Date.now() / 1000),
+          },
+        }),
+      });
+      return;
+    }
+
+    if (body.method === 'getTransaction') {
+      const hash = (body.params as unknown as { hash?: string })?.hash ?? '';
+      const envelopeXdr = pendingEnvelopes.get(hash) ?? '';
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: {
+            status: 'SUCCESS',
+            latestLedger: 2,
+            latestLedgerCloseTime: Math.floor(Date.now() / 1000),
+            oldestLedger: 1,
+            oldestLedgerCloseTime: Math.floor(Date.now() / 1000) - 100,
+            txHash: hash,
+            applicationOrder: 1,
+            feeBump: false,
+            envelopeXdr,
+            resultXdr: buildTransactionResultXdr(),
+            resultMetaXdr: buildTransactionMetaXdr(),
+          },
+        }),
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+}

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -9,6 +9,7 @@ import {
   ORACLE_REGISTRY_CONTRACT_ID,
   COMPLIANCE_CONTRACT_ID,
   REFERRAL_CONTRACT_ID,
+  ACCESS_CONTROL_CONTRACT_ID,
   NETWORK,
   simulateTx,
   submitTx,
@@ -47,7 +48,12 @@ import type {
   RateModelConfig,
   RateSnapshot,
   ReferralStats,
+  Role,
+  MultiSigConfig,
+  ActionPayload,
+  Proposal,
 } from './types';
+import { ALL_ROLES } from './types';
 // Auto-generated contract bindings (single source of truth for the on-chain
 // ABI — methods, struct shapes and error codes). Regenerate with
 // `./scripts/gen-bindings.sh`; see CONTRIBUTING.md.
@@ -2618,6 +2624,270 @@ export async function buildRegisterReferralTx(referee: string, referrer: string)
   })
     .addOperation(
       contract.call('register', new Address(referee).toScVal(), new Address(referrer).toScVal()),
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await simulateRpcTransaction(tx);
+  if (StellarRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Simulation failed: ${sim.error}`);
+  }
+  return StellarRpc.assembleTransaction(tx, sim).build().toXDR();
+}
+
+// ---- #864: role-based multisig access control ----
+
+const SIMULATION_SOURCE = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+
+function roleToScVal(role: Role): xdr.ScVal {
+  return xdr.ScVal.scvVec([nativeToScVal(role, { type: 'symbol' })]);
+}
+
+/**
+ * Encodes an `ActionPayload` (mirrors contracts/access_control/src/lib.rs's
+ * `ActionPayload` enum) the same way `attestorTypeToScVal` above encodes a
+ * unit-variant enum, extended for tuple-variant payloads: a Vec whose first
+ * element is the variant name (Symbol) followed by its fields in order.
+ */
+function actionPayloadToScVal(action: ActionPayload): xdr.ScVal {
+  const tag = nativeToScVal(action.tag, { type: 'symbol' });
+  switch (action.tag) {
+    case 'SetPaused':
+    case 'SetKycRequired':
+      return xdr.ScVal.scvVec([tag, nativeToScVal(action.values[0], { type: 'bool' })]);
+    case 'SetYield':
+    case 'SetMaxUtilization':
+      return xdr.ScVal.scvVec([tag, nativeToScVal(action.values[0], { type: 'u32' })]);
+    case 'SetTreasury':
+    case 'SetOracleContract':
+    case 'SetOracle':
+    case 'AddKeeper':
+      return xdr.ScVal.scvVec([tag, new Address(action.values[0]).toScVal()]);
+    case 'WithdrawRevenue':
+      return xdr.ScVal.scvVec([
+        tag,
+        new Address(action.values[0]).toScVal(),
+        nativeToScVal(action.values[1], { type: 'i128' }),
+      ]);
+    case 'SetInvestorKyc':
+      return xdr.ScVal.scvVec([
+        tag,
+        new Address(action.values[0]).toScVal(),
+        nativeToScVal(action.values[1], { type: 'bool' }),
+      ]);
+    case 'RegisterDebtor':
+      return xdr.ScVal.scvVec([
+        tag,
+        nativeToScVal(action.values[0], { type: 'string' }),
+        nativeToScVal(action.values[1], { type: 'string' }),
+        nativeToScVal(action.values[2], { type: 'i128' }),
+      ]);
+    case 'DeactivateDebtor':
+      return xdr.ScVal.scvVec([tag, nativeToScVal(action.values[0], { type: 'string' })]);
+    case 'SetLateThreshold':
+      return xdr.ScVal.scvVec([tag, nativeToScVal(action.values[0], { type: 'i64' })]);
+    case 'SetScoreThresholds':
+      return xdr.ScVal.scvVec([
+        tag,
+        nativeToScVal(action.values[0], { type: 'u32' }),
+        nativeToScVal(action.values[1], { type: 'u32' }),
+        nativeToScVal(action.values[2], { type: 'u32' }),
+        nativeToScVal(action.values[3], { type: 'u32' }),
+      ]);
+    case 'RegisterAttestor':
+      return xdr.ScVal.scvVec([
+        tag,
+        new Address(action.values[0]).toScVal(),
+        nativeToScVal(action.values[1], { type: 'u32' }),
+        nativeToScVal(action.values[2], { type: 'u32' }),
+      ]);
+    case 'AddSigner':
+    case 'RemoveSigner':
+      return xdr.ScVal.scvVec([
+        tag,
+        roleToScVal(action.values[0]),
+        new Address(action.values[1]).toScVal(),
+      ]);
+    case 'SetThreshold':
+      return xdr.ScVal.scvVec([
+        tag,
+        roleToScVal(action.values[0]),
+        nativeToScVal(action.values[1], { type: 'u32' }),
+      ]);
+  }
+}
+
+/**
+ * `scValToNative` decodes our `[tag, ...fields]` vec encoding of an
+ * `ActionPayload` variant into a flat native array (e.g. `['SetYield', 650]`),
+ * not the `{ tag, values }` shape `ActionPayload` expects — reshape it here.
+ */
+function actionPayloadFromNative(raw: unknown): ActionPayload {
+  const [tag, ...values] = raw as [ActionPayload['tag'], ...unknown[]];
+  return { tag, values } as ActionPayload;
+}
+
+function proposalFromScVal(raw: Record<string, unknown>): Proposal {
+  return {
+    role: enumTagFromNative<Role>(raw.role),
+    target: raw.target as StellarAddress,
+    action: actionPayloadFromNative(raw.action),
+    proposer: raw.proposer as StellarAddress,
+    approvals: (raw.approvals as StellarAddress[]) ?? [],
+    createdAt: Number(raw.created_at ?? 0),
+    expiresAt: Number(raw.expires_at ?? 0),
+    status: enumTagFromNative<ProposalStatusRaw>(raw.status) as unknown as Proposal['status'],
+  };
+}
+
+type ProposalStatusRaw = 'Pending' | 'Approved' | 'Executed' | 'Rejected';
+
+export async function getRoleConfig(role: Role): Promise<MultiSigConfig | null> {
+  const sim = await simulateTx(
+    ACCESS_CONTROL_CONTRACT_ID,
+    'get_role_config',
+    [roleToScVal(role)],
+    SIMULATION_SOURCE,
+  );
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  const raw = scValToNative(result!.retval) as Record<string, unknown> | null;
+  if (!raw) return null;
+  return {
+    signers: (raw.signers as StellarAddress[]) ?? [],
+    threshold: Number(raw.threshold ?? 0),
+  };
+}
+
+/** Fetches every role's config in one round-trip, for the admin roles page. */
+export async function listAllRoleConfigs(): Promise<Record<Role, MultiSigConfig | null>> {
+  const entries = await Promise.all(
+    ALL_ROLES.map(async (role) => [role, await getRoleConfig(role)] as const),
+  );
+  return Object.fromEntries(entries) as Record<Role, MultiSigConfig | null>;
+}
+
+export async function isRoleSigner(role: Role, address: string): Promise<boolean> {
+  const sim = await simulateTx(
+    ACCESS_CONTROL_CONTRACT_ID,
+    'is_signer',
+    [roleToScVal(role), new Address(address).toScVal()],
+    SIMULATION_SOURCE,
+  );
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  return Boolean(scValToNative(result!.retval));
+}
+
+export async function getProposal(proposalId: number): Promise<Proposal | null> {
+  const sim = await simulateTx(
+    ACCESS_CONTROL_CONTRACT_ID,
+    'get_proposal',
+    [nativeToScVal(proposalId, { type: 'u64' })],
+    SIMULATION_SOURCE,
+  );
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  const raw = scValToNative(result!.retval) as Record<string, unknown> | null;
+  return raw ? proposalFromScVal(raw) : null;
+}
+
+async function getNextProposalId(): Promise<number> {
+  const sim = await simulateTx(
+    ACCESS_CONTROL_CONTRACT_ID,
+    'get_next_proposal_id',
+    [],
+    SIMULATION_SOURCE,
+  );
+  const result = (sim as StellarRpc.Api.SimulateTransactionSuccessResponse).result;
+  return Number(scValToNative(result!.retval));
+}
+
+/**
+ * Fetches every proposal in `0..getNextProposalId()` — no pagination, since
+ * this governance system is meant for tens of proposals, not thousands.
+ */
+export async function listProposals(): Promise<Array<{ id: number; proposal: Proposal }>> {
+  if (!ACCESS_CONTROL_CONTRACT_ID) return [];
+  const nextId = await getNextProposalId();
+  const results: Array<{ id: number; proposal: Proposal }> = [];
+  for (let id = 0; id < nextId; id++) {
+    const proposal = await getProposal(id);
+    if (proposal) results.push({ id, proposal });
+  }
+  return results;
+}
+
+export async function buildProposeActionTx(params: {
+  role: Role;
+  proposer: string;
+  target: string;
+  action: ActionPayload;
+}): Promise<string> {
+  const account = await getRpcAccount(params.proposer);
+  const contract = new Contract(ACCESS_CONTROL_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK })
+    .addOperation(
+      contract.call(
+        'propose_action',
+        roleToScVal(params.role),
+        new Address(params.proposer).toScVal(),
+        new Address(params.target).toScVal(),
+        actionPayloadToScVal(params.action),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await simulateRpcTransaction(tx);
+  if (StellarRpc.Api.isSimulationError(sim)) {
+    throw new Error(`Simulation failed: ${sim.error}`);
+  }
+  return StellarRpc.assembleTransaction(tx, sim).build().toXDR();
+}
+
+function buildSignerOnlyActionTx(
+  method: 'approve_action' | 'reject_action' | 'revoke_approval',
+): (params: { signer: string; proposalId: number }) => Promise<string> {
+  return async ({ signer, proposalId }) => {
+    const account = await getRpcAccount(signer);
+    const contract = new Contract(ACCESS_CONTROL_CONTRACT_ID);
+
+    const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK })
+      .addOperation(
+        contract.call(
+          method,
+          new Address(signer).toScVal(),
+          nativeToScVal(proposalId, { type: 'u64' }),
+        ),
+      )
+      .setTimeout(30)
+      .build();
+
+    const sim = await simulateRpcTransaction(tx);
+    if (StellarRpc.Api.isSimulationError(sim)) {
+      throw new Error(`Simulation failed: ${sim.error}`);
+    }
+    return StellarRpc.assembleTransaction(tx, sim).build().toXDR();
+  };
+}
+
+export const buildApproveActionTx = buildSignerOnlyActionTx('approve_action');
+export const buildRejectActionTx = buildSignerOnlyActionTx('reject_action');
+export const buildRevokeApprovalTx = buildSignerOnlyActionTx('revoke_approval');
+
+export async function buildExecuteActionTx(params: {
+  caller: string;
+  proposalId: number;
+}): Promise<string> {
+  const account = await getRpcAccount(params.caller);
+  const contract = new Contract(ACCESS_CONTROL_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK })
+    .addOperation(
+      contract.call(
+        'execute_action',
+        new Address(params.caller).toScVal(),
+        nativeToScVal(params.proposalId, { type: 'u64' }),
+      ),
     )
     .setTimeout(30)
     .build();

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -44,6 +44,9 @@ export const COMPLIANCE_CONTRACT_ID = process.env.NEXT_PUBLIC_COMPLIANCE_CONTRAC
 // #799: on-chain referral program — optional, unset until deployed.
 export const REFERRAL_CONTRACT_ID = process.env.NEXT_PUBLIC_REFERRAL_CONTRACT_ID ?? '';
 
+// #864: role-based multisig access-control registry — optional, unset until deployed.
+export const ACCESS_CONTROL_CONTRACT_ID = process.env.NEXT_PUBLIC_ACCESS_CONTROL_CONTRACT_ID ?? '';
+
 export const SHARE_TOKEN_ID = process.env.NEXT_PUBLIC_SHARE_TOKEN_ID ?? '';
 export const USDC_TOKEN_ID = process.env.NEXT_PUBLIC_USDC_TOKEN_ID ?? '';
 export const EURC_TOKEN_ID = process.env.NEXT_PUBLIC_EURC_TOKEN_ID ?? '';

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -307,3 +307,68 @@ export interface ReferralStats {
   referrer: StellarAddress;
   referralCount: number;
 }
+
+// #864: role-based multisig access control
+export type Role =
+  | 'SuperAdmin'
+  | 'RiskManager'
+  | 'TreasuryManager'
+  | 'ComplianceOfficer'
+  | 'OracleManager';
+
+export const ALL_ROLES: Role[] = [
+  'SuperAdmin',
+  'RiskManager',
+  'TreasuryManager',
+  'ComplianceOfficer',
+  'OracleManager',
+];
+
+export const ROLE_LABELS: Record<Role, string> = {
+  SuperAdmin: 'Super Admin',
+  RiskManager: 'Risk Manager',
+  TreasuryManager: 'Treasury Manager',
+  ComplianceOfficer: 'Compliance Officer',
+  OracleManager: 'Oracle Manager',
+};
+
+export interface MultiSigConfig {
+  signers: StellarAddress[];
+  threshold: number;
+}
+
+// Named distinctly from `ProposalStatus` above (governance module) since
+// access-control proposals have a different status lifecycle.
+export type AccessControlProposalStatus = 'Pending' | 'Approved' | 'Executed' | 'Rejected';
+
+/** Mirrors contracts/access_control/src/lib.rs's `ActionPayload` enum. */
+export type ActionPayload =
+  | { tag: 'SetPaused'; values: [boolean] }
+  | { tag: 'SetYield'; values: [number] }
+  | { tag: 'SetTreasury'; values: [string] }
+  | { tag: 'WithdrawRevenue'; values: [string, bigint] }
+  | { tag: 'SetOracleContract'; values: [string] }
+  | { tag: 'SetKycRequired'; values: [boolean] }
+  | { tag: 'SetInvestorKyc'; values: [string, boolean] }
+  | { tag: 'SetMaxUtilization'; values: [number] }
+  | { tag: 'SetOracle'; values: [string] }
+  | { tag: 'RegisterDebtor'; values: [string, string, bigint] }
+  | { tag: 'DeactivateDebtor'; values: [string] }
+  | { tag: 'AddKeeper'; values: [string] }
+  | { tag: 'SetLateThreshold'; values: [bigint] }
+  | { tag: 'SetScoreThresholds'; values: [number, number, number, number] }
+  | { tag: 'RegisterAttestor'; values: [string, number, number] }
+  | { tag: 'AddSigner'; values: [Role, string] }
+  | { tag: 'RemoveSigner'; values: [Role, string] }
+  | { tag: 'SetThreshold'; values: [Role, number] };
+
+export interface Proposal {
+  role: Role;
+  target: StellarAddress;
+  action: ActionPayload;
+  proposer: StellarAddress;
+  approvals: StellarAddress[];
+  createdAt: number;
+  expiresAt: number;
+  status: AccessControlProposalStatus;
+}

--- a/packages/sdk/src/astera-client.ts
+++ b/packages/sdk/src/astera-client.ts
@@ -3,6 +3,7 @@ import { PoolClient } from './clients/pool';
 import { CreditScoreClient } from './clients/credit_score';
 import { OracleRegistryClient } from './clients/oracle_registry';
 import { ComplianceClient } from './clients/compliance';
+import { AccessControlClient } from './clients/access_control';
 import type {
   AsteraConfig,
   Invoice,
@@ -24,6 +25,10 @@ import type {
   RiskTier,
   ComplianceRecord,
   ScreeningHistoryEntry,
+  Role,
+  MultiSigConfig,
+  Proposal,
+  ActionPayload,
 } from './types';
 
 export class AsteraClient {
@@ -32,6 +37,7 @@ export class AsteraClient {
   private creditScoreClient: CreditScoreClient;
   private oracleRegistryClient: OracleRegistryClient;
   private complianceClient: ComplianceClient;
+  private accessControlClient: AccessControlClient;
 
   constructor(config: AsteraConfig) {
     this.invoiceClient = new InvoiceClient({
@@ -58,6 +64,11 @@ export class AsteraClient {
       rpcUrl: config.rpcUrl,
       network: config.network,
       contractId: config.complianceContractId ?? '',
+    });
+    this.accessControlClient = new AccessControlClient({
+      rpcUrl: config.rpcUrl,
+      network: config.network,
+      contractId: config.accessControlContractId ?? '',
     });
   }
 
@@ -331,5 +342,62 @@ export class AsteraClient {
       onProgress?: (progress: TransactionProgress) => void;
     }): Promise<string> =>
       this.complianceClient.requestReview(params),
+  };
+
+  /** #864: role-based multisig access control. */
+  public readonly accessControl = {
+    getRoleConfig: (role: Role): Promise<MultiSigConfig | null> =>
+      this.accessControlClient.getRoleConfig(role),
+
+    isSigner: (role: Role, address: string): Promise<boolean> =>
+      this.accessControlClient.isSigner(role, address),
+
+    getProposal: (proposalId: bigint | number): Promise<Proposal | null> =>
+      this.accessControlClient.getProposal(proposalId),
+
+    listProposals: (): Promise<Array<{ id: bigint; proposal: Proposal }>> =>
+      this.accessControlClient.listProposals(),
+
+    proposeAction: (params: {
+      signer: (txXdr: string) => Promise<string>;
+      role: Role;
+      proposer: string;
+      target: string;
+      action: ActionPayload;
+      onProgress?: (progress: TransactionProgress) => void;
+    }): Promise<string> =>
+      this.accessControlClient.proposeAction(params),
+
+    approveAction: (params: {
+      signer: (txXdr: string) => Promise<string>;
+      signerAddress: string;
+      proposalId: bigint | number;
+      onProgress?: (progress: TransactionProgress) => void;
+    }): Promise<string> =>
+      this.accessControlClient.approveAction(params),
+
+    revokeApproval: (params: {
+      signer: (txXdr: string) => Promise<string>;
+      signerAddress: string;
+      proposalId: bigint | number;
+      onProgress?: (progress: TransactionProgress) => void;
+    }): Promise<string> =>
+      this.accessControlClient.revokeApproval(params),
+
+    rejectAction: (params: {
+      signer: (txXdr: string) => Promise<string>;
+      signerAddress: string;
+      proposalId: bigint | number;
+      onProgress?: (progress: TransactionProgress) => void;
+    }): Promise<string> =>
+      this.accessControlClient.rejectAction(params),
+
+    executeAction: (params: {
+      signer: (txXdr: string) => Promise<string>;
+      caller: string;
+      proposalId: bigint | number;
+      onProgress?: (progress: TransactionProgress) => void;
+    }): Promise<string> =>
+      this.accessControlClient.executeAction(params),
   };
 }

--- a/packages/sdk/src/clients/access_control.ts
+++ b/packages/sdk/src/clients/access_control.ts
@@ -1,0 +1,303 @@
+import { rpc as StellarRpc } from '@stellar/stellar-sdk';
+import { BaseClient, nativeToScVal, scValToNative, Address, xdr } from './base';
+import type {
+  ClientConfig,
+  Signer,
+  TransactionProgress,
+  Role,
+  MultiSigConfig,
+  ProposalStatus,
+  ActionPayload,
+  Proposal,
+} from '../types';
+
+function roleToScVal(role: Role): xdr.ScVal {
+  return xdr.ScVal.scvVec([nativeToScVal(role, { type: 'symbol' })]);
+}
+
+function roleFromNative(raw: unknown): Role {
+  // A unit-variant contracttype enum decodes to either the bare tag string
+  // or a one-element array wrapping it, depending on SDK version — handle
+  // both so this doesn't silently break on a minor @stellar/stellar-sdk bump.
+  if (Array.isArray(raw)) return raw[0] as Role;
+  return raw as Role;
+}
+
+/**
+ * `scValToNative` decodes our `[tag, ...fields]` vec encoding of an
+ * `ActionPayload` variant into a flat native array (e.g. `['SetYield', 650]`),
+ * not the `{ tag, values }` shape `ActionPayload` expects — reshape it here.
+ */
+function actionPayloadFromNative(raw: unknown): ActionPayload {
+  const [tag, ...values] = raw as [ActionPayload['tag'], ...unknown[]];
+  return { tag, values } as ActionPayload;
+}
+
+/**
+ * Encodes an `ActionPayload` (mirrors contracts/access_control/src/lib.rs's
+ * `ActionPayload` enum) into the ScVal shape Soroban expects for a Rust
+ * `#[contracttype]` enum-with-payload: a Vec whose first element is the
+ * variant name (Symbol) followed by the variant's fields in declaration
+ * order.
+ */
+function actionPayloadToScVal(action: ActionPayload): xdr.ScVal {
+  const tag = nativeToScVal(action.tag, { type: 'symbol' });
+  switch (action.tag) {
+    case 'SetPaused':
+    case 'SetKycRequired': {
+      const [paused] = action.values;
+      return xdr.ScVal.scvVec([tag, nativeToScVal(paused, { type: 'bool' })]);
+    }
+    case 'SetYield':
+    case 'SetMaxUtilization': {
+      const [bps] = action.values;
+      return xdr.ScVal.scvVec([tag, nativeToScVal(bps, { type: 'u32' })]);
+    }
+    case 'SetTreasury':
+    case 'SetOracleContract':
+    case 'SetOracle':
+    case 'AddKeeper': {
+      const [address] = action.values;
+      return xdr.ScVal.scvVec([tag, new Address(address).toScVal()]);
+    }
+    case 'WithdrawRevenue': {
+      const [token, amount] = action.values;
+      return xdr.ScVal.scvVec([
+        tag,
+        new Address(token).toScVal(),
+        nativeToScVal(amount, { type: 'i128' }),
+      ]);
+    }
+    case 'SetInvestorKyc': {
+      const [investor, approved] = action.values;
+      return xdr.ScVal.scvVec([
+        tag,
+        new Address(investor).toScVal(),
+        nativeToScVal(approved, { type: 'bool' }),
+      ]);
+    }
+    case 'RegisterDebtor': {
+      const [debtorId, debtorName, maxExposure] = action.values;
+      return xdr.ScVal.scvVec([
+        tag,
+        nativeToScVal(debtorId, { type: 'string' }),
+        nativeToScVal(debtorName, { type: 'string' }),
+        nativeToScVal(maxExposure, { type: 'i128' }),
+      ]);
+    }
+    case 'DeactivateDebtor': {
+      const [debtorId] = action.values;
+      return xdr.ScVal.scvVec([tag, nativeToScVal(debtorId, { type: 'string' })]);
+    }
+    case 'SetLateThreshold': {
+      const [days] = action.values;
+      return xdr.ScVal.scvVec([tag, nativeToScVal(days, { type: 'i64' })]);
+    }
+    case 'SetScoreThresholds': {
+      const [excellent, veryGood, good, fair] = action.values;
+      return xdr.ScVal.scvVec([
+        tag,
+        nativeToScVal(excellent, { type: 'u32' }),
+        nativeToScVal(veryGood, { type: 'u32' }),
+        nativeToScVal(good, { type: 'u32' }),
+        nativeToScVal(fair, { type: 'u32' }),
+      ]);
+    }
+    case 'RegisterAttestor': {
+      const [address, attestorType, weightBps] = action.values;
+      return xdr.ScVal.scvVec([
+        tag,
+        new Address(address).toScVal(),
+        nativeToScVal(attestorType, { type: 'u32' }),
+        nativeToScVal(weightBps, { type: 'u32' }),
+      ]);
+    }
+    case 'AddSigner':
+    case 'RemoveSigner': {
+      const [role, address] = action.values;
+      return xdr.ScVal.scvVec([tag, roleToScVal(role), new Address(address).toScVal()]);
+    }
+    case 'SetThreshold': {
+      const [role, threshold] = action.values;
+      return xdr.ScVal.scvVec([tag, roleToScVal(role), nativeToScVal(threshold, { type: 'u32' })]);
+    }
+  }
+}
+
+export class AccessControlClient extends BaseClient {
+  constructor(config: ClientConfig) {
+    super(config);
+  }
+
+  async initialize(params: {
+    signer: Signer;
+    superAdminSigners: string[];
+    superAdminThreshold: number;
+    proposalExpirySecs: number;
+    onProgress?: (progress: TransactionProgress) => void;
+  }): Promise<string> {
+    const source = params.superAdminSigners[0];
+    return this.buildAndSendTx(
+      source,
+      'initialize',
+      [
+        xdr.ScVal.scvVec(params.superAdminSigners.map((a) => new Address(a).toScVal())),
+        nativeToScVal(params.superAdminThreshold, { type: 'u32' }),
+        nativeToScVal(params.proposalExpirySecs, { type: 'u64' }),
+      ],
+      params.onProgress,
+    );
+  }
+
+  async getRoleConfig(role: Role): Promise<MultiSigConfig | null> {
+    const result = await this.simulate('get_role_config', [roleToScVal(role)]);
+    if (StellarRpc.Api.isSimulationError(result)) {
+      throw new Error(`Simulation failed: ${result.error}`);
+    }
+    const raw = scValToNative(result.result!.retval) as Record<string, unknown> | null;
+    if (!raw) return null;
+    return {
+      signers: (raw.signers as string[]) ?? [],
+      threshold: Number(raw.threshold ?? 0),
+    };
+  }
+
+  async isSigner(role: Role, address: string): Promise<boolean> {
+    const result = await this.simulate('is_signer', [roleToScVal(role), new Address(address).toScVal()]);
+    if (StellarRpc.Api.isSimulationError(result)) {
+      throw new Error(`Simulation failed: ${result.error}`);
+    }
+    return Boolean(scValToNative(result.result!.retval));
+  }
+
+  /** One past the highest issued proposal id — proposals exist for `0..getNextProposalId()`. */
+  async getNextProposalId(): Promise<bigint> {
+    const result = await this.simulate('get_next_proposal_id', []);
+    if (StellarRpc.Api.isSimulationError(result)) {
+      throw new Error(`Simulation failed: ${result.error}`);
+    }
+    return BigInt(scValToNative(result.result!.retval) as bigint | number);
+  }
+
+  /**
+   * Fetches every proposal id in `0..getNextProposalId()`, for a simple
+   * admin-page proposal queue. Not paginated — fine for the scale this
+   * governance system is meant for (tens, not thousands, of proposals).
+   */
+  async listProposals(): Promise<Array<{ id: bigint; proposal: Proposal }>> {
+    const nextId = await this.getNextProposalId();
+    const results: Array<{ id: bigint; proposal: Proposal }> = [];
+    for (let id = 0n; id < nextId; id += 1n) {
+      const proposal = await this.getProposal(id);
+      if (proposal) results.push({ id, proposal });
+    }
+    return results;
+  }
+
+  async getProposal(proposalId: bigint | number): Promise<Proposal | null> {
+    const result = await this.simulate('get_proposal', [
+      nativeToScVal(proposalId, { type: 'u64' }),
+    ]);
+    if (StellarRpc.Api.isSimulationError(result)) {
+      throw new Error(`Simulation failed: ${result.error}`);
+    }
+    const raw = scValToNative(result.result!.retval) as Record<string, unknown> | null;
+    if (!raw) return null;
+    return {
+      role: roleFromNative(raw.role),
+      target: raw.target as string,
+      action: actionPayloadFromNative(raw.action),
+      proposer: raw.proposer as string,
+      approvals: (raw.approvals as string[]) ?? [],
+      createdAt: BigInt((raw.created_at as bigint | number | string) ?? 0),
+      expiresAt: BigInt((raw.expires_at as bigint | number | string) ?? 0),
+      status: roleFromNative(raw.status) as unknown as ProposalStatus,
+    };
+  }
+
+  async proposeAction(params: {
+    signer: Signer;
+    role: Role;
+    proposer: string;
+    target: string;
+    action: ActionPayload;
+    onProgress?: (progress: TransactionProgress) => void;
+  }): Promise<string> {
+    return this.buildAndSendTx(
+      params.proposer,
+      'propose_action',
+      [
+        roleToScVal(params.role),
+        new Address(params.proposer).toScVal(),
+        new Address(params.target).toScVal(),
+        actionPayloadToScVal(params.action),
+      ],
+      params.onProgress,
+    );
+  }
+
+  async approveAction(params: {
+    signer: Signer;
+    signerAddress: string;
+    proposalId: bigint | number;
+    onProgress?: (progress: TransactionProgress) => void;
+  }): Promise<string> {
+    return this.buildAndSendTx(
+      params.signerAddress,
+      'approve_action',
+      [
+        new Address(params.signerAddress).toScVal(),
+        nativeToScVal(params.proposalId, { type: 'u64' }),
+      ],
+      params.onProgress,
+    );
+  }
+
+  async revokeApproval(params: {
+    signer: Signer;
+    signerAddress: string;
+    proposalId: bigint | number;
+    onProgress?: (progress: TransactionProgress) => void;
+  }): Promise<string> {
+    return this.buildAndSendTx(
+      params.signerAddress,
+      'revoke_approval',
+      [
+        new Address(params.signerAddress).toScVal(),
+        nativeToScVal(params.proposalId, { type: 'u64' }),
+      ],
+      params.onProgress,
+    );
+  }
+
+  async rejectAction(params: {
+    signer: Signer;
+    signerAddress: string;
+    proposalId: bigint | number;
+    onProgress?: (progress: TransactionProgress) => void;
+  }): Promise<string> {
+    return this.buildAndSendTx(
+      params.signerAddress,
+      'reject_action',
+      [
+        new Address(params.signerAddress).toScVal(),
+        nativeToScVal(params.proposalId, { type: 'u64' }),
+      ],
+      params.onProgress,
+    );
+  }
+
+  async executeAction(params: {
+    signer: Signer;
+    caller: string;
+    proposalId: bigint | number;
+    onProgress?: (progress: TransactionProgress) => void;
+  }): Promise<string> {
+    return this.buildAndSendTx(
+      params.caller,
+      'execute_action',
+      [new Address(params.caller).toScVal(), nativeToScVal(params.proposalId, { type: 'u64' })],
+      params.onProgress,
+    );
+  }
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -141,6 +141,75 @@ export interface AsteraConfig {
   creditScoreContractId?: string;
   oracleRegistryContractId?: string;
   complianceContractId?: string;
+  /** #864: role-based multisig access-control contract, if deployed. */
+  accessControlContractId?: string;
+}
+
+// ─── #864: role-based multisig access control ──────────────────────────────
+// Mirrors contracts/access_control/src/lib.rs's public types.
+
+export type Role =
+  | 'SuperAdmin'
+  | 'RiskManager'
+  | 'TreasuryManager'
+  | 'ComplianceOfficer'
+  | 'OracleManager';
+
+export const ALL_ROLES: Role[] = [
+  'SuperAdmin',
+  'RiskManager',
+  'TreasuryManager',
+  'ComplianceOfficer',
+  'OracleManager',
+];
+
+/** Human-readable label for one of the five fixed roles, for admin UI. */
+export const ROLE_LABELS: Record<Role, string> = {
+  SuperAdmin: 'Super Admin',
+  RiskManager: 'Risk Manager',
+  TreasuryManager: 'Treasury Manager',
+  ComplianceOfficer: 'Compliance Officer',
+  OracleManager: 'Oracle Manager',
+};
+
+export interface MultiSigConfig {
+  signers: string[];
+  threshold: number;
+}
+
+export type ProposalStatus = 'Pending' | 'Approved' | 'Executed' | 'Rejected';
+
+// Mirrors contracts/access_control/src/lib.rs's `ActionPayload` enum. Each
+// variant's `values` tuple matches that Rust variant's fields in order.
+export type ActionPayload =
+  | { tag: 'SetPaused'; values: [boolean] }
+  | { tag: 'SetYield'; values: [number] }
+  | { tag: 'SetTreasury'; values: [string] }
+  | { tag: 'WithdrawRevenue'; values: [string, bigint] }
+  | { tag: 'SetOracleContract'; values: [string] }
+  | { tag: 'SetKycRequired'; values: [boolean] }
+  | { tag: 'SetInvestorKyc'; values: [string, boolean] }
+  | { tag: 'SetMaxUtilization'; values: [number] }
+  | { tag: 'SetOracle'; values: [string] }
+  | { tag: 'RegisterDebtor'; values: [string, string, bigint] }
+  | { tag: 'DeactivateDebtor'; values: [string] }
+  | { tag: 'AddKeeper'; values: [string] }
+  | { tag: 'SetLateThreshold'; values: [bigint] }
+  | { tag: 'SetScoreThresholds'; values: [number, number, number, number] }
+  | { tag: 'RegisterAttestor'; values: [string, number, number] }
+  | { tag: 'AddSigner'; values: [Role, string] }
+  | { tag: 'RemoveSigner'; values: [Role, string] }
+  | { tag: 'SetThreshold'; values: [Role, number] };
+
+export interface Proposal {
+  role: Role;
+  target: string;
+  action: ActionPayload;
+  proposer: string;
+  approvals: string[];
+  createdAt: bigint;
+  expiresAt: bigint;
+  status: ProposalStatus;
 }
 
 export type ComplianceStatus =

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -24,4 +24,10 @@ export type {
   RiskTier,
   ComplianceRecord,
   ScreeningHistoryEntry,
+  Role,
+  MultiSigConfig,
+  ProposalStatus,
+  ActionPayload,
+  Proposal,
 } from '../../packages/sdk/src/types';
+export { ALL_ROLES, ROLE_LABELS } from '../../packages/sdk/src/types';

--- a/sdk/src/generated/access_control.ts
+++ b/sdk/src/generated/access_control.ts
@@ -1,0 +1,23 @@
+// #864: mirrors contracts/access_control/src/lib.rs's `AccessControlError`
+// #[contracterror] enum so JS consumers can decode/report the same codes.
+export const Errors = {
+  0: { message: 'AlreadyInitialized' },
+  1: { message: 'NotInitialized' },
+  2: { message: 'NotASigner' },
+  3: { message: 'AlreadyApproved' },
+  4: { message: 'ThresholdNotMet' },
+  5: { message: 'ProposalNotFound' },
+  6: { message: 'ProposalExpired' },
+  7: { message: 'ProposalNotPending' },
+  8: { message: 'ProposalNotApproved' },
+  9: { message: 'InvalidThreshold' },
+  10: { message: 'DuplicateSigner' },
+  11: { message: 'RoleNotConfigured' },
+  12: { message: 'SelfManagementRequiresSuperAdmin' },
+  13: { message: 'InvalidExpiryWindow' },
+  14: { message: 'SignerNotFound' },
+  15: { message: 'NoApprovalToRevoke' },
+} as const;
+
+export type AccessControlErrorCode = keyof typeof Errors;
+export type AccessControlErrorMessage = (typeof Errors)[AccessControlErrorCode]['message'];

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -7,4 +7,5 @@ export { Errors as CreditScoreErrors } from './generated/credit_score';
 export { GovernanceError } from './generated/governance';
 export { Errors as OracleRegistryErrors } from './generated/oracle_registry';
 export { Errors as ComplianceErrors } from './generated/compliance';
+export { Errors as AccessControlErrors } from './generated/access_control';
 export * from './events';


### PR DESCRIPTION
## Summary

Closes #864. Adds a role-based multisig access-control system so that sensitive admin actions on `pool`, `invoice`, and `credit_score` require N-of-M signer approval instead of a single admin key.

- New `access_control` contract crate: per-role signer sets + threshold, `propose_action` → `approve_action`/`reject_action`/`revoke_approval` → `execute_action` lifecycle (CEI: status flips to `Executed` before the cross-contract call).
- `pool`, `invoice`, `credit_score` each gain `*_via_ac` entrypoints that route the corresponding admin action through the multisig instead of a raw admin signature. (Suffixed `_via_ac`, not `_via_access_control`, because Soroban caps exported function names at 32 chars.)
- SDK bindings added in `packages/sdk/src/clients/access_control.ts` and the `sdk/` public re-export layer.
- Frontend: new `/admin/roles` page (propose/approve/reject/revoke/execute UI, per-role signer + threshold display), nav entry, and a Playwright spec (`e2e/admin-roles.spec.ts`) driving a full two-wallet propose→approve→execute flow against a purpose-built Soroban RPC mock (`e2e/mocks/soroban-access-control.ts`).

## Bug fixed along the way

`scValToNative` decodes a Soroban tuple-variant enum (e.g. `ActionPayload::SetYield(650)`) into a flat array (`['SetYield', 650]`), not the `{ tag, values }` shape the TS `ActionPayload` union expects. Both `frontend/lib/contracts.ts` and `packages/sdk/src/clients/access_control.ts` now reshape it via a small `actionPayloadFromNative` helper instead of an unchecked cast.

## Pre-existing issues found, NOT fixed here (out of scope, flagging for visibility)

While building and trying to get the new Playwright spec to run live, I hit three separate, pre-existing problems unrelated to this change:

1. **`next build` is broken on `main`** — `app/invoice/new/page.tsx` has a duplicate `toStroops` import, plus missing `GlossaryTerm`/`BorrowerCreditBadge` components and a `useSearchParams` typo. Confirmed via `git stash` that I never touched this file.
2. **CSP blocks Playwright's `addInitScript` on every admin e2e spec.** `next.config.mjs`'s `Content-Security-Policy: script-src 'self' 'unsafe-eval'` (no `unsafe-inline`/nonce) rejects the inline `<script>` Playwright injects for Freighter mocking. Reproduced identically on the existing, unmodified `admin-oracles.spec.ts` — this isn't specific to my new spec.
3. **Checksum-invalid placeholder address.** The read-only "simulation source" address hardcoded ~40+ times in `lib/contracts.ts` (`GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN`) fails `StrKey` validation, so `Server.getAccount()` throws synchronously before any network call — breaking `useAdminGuard`/`getPoolConfig()` (and thus every `/admin/*` page) whenever `NEXT_PUBLIC_USE_MOCK` isn't set. I didn't fix this broadly since it's referenced literally in existing test fixtures (`__tests__/lib/analytics.test.ts`, `__tests__/components/TopSmesTable.test.tsx`) and a safe replacement needs a real funded testnet address.

Because of (1)–(3), I could not get a live, click-through Playwright run of the new spec locally (it stalled behind an apparent redirect loop after disabling CSP + bypassing the guard for a local-only test, which I did not chase further). The mock's encode/decode logic and the tx-builder round trips were verified manually against the real `@stellar/stellar-sdk` XDR types instead. `tsc --noEmit` is clean (zero new errors vs. the pre-existing baseline) and 37 Rust tests pass across the touched contracts.

## Test plan

- [x] `cargo test` across `access_control`, `pool`, `invoice`, `credit_score` (37 tests passing)
- [x] `npx tsc --noEmit` in `frontend/` — zero new errors vs. pre-existing baseline
- [x] `packages/sdk` typechecks cleanly
- [ ] Live Playwright run of `e2e/admin-roles.spec.ts` — blocked by the pre-existing CSP/build issues above; logic verified manually instead
- [ ] Maintainer review of whether items 1–3 above should be split into separate follow-up issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)