### PR TITLE
fix: private invoices are viewable via direct URL on app/invoice/[id]

### DIFF
--- a/frontend/app/invoice/[id]/page.test.tsx
+++ b/frontend/app/invoice/[id]/page.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import InvoiceDetailPage from './page';
+import { useParams } from 'next/navigation';
+import { useStore } from '@/lib/store';
+import {
+  getInvoice,
+  getInvoiceMetadata,
+  getPoolConfig,
+  getFundedInvoice,
+  getCollateralConfig,
+  getCollateralDeposit,
+  isInvoicePrivate,
+  getFullCreditScore,
+  getCoFundingRound,
+} from '@/lib/contracts';
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('@/lib/store', () => ({
+  useStore: jest.fn(),
+}));
+
+jest.mock('@/lib/contracts', () => ({
+  getInvoice: jest.fn(),
+  getInvoiceMetadata: jest.fn(),
+  getPoolConfig: jest.fn(),
+  getFundedInvoice: jest.fn(),
+  buildRepayTx: jest.fn(),
+  buildDisputeTx: jest.fn(),
+  getCollateralConfig: jest.fn(),
+  getCollateralDeposit: jest.fn(),
+  buildDepositCollateralTx: jest.fn(),
+  isInvoicePrivate: jest.fn(),
+  buildSetInvoicePrivateTx: jest.fn(),
+  getFullCreditScore: jest.fn(),
+  getCoFundingRound: jest.fn(),
+  buildCommitToInvoiceTx: jest.fn(),
+  submitTx: jest.fn(),
+}));
+
+jest.mock('@/lib/stellar', () => ({
+  formatAmount: () => '$1.00',
+  formatUSDC: () => '$1.00',
+  formatDate: () => '2024-01-01',
+  daysUntil: () => 10,
+  truncateAddress: (value: string) => value,
+  rpcGetEvents: jest.fn().mockResolvedValue({ events: [] }),
+  rpcGetLatestLedger: jest.fn().mockResolvedValue({ sequence: 1_000_000 }),
+  toStroops: () => 1_000_000n,
+  INVOICE_CONTRACT_ID: 'CINVOICE',
+  POOL_CONTRACT_ID: 'CPOOL',
+  USDC_TOKEN_ID: 'CUSD',
+  nativeToScVal: (value: unknown) => value,
+  scValToNative: (value: unknown) => value,
+  xdr: {},
+  Address: class {
+    constructor(public value: string) {}
+    toScVal() {
+      return this.value;
+    }
+  },
+}));
+
+jest.mock('@/lib/simulateFee', () => ({
+  simulateContractCall: jest.fn(),
+}));
+
+jest.mock('@/hooks/useTransactionSimulation', () => ({
+  useTransactionSimulation: () => null,
+}));
+
+jest.mock('@/components/InvoicePDF', () => ({
+  downloadInvoicePDF: jest.fn(),
+}));
+
+jest.mock('@/components/GlossaryTerm', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/ConfirmActionModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/WalletConnect', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/Skeleton', () => ({
+  Skeleton: ({ className }: { className: string }) => <div className={className} />,
+}));
+
+jest.mock('@/components/EstimatedFee', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('InvoiceDetailPage private access', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useParams as jest.Mock).mockReturnValue({ id: '42' });
+    (useStore as jest.Mock).mockReturnValue({
+      wallet: { address: 'GBOWNER', connected: false, network: 'testnet' },
+    });
+    (isInvoicePrivate as jest.Mock).mockResolvedValue(true);
+    (getInvoice as jest.Mock).mockResolvedValue({
+      id: 42,
+      owner: 'GBOWNER',
+      debtor: 'Acme',
+      amount: 10_000n,
+      dueDate: 1_700_000_000,
+      description: 'Invoice',
+      status: 'Funded',
+      createdAt: 1,
+      fundedAt: 1,
+      paidAt: 0,
+      poolContract: 'CPOOL',
+    });
+    (getInvoiceMetadata as jest.Mock).mockResolvedValue({
+      name: 'Private invoice title',
+      description: 'Invoice description',
+      image: '',
+      amount: 10_000n,
+      debtor: 'Acme',
+      dueDate: 1_700_000_000,
+      status: 'Funded',
+      symbol: 'USDC',
+      decimals: 6,
+    });
+    (getPoolConfig as jest.Mock).mockResolvedValue({
+      admin: 'GADMIN',
+      yieldBps: 0,
+      factoringFeeBps: 0,
+      compoundInterest: false,
+      proposedYieldBps: 0,
+      yieldProposalAt: 0,
+      yieldTimelockSecs: 0,
+      maxSingleInvestorBps: 0,
+      maxWithdrawalQueueAgeDays: 0,
+      maxWithdrawalQueueDepth: 0,
+      invoiceContract: 'CINVOICE',
+    });
+    (getFundedInvoice as jest.Mock).mockResolvedValue({
+      principal: 10_000n,
+      dueDate: 1_700_000_000,
+      fundedAt: 1,
+      factoringFee: 0n,
+      repaidAmount: 0n,
+    });
+    (getCollateralConfig as jest.Mock).mockResolvedValue(null);
+    (getCollateralDeposit as jest.Mock).mockResolvedValue(null);
+    (getFullCreditScore as jest.Mock).mockResolvedValue(null);
+    (getCoFundingRound as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('blocks private invoices for non-owners before rendering invoice content', async () => {
+    render(<InvoiceDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Invoice not found.')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Private invoice title')).not.toBeInTheDocument();
+    expect(isInvoicePrivate).toHaveBeenCalledWith(42);
+  });
+});

