### PR TITLE
fix: submit_screening_result doesn't enforce get_rescreening_interval

### DIFF
--- a/contracts/compliance/src/lib.rs
+++ b/contracts/compliance/src/lib.rs
@@ -51,6 +51,8 @@ pub enum ComplianceError {
     InvalidReason = 12,
     // #927: caller has already requested review for this address within the cooldown window.
     ReviewRequestTooSoon = 13,
+    // Screener has already screened this subject within the rescreening interval.
+    RescreeningTooSoon = 14,
 }
 
 #[contracttype]
@@ -98,6 +100,18 @@ pub struct ScreeningHistoryEntry {
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
+pub struct ScreenerSubmissionEntry {
+    pub subject_address: Address,
+    pub status: ComplianceStatus,
+    pub reason_code: u32,
+    pub risk_tier: RiskTier,
+    pub screened_at: u64,
+    pub expires_at: u64,
+    pub notes_hash: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PendingScreener {
     pub address: Address,
     pub proposed_at: u64,
@@ -120,6 +134,10 @@ pub enum DataKey {
     PendingReviewIds,
     // #927: last request_review timestamp keyed by (caller, target address).
     ReviewRequestedAt(Address, Address),
+    // Screener submission history keyed by screener address.
+    ScreenerSubmissions(Address),
+    // Last screening timestamp keyed by (screener, subject address).
+    LastScreenedAt(Address, Address),
 }
 
 const EVT: Symbol = symbol_short!("COMPLY");
@@ -389,6 +407,19 @@ impl ComplianceContract {
         }
 
         let now = env.ledger().timestamp();
+
+        // Enforce rescreening interval: screener cannot rescreen same subject within interval
+        let last_screened_key = DataKey::LastScreenedAt(screener.clone(), address.clone());
+        if let Some(last_at) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&last_screened_key)
+        {
+            let interval = Self::get_rescreening_interval(env.clone());
+            if now < last_at.saturating_add(interval) {
+                return Err(ComplianceError::RescreeningTooSoon);
+            }
+        }
         let effective_expires = if expires_at == 0 {
             let interval = Self::get_rescreening_interval(env.clone());
             now.saturating_add(interval)
@@ -428,9 +459,28 @@ impl ComplianceContract {
                 screened_at: now,
                 screened_by: screener.clone(),
                 expires_at: effective_expires,
+                notes_hash: notes_hash.clone(),
+            },
+        );
+
+        Self::append_screener_submission(
+            &env,
+            &screener,
+            ScreenerSubmissionEntry {
+                subject_address: address.clone(),
+                status: status.clone(),
+                reason_code,
+                risk_tier,
+                screened_at: now,
+                expires_at: effective_expires,
                 notes_hash,
             },
         );
+
+        // Update last screening timestamp for this (screener, subject) pair
+        env.storage()
+            .instance()
+            .set(&last_screened_key, &now);
 
         Self::sync_status_lists(&env, &address, &status);
 
@@ -515,6 +565,20 @@ impl ComplianceContract {
                 risk_tier: record.risk_tier.clone(),
                 screened_at: now,
                 screened_by: caller.clone(),
+                expires_at: 0,
+                notes_hash: reason.clone(),
+            },
+        );
+
+        Self::append_screener_submission(
+            &env,
+            &caller,
+            ScreenerSubmissionEntry {
+                subject_address: address.clone(),
+                status: ComplianceStatus::PendingReview,
+                reason_code: 0,
+                risk_tier: record.risk_tier.clone(),
+                screened_at: now,
                 expires_at: 0,
                 notes_hash: reason,
             },
@@ -606,6 +670,15 @@ impl ComplianceContract {
         env.storage()
             .persistent()
             .get(&DataKey::History(address))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Returns all screening submissions made by a specific screener across all subjects.
+    /// This allows screeners to audit their own submission history.
+    pub fn get_screener_submissions(env: Env, screener: Address) -> Vec<ScreenerSubmissionEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ScreenerSubmissions(screener))
             .unwrap_or(Vec::new(&env))
     }
 
@@ -713,6 +786,30 @@ impl ComplianceContract {
         }
         history.push_back(entry);
         env.storage().persistent().set(&key, &history);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, REGISTRY_TTL, REGISTRY_TTL);
+    }
+
+    fn append_screener_submission(env: &Env, screener: &Address, entry: ScreenerSubmissionEntry) {
+        let key = DataKey::ScreenerSubmissions(screener.clone());
+        let mut submissions: Vec<ScreenerSubmissionEntry> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(env));
+        if submissions.len() >= MAX_HISTORY_ENTRIES {
+            // Drop oldest to keep storage bounded.
+            let mut trimmed = Vec::new(env);
+            for i in 1..submissions.len() {
+                if let Some(e) = submissions.get(i) {
+                    trimmed.push_back(e);
+                }
+            }
+            submissions = trimmed;
+        }
+        submissions.push_back(entry);
+        env.storage().persistent().set(&key, &submissions);
         env.storage()
             .persistent()
             .extend_ttl(&key, REGISTRY_TTL, REGISTRY_TTL);

