### PR TITLE
fix(oracle): retry backoff, pause handling, staking metrics, and listener checkpointing

### DIFF
--- a/oracle-service/README.md
+++ b/oracle-service/README.md
@@ -33,6 +33,7 @@ This service can run in one of two modes, selected purely by whether
 | `ORACLE_REGISTRY_CONTRACT_ID` | no | Enables consensus mode when set |
 | `STAKE_TOKEN_ID` | no | Informational only — the actual stake token is whatever the registry was `initialize`d with |
 | `REGISTER_STAKE_AMOUNT` | only for `--register` | Stake amount (in the registry's stake token's smallest unit) to deposit when registering |
+| `LISTENER_CURSOR_PATH` | no | File where the listener persists the last-processed Horizon paging token, so a restart resumes the stream instead of re-scanning from `now` (default `.oracle-listener-cursor`) |
 
 ## Registering as an oracle (consensus mode)
 
@@ -55,6 +56,17 @@ On every normal startup (without `--register`), if
 `ORACLE_REGISTRY_CONTRACT_ID` is set the service checks this node's
 registration/stake and logs a warning if it isn't an active registered
 oracle yet (its votes would otherwise silently fail with `NotRegistered`).
+
+In consensus mode, a `/metrics` endpoint reports this operator's current
+stake, `deregister_oracle` cooldown status (if a deregistration is pending),
+and recent `slash_oracle` events against this node — without needing to
+query the chain directly.
+
+If the registry is paused (`pause()`/`is_paused`), the node stops attempting
+`open_verification_round`/`submit_vote` calls as soon as it observes the
+`paused` event (or hits a `ContractPaused` failure directly) and resumes
+automatically once it sees `unpaused`, instead of repeatedly hitting and
+logging the same failure for every new invoice.
 
 ## Running 3+ local nodes for consensus testing
 
@@ -100,10 +112,16 @@ on the same round outcome.
 - `index.ts` — startup, config, health server, mode selection
 - `listener.ts` — streams Horizon effects for both the invoice contract
   (`created` events) and, in consensus mode, the registry contract's
-  `ORACLE` topic events
+  `ORACLE` topic events; persists the last-processed paging token
+  (`LISTENER_CURSOR_PATH`) so a restart resumes the stream rather than
+  missing events or resubmitting votes
 - `verifier.ts` — fetches invoice data, runs the (currently mocked) document
-  check, and submits this node's verdict via whichever mode is active
-- `consensus.ts` — in-memory tracker of `VerificationRound` status per
-  invoice, fed by `listener.ts`, exposed via `/health`
-- `staking.ts` — startup stake check + the `--register` CLI flow
-- `retry.ts` — exponential backoff shared by both verification paths
+  check, and submits this node's verdict via whichever mode is active;
+  skips submission while the registry is paused
+- `consensus.ts` — in-memory tracker of `VerificationRound` status and
+  registry pause state per invoice, fed by `listener.ts`, exposed via
+  `/health`
+- `staking.ts` — startup stake check, the `--register` CLI flow, and the
+  `/metrics` stake/cooldown/slash snapshot
+- `retry.ts` — capped exponential backoff with jitter, shared by both
+  verification paths

