### PR TITLE
feat: add dark mode support with CSS variable-driven theming

### DIFF
--- a/frontend/app/dashboard/credit/page.tsx
+++ b/frontend/app/dashboard/credit/page.tsx
@@ -143,8 +143,8 @@ export default function CreditProfilePage() {
       <div>
         <h1 className="text-3xl font-bold mb-2">Credit Profile</h1>
         <p className="text-brand-muted text-sm">
-          Your on-chain credit score, blended with any verified external attestations —
-          business registry checks, credit bureau data, or other on-chain protocol history.
+          Your on-chain credit score, blended with any verified external attestations — business
+          registry checks, credit bureau data, or other on-chain protocol history.
         </p>
       </div>
 
@@ -239,7 +239,7 @@ export default function CreditProfilePage() {
             <h3 className="font-semibold">Dispute attestation #{disputeTarget}</h3>
             <button
               onClick={() => setDisputeTarget(null)}
-              className="text-brand-muted hover:text-white text-sm"
+              className="text-brand-muted hover:text-brand-text text-sm"
             >
               Cancel
             </button>
@@ -253,7 +253,7 @@ export default function CreditProfilePage() {
                 placeholder="Why is this attestation incorrect?"
                 required
                 rows={3}
-                className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-white placeholder-brand-muted focus:outline-none focus:border-brand-gold text-sm"
+                className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-brand-text placeholder-brand-muted focus:outline-none focus:border-brand-gold text-sm"
               />
             </div>
             <button
@@ -264,8 +264,8 @@ export default function CreditProfilePage() {
               {txLoading ? 'Processing…' : 'File Dispute'}
             </button>
             <p className="text-xs text-brand-muted">
-              Filing a dispute immediately excludes this attestation from your blended score
-              until an admin reviews it.
+              Filing a dispute immediately excludes this attestation from your blended score until
+              an admin reviews it.
             </p>
           </form>
         </div>
@@ -288,7 +288,7 @@ export default function CreditProfilePage() {
                 max={10000}
                 value={simWeightBps}
                 onChange={(e) => setSimWeightBps(e.target.value)}
-                className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-white focus:outline-none focus:border-brand-gold text-sm"
+                className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-brand-text focus:outline-none focus:border-brand-gold text-sm"
               />
             </div>
             <div>
@@ -299,7 +299,7 @@ export default function CreditProfilePage() {
                 max={1000}
                 value={simScoreContribution}
                 onChange={(e) => setSimScoreContribution(e.target.value)}
-                className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-white focus:outline-none focus:border-brand-gold text-sm"
+                className="w-full bg-brand-dark border border-brand-border rounded-xl px-4 py-2.5 text-brand-text focus:outline-none focus:border-brand-gold text-sm"
               />
             </div>
             <button
@@ -312,7 +312,8 @@ export default function CreditProfilePage() {
           </form>
           {simResult !== null && (
             <p className="text-sm">
-              Your blended score would be <span className="font-bold gradient-text">{simResult}</span>
+              Your blended score would be{' '}
+              <span className="font-bold gradient-text">{simResult}</span>
               {score && (
                 <span className="text-brand-muted">
                   {' '}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -32,7 +32,12 @@ type DashboardRow = { invoice: Invoice; metadata: InvoiceMetadata };
 
 type StatusFilter = Invoice['status'] | 'All';
 type SortOption =
-  'created-desc' | 'created-asc' | 'amount-desc' | 'amount-asc' | 'due-asc' | 'due-desc';
+  | 'created-desc'
+  | 'created-asc'
+  | 'amount-desc'
+  | 'amount-asc'
+  | 'due-asc'
+  | 'due-desc';
 
 /** Number of invoices to load per page */
 const PAGE_SIZE = 20;
@@ -366,7 +371,7 @@ function DashboardContent() {
                   className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
                     viewMode === DASHBOARD_VIEW_MODES.LIST
                       ? 'bg-brand-gold text-brand-dark'
-                      : 'text-brand-muted hover:text-white'
+                      : 'text-brand-muted hover:text-brand-text'
                   }`}
                 >
                   {t('view.list')}
@@ -376,7 +381,7 @@ function DashboardContent() {
                   className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
                     viewMode === DASHBOARD_VIEW_MODES.PIPELINE
                       ? 'bg-brand-gold text-brand-dark'
-                      : 'text-brand-muted hover:text-white'
+                      : 'text-brand-muted hover:text-brand-text'
                   }`}
                 >
                   {t('view.pipeline')}
@@ -385,7 +390,7 @@ function DashboardContent() {
             )}
             <button
               onClick={() => setShowOnboarding(true)}
-              className="min-h-[44px] px-4 py-2 text-brand-muted hover:text-white transition-colors text-sm"
+              className="min-h-[44px] px-4 py-2 text-brand-muted hover:text-brand-text transition-colors text-sm"
             >
               {t('help')}
             </button>
@@ -411,13 +416,13 @@ function DashboardContent() {
             <div className="mb-6 inline-flex rounded-xl border border-brand-border bg-brand-card p-1">
               <button
                 onClick={() => setDashboardTab('borrower')}
-                className={`rounded-lg px-4 py-2 text-sm font-medium ${dashboardTab === 'borrower' ? 'bg-brand-gold text-brand-dark' : 'text-brand-muted hover:text-white'}`}
+                className={`rounded-lg px-4 py-2 text-sm font-medium ${dashboardTab === 'borrower' ? 'bg-brand-gold text-brand-dark' : 'text-brand-muted hover:text-brand-text'}`}
               >
                 Borrower
               </button>
               <button
                 onClick={() => setDashboardTab('lender')}
-                className={`rounded-lg px-4 py-2 text-sm font-medium ${dashboardTab === 'lender' ? 'bg-brand-gold text-brand-dark' : 'text-brand-muted hover:text-white'}`}
+                className={`rounded-lg px-4 py-2 text-sm font-medium ${dashboardTab === 'lender' ? 'bg-brand-gold text-brand-dark' : 'text-brand-muted hover:text-brand-text'}`}
               >
                 Lender
               </button>
@@ -464,7 +469,9 @@ function DashboardContent() {
                           className="p-3 sm:p-4 bg-brand-card border border-brand-border rounded-xl min-h-[88px] flex flex-col justify-center"
                         >
                           <p className="text-xs text-brand-muted mb-1">{s.label}</p>
-                          <p className={`text-lg sm:text-xl font-bold ${s.highlight ? 'gradient-text' : ''}`}>
+                          <p
+                            className={`text-lg sm:text-xl font-bold ${s.highlight ? 'gradient-text' : ''}`}
+                          >
                             {s.value}
                           </p>
                         </div>
@@ -496,12 +503,12 @@ function DashboardContent() {
                         placeholder={t('searchPlaceholder')}
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
-                        className="w-full bg-brand-dark border border-brand-border rounded-xl pl-9 pr-4 py-2.5 text-sm text-white placeholder-brand-muted focus:outline-none focus:border-brand-gold"
+                        className="w-full bg-brand-dark border border-brand-border rounded-xl pl-9 pr-4 py-2.5 text-sm text-brand-text placeholder-brand-muted focus:outline-none focus:border-brand-gold"
                       />
                       {search && (
                         <button
                           onClick={() => setSearch('')}
-                          className="absolute right-3 top-1/2 -translate-y-1/2 text-brand-muted hover:text-white"
+                          className="absolute right-3 top-1/2 -translate-y-1/2 text-brand-muted hover:text-brand-text"
                         >
                           ✕
                         </button>
@@ -517,7 +524,7 @@ function DashboardContent() {
                               className={`min-h-[36px] px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
                                 statusFilters.length === 0
                                   ? 'bg-brand-gold text-brand-dark'
-                                  : 'text-brand-muted hover:text-white bg-brand-card border border-brand-border'
+                                  : 'text-brand-muted hover:text-brand-text bg-brand-card border border-brand-border'
                               }`}
                             >
                               {t('status.all')}
@@ -535,7 +542,7 @@ function DashboardContent() {
                                 className={`min-h-[36px] px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
                                   statusFilters.includes(tab)
                                     ? 'bg-brand-gold text-brand-dark'
-                                    : 'text-brand-muted hover:text-white bg-brand-card border border-brand-border'
+                                    : 'text-brand-muted hover:text-brand-text bg-brand-card border border-brand-border'
                                 }`}
                               >
                                 {t(`status.${tab.toLowerCase()}`)}
@@ -546,7 +553,7 @@ function DashboardContent() {
                           <select
                             value={sort}
                             onChange={(e) => setSort(e.target.value as SortOption)}
-                            className="w-full sm:w-auto bg-brand-dark border border-brand-border rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-brand-gold cursor-pointer min-h-[36px]"
+                            className="w-full sm:w-auto bg-brand-dark border border-brand-border rounded-lg px-3 py-2 text-xs text-brand-text focus:outline-none focus:border-brand-gold cursor-pointer min-h-[36px]"
                           >
                             {SORT_OPTIONS.map((opt) => (
                               <option key={opt.value} value={opt.value}>
@@ -563,7 +570,7 @@ function DashboardContent() {
                                 onClick={() =>
                                   setStatusFilters((prev) => prev.filter((item) => item !== status))
                                 }
-                                className="px-2.5 py-1 rounded-full text-xs bg-brand-card border border-brand-border text-white hover:border-brand-gold/60"
+                                className="px-2.5 py-1 rounded-full text-xs bg-brand-card border border-brand-border text-brand-text hover:border-brand-gold/60"
                               >
                                 {t(`status.${status.toLowerCase()}`)} ✕
                               </button>
@@ -634,7 +641,7 @@ function DashboardContent() {
                             <button
                               onClick={() => setPage((p) => Math.max(0, p - 1))}
                               disabled={page === 0}
-                              className="px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm font-medium text-white hover:border-brand-gold/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                              className="px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm font-medium text-brand-text hover:border-brand-gold/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                               aria-label="Previous page"
                             >
                               ← Prev
@@ -654,7 +661,7 @@ function DashboardContent() {
                                 setPage(nextPage);
                               }}
                               disabled={page >= totalPages - 1 && !hasMore}
-                              className="px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm font-medium text-white hover:border-brand-gold/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                              className="px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm font-medium text-brand-text hover:border-brand-gold/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                               aria-label="Next page"
                             >
                               {loadingMore ? (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -5,9 +5,11 @@
 /* ---- Dark mode (default) ---- */
 :root {
   --bg: #0a0e1a;
+  --bg-navy: #0d1526;
   --card: #111827;
   --border: #1f2a3c;
   --gold: #f5a623;
+  --amber: #e8920a;
   --muted: #6b7a99;
   --text-primary: #f9fafb;
   --text-secondary: #d1d5db;
@@ -16,49 +18,14 @@
 /* ---- Light mode ---- */
 :root.light {
   --bg: #f8fafc;
+  --bg-navy: #f1f5f9;
   --card: #ffffff;
   --border: #e2e8f0;
   --gold: #d97706;
+  --amber: #b45309;
   --muted: #64748b;
   --text-primary: #0f172a;
   --text-secondary: #334155;
-}
-
-/* ---- Light mode: override hardcoded Tailwind brand colors ---- */
-:root.light .bg-brand-dark {
-  background-color: #f1f5f9 !important;
-}
-:root.light .bg-brand-card {
-  background-color: #ffffff !important;
-}
-:root.light .bg-brand-navy {
-  background-color: #f8fafc !important;
-}
-:root.light .border-brand-border {
-  border-color: #e2e8f0 !important;
-}
-:root.light .text-white {
-  color: #0f172a !important;
-}
-:root.light .text-brand-muted {
-  color: #64748b !important;
-}
-:root.light .placeholder-brand-muted::placeholder {
-  color: #94a3b8 !important;
-}
-:root.light .bg-brand-dark\/80 {
-  background-color: rgba(248, 250, 252, 0.9) !important;
-}
-:root.light input,
-:root.light textarea,
-:root.light select {
-  background-color: #f8fafc;
-  color: #0f172a;
-  border-color: #e2e8f0;
-}
-:root.light input::placeholder,
-:root.light textarea::placeholder {
-  color: #94a3b8;
 }
 
 * {
@@ -146,4 +113,13 @@ body {
 }
 :root.light .badge-disputed {
   @apply bg-orange-100 text-orange-700 border border-orange-300;
+}
+
+/* Light mode select element styling */
+:root.light select {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 0.5rem center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  padding-right: 2.5rem;
 }

--- a/frontend/app/portfolio/page.tsx
+++ b/frontend/app/portfolio/page.tsx
@@ -95,7 +95,7 @@ function StatCard({
   return (
     <div className="bg-brand-card border border-brand-border rounded-2xl p-6 flex flex-col gap-1">
       <p className="text-brand-muted text-sm font-medium">{label}</p>
-      <p className={`text-2xl font-bold ${highlight ? 'text-brand-gold' : 'text-white'}`}>
+      <p className={`text-2xl font-bold ${highlight ? 'text-brand-gold' : 'text-brand-text'}`}>
         {value}
       </p>
       {sub && <p className="text-xs text-brand-muted mt-1">{sub}</p>}
@@ -135,7 +135,7 @@ function AllocationPie({ slices }: { slices: { label: string; pct: number; color
   }
 
   const cumulativeEnds = slices.reduce<number[]>((acc, s) => {
-    const prev = acc.length > 0 ? acc[acc.length - 1] ?? 0 : 0;
+    const prev = acc.length > 0 ? (acc[acc.length - 1] ?? 0) : 0;
     return [...acc, prev + s.pct];
   }, []);
 
@@ -162,7 +162,7 @@ function AllocationPie({ slices }: { slices: { label: string; pct: number; color
               style={{ background: COLORS[i % COLORS.length] }}
             />
             <span className="text-brand-muted">{s.label}</span>
-            <span className="text-white font-medium ml-auto">{s.pct.toFixed(1)}%</span>
+            <span className="text-brand-text font-medium ml-auto">{s.pct.toFixed(1)}%</span>
           </div>
         ))}
       </div>
@@ -355,7 +355,7 @@ export default function PortfolioPage() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-white">Investor Portfolio</h1>
+          <h1 className="text-3xl font-bold text-brand-text">Investor Portfolio</h1>
           <p className="text-brand-muted mt-1 text-sm">
             {lastRefresh
               ? `Last updated: ${lastRefresh.toLocaleTimeString()}`
@@ -365,7 +365,7 @@ export default function PortfolioPage() {
         <button
           onClick={load}
           disabled={loading}
-          className="flex items-center gap-2 px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm text-white hover:bg-brand-border transition-colors disabled:opacity-50"
+          className="flex items-center gap-2 px-4 py-2 bg-brand-card border border-brand-border rounded-xl text-sm text-brand-text hover:bg-brand-border transition-colors disabled:opacity-50"
         >
           {loading ? (
             <span className="w-4 h-4 border-2 border-brand-gold border-t-transparent rounded-full animate-spin" />
@@ -431,7 +431,9 @@ export default function PortfolioPage() {
             <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-6">
               <div className="flex-1">
                 <p className="text-brand-muted text-sm mb-1">Total Portfolio Value</p>
-                <p className="text-4xl font-bold text-white">{formatUSDC(totalUsdcDeposited)}</p>
+                <p className="text-4xl font-bold text-brand-text">
+                  {formatUSDC(totalUsdcDeposited)}
+                </p>
                 <p className="text-xs text-brand-muted mt-1">
                   ≈ USDC equivalent
                   <span
@@ -444,11 +446,11 @@ export default function PortfolioPage() {
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mt-4 text-sm">
                   <div>
                     <p className="text-brand-muted text-xs">Total Deposited</p>
-                    <p className="text-white font-medium">{formatUSDC(totalUsdcDeposited)}</p>
+                    <p className="text-brand-text font-medium">{formatUSDC(totalUsdcDeposited)}</p>
                   </div>
                   <div>
                     <p className="text-brand-muted text-xs">Total Deployed</p>
-                    <p className="text-white font-medium">{formatUSDC(totalUsdcDeployed)}</p>
+                    <p className="text-brand-text font-medium">{formatUSDC(totalUsdcDeployed)}</p>
                   </div>
                   <div>
                     <p className="text-brand-muted text-xs">Total Earned</p>
@@ -498,20 +500,20 @@ export default function PortfolioPage() {
 
           {/* Pool utilisation */}
           <div className="bg-brand-card border border-brand-border rounded-2xl p-6 mb-8">
-            <h2 className="text-white font-semibold mb-4">Pool Utilisation</h2>
+            <h2 className="text-brand-text font-semibold mb-4">Pool Utilisation</h2>
             <UtilisationBar utilisation={utilisation} />
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mt-6 text-sm">
               <div>
                 <p className="text-brand-muted">Total Pool Deposits</p>
-                <p className="text-white font-medium">{formatUSDC(totalPoolDeposited)}</p>
+                <p className="text-brand-text font-medium">{formatUSDC(totalPoolDeposited)}</p>
               </div>
               <div>
                 <p className="text-brand-muted">Total Deployed</p>
-                <p className="text-white font-medium">{formatUSDC(totalPoolDeployed)}</p>
+                <p className="text-brand-text font-medium">{formatUSDC(totalPoolDeployed)}</p>
               </div>
               <div>
                 <p className="text-brand-muted">Total Paid Out</p>
-                <p className="text-white font-medium">
+                <p className="text-brand-text font-medium">
                   {formatUSDC(rows.reduce((a, r) => a + r.totals.totalPaidOut, 0n))}
                 </p>
               </div>
@@ -526,7 +528,7 @@ export default function PortfolioPage() {
 
           {/* Per-token positions (collapsible when > 1 token) */}
           <div className="space-y-4">
-            <h2 className="text-white font-semibold text-lg">Token Positions</h2>
+            <h2 className="text-brand-text font-semibold text-lg">Token Positions</h2>
             {rows.map(({ token, position, totals, waitEstimate, forecast, rateBps }) => {
               const isCollapsed = collapsed[token] ?? false;
               const usdcDeposited = position ? toUsdcEquiv(position.totalDeposited, rateBps) : 0n;
@@ -547,7 +549,9 @@ export default function PortfolioPage() {
                     }
                   >
                     <div className="flex items-center gap-3">
-                      <h3 className="text-white font-medium text-base">{stablecoinLabel(token)}</h3>
+                      <h3 className="text-brand-text font-medium text-base">
+                        {stablecoinLabel(token)}
+                      </h3>
                       {rateBps !== 10_000 && (
                         <span className="text-xs text-brand-muted">
                           ≈ {formatUSDC(usdcDeposited)} USDC
@@ -574,19 +578,19 @@ export default function PortfolioPage() {
                         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
                           <div>
                             <p className="text-brand-muted">Deposited</p>
-                            <p className="text-white font-medium">
+                            <p className="text-brand-text font-medium">
                               {formatUSDC(position.totalDeposited)}
                             </p>
                           </div>
                           <div>
                             <p className="text-brand-muted">Available</p>
-                            <p className="text-white font-medium">
+                            <p className="text-brand-text font-medium">
                               {formatUSDC(position.available)}
                             </p>
                           </div>
                           <div>
                             <p className="text-brand-muted">Deployed</p>
-                            <p className="text-white font-medium">
+                            <p className="text-brand-text font-medium">
                               {formatUSDC(position.deployed)}
                             </p>
                           </div>
@@ -614,17 +618,17 @@ export default function PortfolioPage() {
                       </div>
 
                       {isQueued && waitEstimate && (
-                        <div className="mt-4 rounded-xl border border-brand-border bg-black/20 p-4">
+                        <div className="mt-4 rounded-xl border border-brand-border bg-brand-navy/40 p-4">
                           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
                             <div>
-                              <p className="text-white font-medium">Withdrawal queue</p>
+                              <p className="text-brand-text font-medium">Withdrawal queue</p>
                               <p className="text-brand-muted text-xs mt-1">
                                 Position {waitEstimate.queuePosition} with{' '}
                                 {formatUSDC(waitEstimate.capitalAhead)} ahead
                               </p>
                               <p className="text-brand-muted text-xs mt-1">
                                 Estimated wait:{' '}
-                                <span className="text-white">
+                                <span className="text-brand-text">
                                   {formatWaitEstimate(waitEstimate.estimatedWaitSecs)}
                                 </span>{' '}
                                 <span className="opacity-60">(estimate, not a guarantee)</span>
@@ -632,14 +636,14 @@ export default function PortfolioPage() {
                             </div>
                             <div className="text-left sm:text-right">
                               <p className="text-brand-muted text-xs">Nearest invoice due</p>
-                              <p className="text-white text-sm font-medium">{dueDate}</p>
+                              <p className="text-brand-text text-sm font-medium">{dueDate}</p>
                             </div>
                           </div>
                           <div className="flex flex-wrap gap-2 mt-3">
                             <button
                               onClick={() => handleCancelWithdrawal(token)}
                               disabled={actionLoading}
-                              className="px-3 py-1.5 text-xs rounded-lg border border-brand-border text-white hover:bg-brand-border transition-colors disabled:opacity-50"
+                              className="px-3 py-1.5 text-xs rounded-lg border border-brand-border text-brand-text hover:bg-brand-border transition-colors disabled:opacity-50"
                             >
                               Cancel request
                             </button>
@@ -656,11 +660,12 @@ export default function PortfolioPage() {
                       )}
 
                       {!isQueued && position && position.available > 0n && (
-                        <div className="mt-4 rounded-xl border border-brand-border bg-black/20 p-4">
-                          <p className="text-white font-medium mb-2">Request withdrawal</p>
+                        <div className="mt-4 rounded-xl border border-brand-border bg-brand-navy/40 p-4">
+                          <p className="text-brand-text font-medium mb-2">Request withdrawal</p>
                           <p className="text-brand-muted text-xs mb-3">
-                            If pool liquidity can&apos;t cover it immediately, your request is queued
-                            and settled automatically (FIFO, oldest-first) as liquidity arrives.
+                            If pool liquidity can&apos;t cover it immediately, your request is
+                            queued and settled automatically (FIFO, oldest-first) as liquidity
+                            arrives.
                           </p>
                           <div className="flex flex-col sm:flex-row gap-2">
                             <input
@@ -672,7 +677,7 @@ export default function PortfolioPage() {
                               onChange={(e) =>
                                 setRequestAmounts((p) => ({ ...p, [token]: e.target.value }))
                               }
-                              className="flex-1 bg-brand-dark border border-brand-border rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none focus:border-brand-gold"
+                              className="flex-1 bg-brand-dark border border-brand-border rounded-lg px-3 py-1.5 text-sm text-brand-text focus:outline-none focus:border-brand-gold"
                             />
                             <button
                               onClick={() => handleRequestWithdrawal(token)}

--- a/frontend/components/ThemeProvider.tsx
+++ b/frontend/components/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
 type Theme = 'dark' | 'light';
 
@@ -27,29 +27,46 @@ function applyTheme(next: Theme) {
   }
 }
 
+const STORAGE_KEY = 'astera-theme';
+
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  // Initialise synchronously on client; default to 'dark' for SSR
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window === 'undefined') return 'dark';
-    const stored = localStorage.getItem('astera-theme') as Theme | null;
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
     return (
       stored ?? (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
     );
   });
 
-  // Keep the DOM in sync whenever theme changes
+  // Track whether the user has explicitly chosen a theme
+  const userExplicit = useRef(false);
+
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);
 
-  function toggleTheme() {
+  // Listen for OS-level preference changes when user hasn't explicitly set one
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: light)');
+    function handleChange(e: MediaQueryListEvent) {
+      if (userExplicit.current) return;
+      const next: Theme = e.matches ? 'light' : 'dark';
+      setTheme(next);
+      applyTheme(next);
+    }
+    mql.addEventListener('change', handleChange);
+    return () => mql.removeEventListener('change', handleChange);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    userExplicit.current = true;
     setTheme((prev) => {
       const next: Theme = prev === 'dark' ? 'light' : 'dark';
       applyTheme(next);
-      localStorage.setItem('astera-theme', next);
+      localStorage.setItem(STORAGE_KEY, next);
       return next;
     });
-  }
+  }, []);
 
   return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -7,13 +7,15 @@ const config: Config = {
     extend: {
       colors: {
         brand: {
-          gold: '#F5A623',
-          amber: '#E8920A',
-          dark: '#0A0E1A',
-          navy: '#0D1526',
-          card: '#111827',
-          border: '#1F2A3C',
-          muted: '#6B7A99',
+          gold: 'var(--gold)',
+          amber: 'var(--amber)',
+          dark: 'var(--bg)',
+          navy: 'var(--bg-navy)',
+          card: 'var(--card)',
+          border: 'var(--border)',
+          muted: 'var(--muted)',
+          text: 'var(--text-primary)',
+          'text-secondary': 'var(--text-secondary)',
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary

Adds proper dark mode / light mode support to `app/dashboard` and `app/portfolio` with `prefers-color-scheme` handling, resolving #962.

## Changes

### Core theming infrastructure
- **`tailwind.config.ts`** — Convert all hardcoded brand hex colors to CSS custom properties (`var(--gold)`, `var(--card)`, etc.) so colors automatically adapt to the active theme
- **`globals.css`** — Expand CSS variable definitions for both `:root` (dark) and `:root.light` (light) including `--bg-navy`, `--amber`, `--text-primary`, `--text-secondary`. Remove fragile `!important` light-mode overrides that were used to patch hardcoded brand classes
- **`ThemeProvider.tsx`** — Add `matchMedia.addEventListener("change")` listener so the app follows OS `prefers-color-scheme` changes when the user has not explicitly toggled the theme

### Page-level updates
- **`app/dashboard/page.tsx`** — Replace all `text-white` / `hover:text-white` with theme-aware `text-brand-text` / `hover:text-brand-text` classes
- **`app/dashboard/credit/page.tsx`** — Same treatment for inputs, textareas, and hover states
- **`app/portfolio/page.tsx`** — Replace `text-white` with `text-brand-text`, replace `bg-black/20` overlays with `bg-brand-navy/40`

## What this fixes

| Before | After |
|--------|-------|
| Brand colors hardcoded to dark hex values | Colors resolve via CSS variables, switching per theme |
| Light mode patched with `!important` overrides | Clean CSS variable cascade — no overrides needed |
| No OS preference change listener | Follows `prefers-color-scheme` in real time |
| `text-white` always white regardless of theme | `text-brand-text` resolves to `--text-primary` (dark in light mode) |

## Testing

- [x] Dark mode renders correctly (default)
- [x] Light mode renders correctly via toggle
- [x] OS `prefers-color-scheme` changes are reflected when no explicit preference is set
- [x] Theme persists across page reloads via localStorage
- [x] ESLint passes (0 errors, pre-existing warnings only)
- [x] TypeScript compiles (pre-existing errors only, none from this PR)