--- a/contracts/compliance/tests/screener_tests.rs
+++ b/contracts/compliance/tests/screener_tests.rs
@@ -150,3 +150,251 @@ fn test_request_review_no_screener_privilege_needed() {
     client.request_review(&anyone, &target, &String::from_str(&env, "alert"));
     assert!(!client.is_cleared(&target));
 }
+
+#[test]
+fn test_screener_can_audit_own_submissions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_screener_timelock(&admin, &0u64);
+    let screener = Address::generate(&env);
+    client.register_screener(&admin, &screener);
+
+    let subject1 = Address::generate(&env);
+    let subject2 = Address::generate(&env);
+    let subject3 = Address::generate(&env);
+
+    // Screener submits results for multiple subjects
+    client.submit_screening_result(
+        &screener,
+        &subject1,
+        &ComplianceStatus::Cleared,
+        &0u32,
+        &RiskTier::Low,
+        &(1_000_000u64 + 1000),
+        &String::from_str(&env, "ok1"),
+    );
+
+    client.submit_screening_result(
+        &screener,
+        &subject2,
+        &ComplianceStatus::Flagged,
+        &42u32,
+        &RiskTier::High,
+        &(1_000_000u64 + 2000),
+        &String::from_str(&env, "sanctions"),
+    );
+
+    client.submit_screening_result(
+        &screener,
+        &subject3,
+        &ComplianceStatus::Cleared,
+        &0u32,
+        &RiskTier::Medium,
+        &(1_000_000u64 + 3000),
+        &String::from_str(&env, "ok2"),
+    );
+
+    // Screener can retrieve their own submission history
+    let submissions = client.get_screener_submissions(&screener);
+    assert_eq!(submissions.len(), 3);
+
+    // Verify entries are in order (most recent last)
+    let sub1 = submissions.get(0).unwrap();
+    assert_eq!(sub1.subject_address, subject1);
+    assert_eq!(sub1.status, ComplianceStatus::Cleared);
+    assert_eq!(sub1.risk_tier, RiskTier::Low);
+
+    let sub2 = submissions.get(1).unwrap();
+    assert_eq!(sub2.subject_address, subject2);
+    assert_eq!(sub2.status, ComplianceStatus::Flagged);
+    assert_eq!(sub2.risk_tier, RiskTier::High);
+    assert_eq!(sub2.reason_code, 42);
+
+    let sub3 = submissions.get(2).unwrap();
+    assert_eq!(sub3.subject_address, subject3);
+    assert_eq!(sub3.status, ComplianceStatus::Cleared);
+    assert_eq!(sub3.risk_tier, RiskTier::Medium);
+}
+
+#[test]
+fn test_request_review_tracked_in_caller_submissions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let target = Address::generate(&env);
+    let monitor = Address::generate(&env);
+
+    client.submit_screening_result(
+        &admin,
+        &target,
+        &ComplianceStatus::Cleared,
+        &0u32,
+        &RiskTier::Low,
+        &(1_000_000u64 + 99_999),
+        &String::from_str(&env, "ok"),
+    );
+
+    // Monitor requests review
+    client.request_review(&monitor, &target, &String::from_str(&env, "alert"));
+
+    // Monitor can see their submission history
+    let submissions = client.get_screener_submissions(&monitor);
+    assert_eq!(submissions.len(), 1);
+    let sub = submissions.get(0).unwrap();
+    assert_eq!(sub.subject_address, target);
+    assert_eq!(sub.status, ComplianceStatus::PendingReview);
+    assert_eq!(sub.notes_hash, String::from_str(&env, "alert"));
+}
+
+#[test]
+fn test_screener_submissions_empty_for_new_screener() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_screener_timelock(&admin, &0u64);
+    let screener = Address::generate(&env);
+    client.register_screener(&admin, &screener);
+
+    // New screener has empty submission history
+    let submissions = client.get_screener_submissions(&screener);
+    assert_eq!(submissions.len(), 0);
+}
+
+#[test]
+fn test_rescreening_interval_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_screener_timelock(&admin, &0u64);
+    let screener = Address::generate(&env);
+    client.register_screener(&admin, &screener);
+
+    let subject = Address::generate(&env);
+
+    // First screening succeeds
+    client.submit_screening_result(
+        &screener,
+        &subject,
+        &ComplianceStatus::Cleared,
+        &0u32,
+        &RiskTier::Low,
+        &(1_000_000u64 + 1000),
+        &String::from_str(&env, "ok"),
+    );
+
+    // Attempt to rescreen immediately fails (default interval is 180 days)
+    let too_soon = client.try_submit_screening_result(
+        &screener,
+        &subject,
+        &ComplianceStatus::Flagged,
+        &42u32,
+        &RiskTier::High,
+        &(1_000_000u64 + 2000),
+        &String::from_str(&env, "sanctions"),
+    );
+    assert_eq!(too_soon, Err(Ok(ComplianceError::RescreeningTooSoon)));
+
+    // Advance time past the rescreening interval
+    let interval = client.get_rescreening_interval();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + interval + 1);
+
+    // Rescreening after interval succeeds
+    client.submit_screening_result(
+        &screener,
+        &subject,
+        &ComplianceStatus::Flagged,
+        &42u32,
+        &RiskTier::High,
+        &(1_000_000u64 + interval + 2000),
+        &String::from_str(&env, "sanctions"),
+    );
+}
+
+#[test]
+fn test_different_screeners_can_screen_same_subject() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_screener_timelock(&admin, &0u64);
+    let screener1 = Address::generate(&env);
+    let screener2 = Address::generate(&env);
+    client.register_screener(&admin, &screener1);
+    client.register_screener(&admin, &screener2);
+
+    let subject = Address::generate(&env);
+
+    // Screener1 screens the subject
+    client.submit_screening_result(
+        &screener1,
+        &subject,
+        &ComplianceStatus::Cleared,
+        &0u32,
+        &RiskTier::Low,
+        &(1_000_000u64 + 1000),
+        &String::from_str(&env, "ok1"),
+    );
+
+    // Screener2 can screen the same subject immediately (different screener)
+    client.submit_screening_result(
+        &screener2,
+        &subject,
+        &ComplianceStatus::Flagged,
+        &42u32,
+        &RiskTier::High,
+        &(1_000_000u64 + 2000),
+        &String::from_str(&env, "sanctions"),
+    );
+}
+
+#[test]
+fn test_custom_rescreening_interval() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_screener_timelock(&admin, &0u64);
+    let screener = Address::generate(&env);
+    client.register_screener(&admin, &screener);
+
+    // Set custom short interval (1 hour = 3600 seconds)
+    client.set_rescreening_interval(&admin, &3600u64);
+
+    let subject = Address::generate(&env);
+
+    // First screening
+    client.submit_screening_result(
+        &screener,
+        &subject,
+        &ComplianceStatus::Cleared,
+        &0u32,
+        &RiskTier::Low,
+        &(1_000_000u64 + 1000),
+        &String::from_str(&env, "ok"),
+    );
+
+    // Attempt to rescreen before custom interval fails
+    let too_soon = client.try_submit_screening_result(
+        &screener,
+        &subject,
+        &ComplianceStatus::Flagged,
+        &42u32,
+        &RiskTier::High,
+        &(1_000_000u64 + 2000),
+        &String::from_str(&env, "sanctions"),
+    );
+    assert_eq!(too_soon, Err(Ok(ComplianceError::RescreeningTooSoon)));
+
+    // Advance past custom interval
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + 3600 + 1);
+
+    // Rescreening succeeds
+    client.submit_screening_result(
+        &screener,
+        &subject,
+        &ComplianceStatus::Flagged,
+        &42u32,
+        &RiskTier::High,
+        &(1_000_000u64 + 3600 + 2000),
+        &String::from_str(&env, "sanctions"),
+    );
+}