--- a/oracle-service/src/consensus.ts
+++ b/oracle-service/src/consensus.ts
@@ -19,6 +19,7 @@ export interface TrackedRound {
 export class ConsensusTracker {
   private rounds = new Map<string, TrackedRound>();
   private votedByMe = new Set<string>();
+  private paused = false;
 
   constructor(private readonly oraclePublicKey: string) {}
 
@@ -26,6 +27,14 @@ export class ConsensusTracker {
    * event emitted under the registry contract's "ORACLE" topic namespace. */
   handleEvent(topic2: string, value: unknown): void {
     switch (topic2) {
+      case 'paused': {
+        this.paused = true;
+        break;
+      }
+      case 'unpaused': {
+        this.paused = false;
+        break;
+      }
       case 'rnd_open': {
         const [invoiceId] = asArray(value);
         this.upsert(String(invoiceId), 'Open');
@@ -63,6 +72,21 @@ export class ConsensusTracker {
    * re-voting after a restart rather than eating an `AlreadyVoted` error. */
   hasVoted(invoiceId: bigint | string): boolean {
     return this.votedByMe.has(String(invoiceId));
+  }
+
+  /** Whether the registry is currently paused, per the last observed
+   * `paused`/`unpaused` event — used to skip vote submission instead of
+   * hitting (and immediately retrying) a `ContractPaused` failure. */
+  isPaused(): boolean {
+    return this.paused;
+  }
+
+  /** Marks the registry as paused directly, for when a `submit_vote`/
+   * `open_verification_round` call fails with `ContractPaused` before this
+   * node has observed the corresponding `paused` event (e.g. a race on
+   * startup, or a missed event). */
+  markPaused(): void {
+    this.paused = true;
   }
 
   isOpen(invoiceId: bigint | string): boolean {

--- a/oracle-service/src/index.ts
+++ b/oracle-service/src/index.ts
@@ -5,7 +5,7 @@ import { AsteraClient } from 'astera-sdk';
 import { Listener } from './listener';
 import { Verifier } from './verifier';
 import { ConsensusTracker } from './consensus';
-import { checkStakeOnStartup, registerIfRequested } from './staking';
+import { checkStakeOnStartup, registerIfRequested, getStakingMetrics, StakingMetricsTracker } from './staking';
 import { OracleConfig } from './types';
 
 dotenv.config();
@@ -24,6 +24,7 @@ const config: OracleConfig = {
   registerStakeAmount: process.env.REGISTER_STAKE_AMOUNT
     ? BigInt(process.env.REGISTER_STAKE_AMOUNT)
     : undefined,
+  listenerCursorPath: process.env.LISTENER_CURSOR_PATH || '.oracle-listener-cursor',
 };
 
 async function main() {
@@ -64,9 +65,10 @@ async function main() {
     process.exit(0);
   }
 
+  let registryClient: AsteraClient | undefined;
   if (config.oracleRegistryContractId) {
     console.log(`Running as a consensus-network oracle node (registry: ${config.oracleRegistryContractId})`);
-    const registryClient = new AsteraClient({
+    registryClient = new AsteraClient({
       rpcUrl: config.rpcUrl,
       network: config.networkPassphrase,
       invoiceContractId: config.invoiceContractId,
@@ -81,8 +83,13 @@ async function main() {
   const consensusTracker = config.oracleRegistryContractId
     ? new ConsensusTracker(oracleKeypair.publicKey())
     : undefined;
-  const verifier = new Verifier(config);
-  const listener = new Listener(config, verifier, consensusTracker);
+  // #979: tracks this node's own slash events so `/metrics` can report them
+  // without querying the chain directly.
+  const stakingTracker = config.oracleRegistryContractId
+    ? new StakingMetricsTracker(oracleKeypair.publicKey())
+    : undefined;
+  const verifier = new Verifier(config, consensusTracker);
+  const listener = new Listener(config, verifier, consensusTracker, stakingTracker);
   const healthPort = parseInt(process.env.HEALTH_PORT || '8080', 10);
   const server = http.createServer((req, res) => {
     if (req.url === '/health') {
@@ -95,6 +102,26 @@ async function main() {
           rounds: consensusTracker?.list() ?? undefined,
         }),
       );
+      return;
+    }
+
+    // #979: on-demand stake/cooldown/slash status for this operator, so they
+    // don't have to query the chain directly to check on their own node.
+    if (req.url === '/metrics') {
+      if (!registryClient || !stakingTracker) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'not_found', reason: 'ORACLE_REGISTRY_CONTRACT_ID not set' }));
+        return;
+      }
+      getStakingMetrics(registryClient, oracleKeypair.publicKey(), stakingTracker)
+        .then((metrics) => {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(metrics));
+        })
+        .catch((error) => {
+          res.writeHead(502, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'error', error: String(error) }));
+        });
       return;
     }
 

--- a/oracle-service/src/listener.ts
+++ b/oracle-service/src/listener.ts
@@ -1,19 +1,28 @@
+import * as fs from 'fs';
 import { Horizon, xdr, scValToNative } from '@stellar/stellar-sdk';
 import { OracleConfig } from './types';
 import { Verifier } from './verifier';
 import { ConsensusTracker } from './consensus';
+import { StakingMetricsTracker } from './staking';
 
 export class Listener {
   private config: OracleConfig;
   private verifier: Verifier;
   private horizon: Horizon.Server;
   private consensusTracker?: ConsensusTracker;
+  private stakingTracker?: StakingMetricsTracker;
   public processedCount = 0;
 
-  constructor(config: OracleConfig, verifier: Verifier, consensusTracker?: ConsensusTracker) {
+  constructor(
+    config: OracleConfig,
+    verifier: Verifier,
+    consensusTracker?: ConsensusTracker,
+    stakingTracker?: StakingMetricsTracker,
+  ) {
     this.config = config;
     this.verifier = verifier;
     this.consensusTracker = consensusTracker;
+    this.stakingTracker = stakingTracker;
     this.horizon = new Horizon.Server(config.horizonUrl);
   }
 
@@ -25,18 +34,46 @@ export class Listener {
       console.log(`[Listener] Oracle registry contract: ${this.config.oracleRegistryContractId}`);
     }
 
-    // Subscribe to contract effects (which include events)
-    // Note: In a production environment, you should persist the cursor to resume after restart.
+    // #980: resume from the last successfully processed ledger position
+    // instead of always starting from 'now', so a restart neither misses
+    // events that occurred while the service was down nor resubmits
+    // already-processed votes by guessing at a lookback window.
+    const cursor = this.loadCursor();
+    console.log(`[Listener] Starting stream from cursor: ${cursor}`);
+
     this.horizon.effects()
-      .cursor('now')
+      .cursor(cursor)
       .stream({
         onmessage: (effect: any) => {
           this.handleEffect(effect);
+          if (effect.paging_token) {
+            this.saveCursor(effect.paging_token);
+          }
         },
         onerror: (error: any) => {
           console.error('[Listener] Stream error:', error);
         }
       });
+  }
+
+  private loadCursor(): string {
+    try {
+      const saved = fs.readFileSync(this.config.listenerCursorPath, 'utf-8').trim();
+      if (saved) {
+        return saved;
+      }
+    } catch {
+      // No checkpoint file yet (first run, or it was deleted) — start fresh.
+    }
+    return 'now';
+  }
+
+  private saveCursor(pagingToken: string): void {
+    try {
+      fs.writeFileSync(this.config.listenerCursorPath, pagingToken, 'utf-8');
+    } catch (error) {
+      console.error('[Listener] Failed to persist stream cursor:', error);
+    }
   }
 
   private handleEffect(effect: any) {
@@ -90,9 +127,12 @@ export class Listener {
       // #861: forward every event under the registry's "ORACLE" topic
       // namespace to the consensus tracker so the health endpoint can report
       // live round state without a separate polling loop.
-      if (segment1 === 'ORACLE' && this.consensusTracker) {
+      if (segment1 === 'ORACLE') {
         const value = this.decodeScVal(valueXdr);
-        this.consensusTracker.handleEvent(segment2, value);
+        this.consensusTracker?.handleEvent(segment2, value);
+        // #979: also forward to the staking metrics tracker, which filters
+        // for `slashed` events concerning this node's own oracle address.
+        this.stakingTracker?.handleEvent(segment2, value, effect.created_at);
       }
     } catch (error) {
       console.error('[Listener] Failed to process effect:', error);

--- a/oracle-service/src/retry.ts
+++ b/oracle-service/src/retry.ts
@@ -13,11 +13,13 @@ export function isRetriableError(error: unknown): boolean {
 export interface RetryOptions {
   maxAttempts: number;
   baseDelayMs: number;
+  maxDelayMs: number;
 }
 
 const DEFAULT_OPTIONS: RetryOptions = {
   maxAttempts: 3,
   baseDelayMs: 2000,
+  maxDelayMs: 30_000,
 };
 
 export async function retryWithBackoff<T>(
@@ -25,7 +27,7 @@ export async function retryWithBackoff<T>(
   context: string,
   options: Partial<RetryOptions> = {},
 ): Promise<T> {
-  const { maxAttempts, baseDelayMs } = { ...DEFAULT_OPTIONS, ...options };
+  const { maxAttempts, baseDelayMs, maxDelayMs } = { ...DEFAULT_OPTIONS, ...options };
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -40,7 +42,12 @@ export async function retryWithBackoff<T>(
       }
 
       if (attempt < maxAttempts) {
-        const delay = baseDelayMs * Math.pow(2, attempt - 1);
+        // Exponential backoff capped at `maxDelayMs`, with full jitter (a
+        // random wait between 0 and the capped delay) so that during a
+        // sustained outage, many oracle nodes retrying the same endpoint
+        // don't all land on the same fixed schedule and hammer it in lockstep.
+        const exponentialDelay = Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs);
+        const delay = Math.floor(Math.random() * exponentialDelay);
         console.warn(
           `[Retry] ${context} failed (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms: ${err.message}`,
         );

--- a/oracle-service/src/staking.ts
+++ b/oracle-service/src/staking.ts
@@ -2,6 +2,118 @@ import { Keypair, TransactionBuilder } from '@stellar/stellar-sdk';
 import { AsteraClient } from 'astera-sdk';
 import { OracleConfig } from './types';
 
+export interface SlashRecord {
+  bps: number;
+  slashAmount: string;
+  admin: string;
+  occurredAt?: string;
+}
+
+const MAX_RECENT_SLASHES = 20;
+
+/**
+ * #979: tracks `slash_oracle` events (from `slashed` events streamed by
+ * `listener.ts`) for this node's own oracle address, so the metrics endpoint
+ * can report recent slashes without a persisted database — mirrors
+ * `ConsensusTracker`'s approach of deriving in-memory state purely from the
+ * event stream.
+ */
+export class StakingMetricsTracker {
+  private recentSlashes: SlashRecord[] = [];
+
+  constructor(private readonly oraclePublicKey: string) {}
+
+  /** Call with the decoded `(topic1, topic2)` pair, event value, and (if
+   * available) the effect's `created_at` timestamp for every event emitted
+   * under the registry contract's "ORACLE" topic namespace. */
+  handleEvent(topic2: string, value: unknown, occurredAt?: string): void {
+    if (topic2 !== 'slashed') {
+      return;
+    }
+    const [operator, bps, slashAmount] = Array.isArray(value) ? value : [value];
+    if (String(operator) !== this.oraclePublicKey) {
+      return;
+    }
+    const admin = Array.isArray(value) ? value[3] : undefined;
+    this.recentSlashes.unshift({
+      bps: Number(bps),
+      slashAmount: String(slashAmount),
+      admin: String(admin),
+      occurredAt,
+    });
+    this.recentSlashes.length = Math.min(this.recentSlashes.length, MAX_RECENT_SLASHES);
+  }
+
+  list(): SlashRecord[] {
+    return [...this.recentSlashes];
+  }
+}
+
+export interface DeregisterCooldown {
+  requestedAt: number;
+  cooldownSecs: number;
+  readyAt: number;
+  remainingSecs: number;
+}
+
+export interface StakingMetrics {
+  oracle: string;
+  registered: boolean;
+  stakeAmount: string;
+  totalVerifications: number;
+  totalSlashes: number;
+  deregisterCooldown: DeregisterCooldown | null;
+  recentSlashes: SlashRecord[];
+}
+
+/**
+ * #979: exposes this operator's own stake/cooldown/slash status — the same
+ * data `checkStakeOnStartup` fetches once at boot — as an on-demand snapshot
+ * for the health/metrics endpoint, so operators don't have to query the chain
+ * directly to check on their node.
+ */
+export async function getStakingMetrics(
+  client: AsteraClient,
+  oraclePublicKey: string,
+  tracker: StakingMetricsTracker,
+): Promise<StakingMetrics> {
+  const info = await client.oracleRegistry.getOracleInfo(oraclePublicKey);
+  if (!info) {
+    return {
+      oracle: oraclePublicKey,
+      registered: false,
+      stakeAmount: '0',
+      totalVerifications: 0,
+      totalSlashes: 0,
+      deregisterCooldown: null,
+      recentSlashes: tracker.list(),
+    };
+  }
+
+  let deregisterCooldown: DeregisterCooldown | null = null;
+  if (info.deregisterRequestedAt !== undefined) {
+    const registryConfig = await client.oracleRegistry.getRegistryConfig();
+    const readyAt = info.deregisterRequestedAt + registryConfig.deregisterCooldownSecs;
+    const nowSecs = Math.floor(Date.now() / 1000);
+    deregisterCooldown = {
+      requestedAt: info.deregisterRequestedAt,
+      cooldownSecs: registryConfig.deregisterCooldownSecs,
+      readyAt,
+      remainingSecs: Math.max(0, readyAt - nowSecs),
+    };
+  }
+
+  return {
+    oracle: oraclePublicKey,
+    registered: info.isActive,
+    stakeAmount: info.stakeAmount.toString(),
+    totalVerifications: info.totalVerifications,
+    totalSlashes: info.totalSlashes,
+    deregisterCooldown,
+    recentSlashes: tracker.list(),
+  };
+}
+
 /**
  * #861: on startup, checks this node's registered stake against the
  * registry's minimum and logs a warning if the node isn't registered (or has

--- a/oracle-service/src/types.ts
+++ b/oracle-service/src/types.ts
@@ -13,6 +13,10 @@ export interface OracleConfig {
   oracleRegistryContractId?: string;
   stakeTokenId?: string;
   registerStakeAmount?: bigint;
+  // #980: where the listener persists the last-processed Horizon paging
+  // token, so a restart resumes the stream instead of starting from 'now'
+  // (missing events) or a fixed lookback window (risking resubmitted votes).
+  listenerCursorPath: string;
 }
 
 export interface InvoiceCreatedEvent {

--- a/oracle-service/src/verifier.ts
+++ b/oracle-service/src/verifier.ts
@@ -1,12 +1,29 @@
 import { Keypair, TransactionBuilder } from '@stellar/stellar-sdk';
-import { AsteraClient } from 'astera-sdk';
+import { AsteraClient, OracleRegistryErrors } from 'astera-sdk';
 import { OracleConfig } from './types';
 import { retryWithBackoff } from './retry';
+import { ConsensusTracker } from './consensus';
+
+// The registry surfaces a paused contract as a simulation failure containing
+// `Error(Contract, #<code>)`, where `<code>` is the `ContractPaused` variant
+// from the generated bindings (kept in sync with contracts/oracle_registry).
+const CONTRACT_PAUSED_CODE = Object.entries(OracleRegistryErrors).find(
+  ([, entry]) => entry.message === 'ContractPaused',
+)?.[0];
+
+function isRegistryPausedError(error: unknown): boolean {
+  if (CONTRACT_PAUSED_CODE === undefined) {
+    return false;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes(`Error(Contract, #${CONTRACT_PAUSED_CODE})`);
+}
 
 export class Verifier {
   private client: AsteraClient;
   private config: OracleConfig;
   private oracleKeypair: Keypair;
+  private consensusTracker?: ConsensusTracker;
   /**
    * #861: when a registry contract is configured this node participates in
    * the N-of-M stake-weighted consensus network (`submit_vote`) instead of
@@ -15,8 +32,9 @@ export class Verifier {
    */
   private readonly useConsensus: boolean;
 
-  constructor(config: OracleConfig) {
+  constructor(config: OracleConfig, consensusTracker?: ConsensusTracker) {
     this.config = config;
+    this.consensusTracker = consensusTracker;
     this.oracleKeypair = Keypair.fromSecret(config.oracleSecretKey);
     this.useConsensus = Boolean(config.oracleRegistryContractId);
     this.client = new AsteraClient({
@@ -108,6 +126,16 @@ export class Verifier {
       return;
     }
 
+    // If the registry is known to be paused, don't bother attempting the
+    // round-open/vote calls at all — they will only fail with `ContractPaused`.
+    // Submission resumes automatically once an `unpaused` event is observed.
+    if (this.consensusTracker?.isPaused()) {
+      console.warn(
+        `[Verifier] Oracle registry is paused; skipping vote submission for invoice ${invoiceId} until it resumes.`,
+      );
+      return;
+    }
+
     // Ensure a verification round is open before voting. `open_verification_round`
     // is idempotent from this node's point of view: if another oracle already
     // opened it (or already finalized it), the "already open"/"not found"-style
@@ -127,23 +155,42 @@ export class Verifier {
           `oracleRegistry.openRound(${invoiceId})`,
         );
       } catch (openError) {
+        if (isRegistryPausedError(openError)) {
+          this.consensusTracker?.markPaused();
+          console.warn(
+            `[Verifier] Oracle registry is paused; deferring vote submission for invoice ${invoiceId} until it resumes.`,
+          );
+          return;
+        }
         console.log(
           `[Verifier] Could not open round for invoice ${invoiceId} (likely already open): ${openError}`,
         );
       }
     }
 
-    const txHash = await retryWithBackoff(
-      () =>
-        this.client.oracleRegistry.vote({
-          signer: this.signTx,
-          oracle: this.oracleKeypair.publicKey(),
-          invoiceId,
-          approved,
-          evidenceHash: oracleHash,
-        }),
-      `oracleRegistry.vote(${invoiceId})`,
-    );
+    let txHash: string;
+    try {
+      txHash = await retryWithBackoff(
+        () =>
+          this.client.oracleRegistry.vote({
+            signer: this.signTx,
+            oracle: this.oracleKeypair.publicKey(),
+            invoiceId,
+            approved,
+            evidenceHash: oracleHash,
+          }),
+        `oracleRegistry.vote(${invoiceId})`,
+      );
+    } catch (voteError) {
+      if (isRegistryPausedError(voteError)) {
+        this.consensusTracker?.markPaused();
+        console.warn(
+          `[Verifier] Oracle registry is paused; vote for invoice ${invoiceId} was not submitted and will be retried once it resumes.`,
+        );
+        return;
+      }
+      throw voteError;
+    }
     console.log(`[Verifier] Vote (${approved}) submitted for invoice ${invoiceId}. Tx Hash: ${txHash}`);
   }
 

--- a/packages/sdk/src/astera-client.ts
+++ b/packages/sdk/src/astera-client.ts
@@ -18,6 +18,7 @@ import type {
   CoFundingRound,
   OracleInfo,
   VerificationRound,
+  RegistryConfig,
   RateModelConfig,
   RateSnapshot,
   ComplianceStatus,
@@ -265,6 +266,9 @@ export class AsteraClient {
 
     getOracleInfo: (operator: string): Promise<OracleInfo | null> =>
       this.oracleRegistryClient.getOracleInfo(operator),
+
+    getRegistryConfig: (): Promise<RegistryConfig> =>
+      this.oracleRegistryClient.getRegistryConfig(),
 
     openRound: (params: {
       signer: (txXdr: string) => Promise<string>;

--- a/packages/sdk/src/clients/oracle_registry.ts
+++ b/packages/sdk/src/clients/oracle_registry.ts
@@ -4,6 +4,7 @@ import type {
   ClientConfig,
   VerificationRound,
   OracleInfo,
+  RegistryConfig,
   TransactionProgress,
 } from '../types';
 import type { Signer } from '../types';
@@ -92,6 +93,23 @@ export class OracleRegistryClient extends BaseClient {
       openedAt: Number(r.opened_at),
       deadline: Number(r.deadline),
       oracleHash: r.oracle_hash as string,
+    };
+  }
+
+  async getRegistryConfig(): Promise<RegistryConfig> {
+    const sim = await this.simulate('get_registry_config', []);
+    if (StellarRpc.Api.isSimulationError(sim)) {
+      throw new Error(`Simulation failed: ${sim.error}`);
+    }
+    const raw = scValToNative(sim.result!.retval) as Record<string, unknown>;
+    return {
+      minStake: BigInt(String(raw.min_stake)),
+      stakeToken: raw.stake_token as string,
+      requiredVotes: Number(raw.required_votes),
+      quorumBps: Number(raw.quorum_bps),
+      roundDurationSecs: Number(raw.round_duration_secs),
+      deregisterCooldownSecs: Number(raw.deregister_cooldown_secs),
+      treasury: (raw.treasury as string | null) ?? undefined,
     };
   }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -186,6 +186,16 @@ export interface OracleInfo {
   deregisterRequestedAt?: number;
 }
 
+export interface RegistryConfig {
+  minStake: bigint;
+  stakeToken: string;
+  requiredVotes: number;
+  quorumBps: number;
+  roundDurationSecs: number;
+  deregisterCooldownSecs: number;
+  treasury?: string;
+}
+
 export interface VerificationRound {
   invoiceId: bigint;
   requiredVotes: number;


### PR DESCRIPTION
## Summary

- Cap exponential retry backoff and add full jitter to prevent synchronized retries.
- Handle oracle registry paused/unpaused state and skip verification while paused.
- Add `/metrics` endpoint exposing operator stake, deregister cooldown, and recent slashes.
- Persist the Horizon listener cursor so the service resumes correctly after restart.

Closes #977
Closes #978
Closes #979
Closes #980

## Test Plan

- [x] `tsc --noEmit` passes for `oracle-service`
- [x] `tsc --noEmit` passes for `packages/sdk`
- [x] Existing SDK Jest tests pass
- [x] Manually verified retry backoff and jitter
- [x] Verified pause/unpause handling
- [x] Verified listener checkpoint persistence