--- a/frontend/app/invoice/[id]/page.tsx
+++ b/frontend/app/invoice/[id]/page.tsx
@@ -50,6 +50,7 @@ import {
 import { simulateContractCall } from '@/lib/simulateFee';
 import { useTransactionSimulation } from '@/hooks/useTransactionSimulation';
 import EstimatedFee from '@/components/EstimatedFee';
+import BorrowerCreditBadge from '@/components/BorrowerCreditBadge';
 import { projectedInterestStroops, formatApyPercent } from '@/lib/apy';
 import { parseStellarAddress } from '@/lib/types';
 import type {
@@ -298,8 +299,9 @@ export default function InvoiceDetailPage() {
   }, [loadInvoice]);
 
   const days = metadata ? daysUntil(metadata.dueDate) : 0;
-  const isOwner = invoice ? wallet.address === invoice.owner : false;
-  const isAdmin = poolConfig ? wallet.address === poolConfig.admin : false;
+  const isOwner = Boolean(invoice && wallet.connected && wallet.address === invoice.owner);
+  const isAdmin = Boolean(poolConfig && wallet.connected && wallet.address === poolConfig.admin);
+  const canViewInvoice = !isPrivate || isOwner;
   const statusSteps: TransactionStep[] = invoice
     ? [
         { label: 'Created', done: true, ts: invoice.createdAt },
@@ -373,7 +375,13 @@ export default function InvoiceDetailPage() {
 
   const repaySimulation = useTransactionSimulation(
     simulateRepay,
-    isOwner && metadata.status === 'Funded' && !!fundedInvoice && !fullyRepaid && !!wallet.address && !!invoice && (!!repayAmount || remainingDue > 0n),
+    isOwner &&
+      metadata.status === 'Funded' &&
+      !!fundedInvoice &&
+      !fullyRepaid &&
+      !!wallet.address &&
+      !!invoice &&
+      (!!repayAmount || remainingDue > 0n),
   );
 
   async function handleRepay() {
@@ -616,8 +624,8 @@ export default function InvoiceDetailPage() {
   }
 
   // #775: the borrower opted this invoice out of the public sharing link —
-  // hide it from everyone except the owner, same as a genuinely missing invoice.
-  if (isPrivate && !isOwner) {
+  // hide it from everyone except the connected owner, same as a genuinely missing invoice.
+  if (!canViewInvoice) {
     return (
       <div className="min-h-screen pt-24 px-4 sm:px-6 flex flex-col items-center justify-center text-center">
         <p className="text-red-400 mb-4">Invoice not found.</p>
@@ -976,8 +984,8 @@ export default function InvoiceDetailPage() {
             <div>
               <h2 className="text-lg font-semibold mb-1">Fund This Invoice</h2>
               <p className="text-xs text-brand-muted">
-                Join other lenders co-funding this invoice. Committed capital earns a
-                proportional share of this invoice&apos;s principal and interest.
+                Join other lenders co-funding this invoice. Committed capital earns a proportional
+                share of this invoice&apos;s principal and interest.
               </p>
             </div>
 


### PR DESCRIPTION
Closes #958 

## Summary
The invoice detail page now refuses to render private invoices for anyone except the connected owner wallet, so a direct URL no longer exposes the invoice content to unrelated viewers.

What changed
Updated frontend/app/invoice/[id]/page.tsx to enforce the private-invoice check using the connected Freighter wallet state, not just the URL.
Added a regression test in frontend/app/invoice/[id]/page.test.tsx covering the non-owner/private-invoice case.
Verification
I verified this by running:

cd /workspaces/Astera/frontend && npx jest --runInBand --runTestsByPath './app/invoice/[id]/page.test.tsx'
Result:

1 test suite passed
1 test passed