### PR DESCRIPTION
Summary
Adds two enhancements to the compliance contract:

Screener self-service audit - Screeners can now retrieve their complete submission history across all subjects
Rescreening interval enforcement - The rescreening interval is now enforced per (screener, subject) pair
Changes
Screener Self-Service Audit
Added ScreenerSubmissionEntry struct to track submissions with subject address
Added DataKey::ScreenerSubmissions(Address) for screener submission history storage
Added get_screener_submissions() public function for screeners to audit their submissions
Updated submit_screening_result() and request_review() to record in screener's submission history
Storage bounded to 64 entries per screener with FIFO eviction
Rescreening Interval Enforcement
Added RescreeningTooSoon error code
Added DataKey::LastScreenedAt(Address, Address) to track last screening timestamp per (screener, subject)
Added check in submit_screening_result() to enforce rescreening interval before allowing submission
The interval configured via set_rescreening_interval() is now enforced, not advisory
Different screeners can screen the same subject without restriction (enforcement is per-screener)
Tests
Added comprehensive tests:

test_screener_can_audit_own_submissions - Verifies screeners can retrieve submission history
test_request_review_tracked_in_caller_submissions - Verifies request_review tracking
test_screener_submissions_empty_for_new_screener - Verifies empty state
test_rescreening_interval_enforced - Verifies interval enforcement with default interval
test_different_screeners_can_screen_same_subject - Verifies per-screener enforcement
test_custom_rescreening_interval - Verifies custom intervals are respected
Motivation
Previously, screeners had no way to audit their own submissions across all subjects - they could only view history per subject. Additionally, the rescreening interval was purely advisory, allowing screeners to bypass it by submitting rapid rescreenings. These changes improve accountability and ensure the configured interval is actually enforced.

Feedback submitted


Closes #925
Closes #924
Closes #923
Closes #922