### PR TITLE
fix: resolve assigned issues #926 #931 #932 #933

### DIFF
--- a/contracts/compliance/src/lib.rs
+++ b/contracts/compliance/src/lib.rs
@@ -229,6 +229,16 @@ impl ComplianceContract {
         {
             return Err(ComplianceError::ScreenerAlreadyRegistered);
         }
+        // #926: reject re-register while a pending registration already exists.
+        // Otherwise lowering set_screener_timelock and re-calling register could
+        // overwrite the frozen effective_at (or instantly activate with timelock 0).
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::PendingScreener(screener.clone()))
+        {
+            return Err(ComplianceError::ScreenerAlreadyRegistered);
+        }
 
         let timelock: u64 = env
             .storage()
@@ -240,6 +250,8 @@ impl ComplianceContract {
         if timelock == 0 {
             Self::activate_screener(&env, &screener)?;
         } else {
+            // Freeze effective_at at registration time — confirm uses this value,
+            // never the live ScreenerTimelockSecs config (#926).
             let pending = PendingScreener {
                 address: screener.clone(),
                 proposed_at: now,
@@ -359,6 +371,9 @@ impl ComplianceContract {
             .unwrap_or(DEFAULT_RESCREENING_INTERVAL_SECS)
     }
 
+    /// Updates the timelock applied to *future* `register_screener` calls only.
+    /// #926: must not rewrite `effective_at` on any in-flight PendingScreener —
+    /// confirm always uses the value frozen at registration time.
     pub fn set_screener_timelock(
         env: Env,
         admin: Address,

--- a/contracts/compliance/tests/screener_tests.rs
+++ b/contracts/compliance/tests/screener_tests.rs
@@ -398,3 +398,78 @@ fn test_custom_rescreening_interval() {
         &String::from_str(&env, "sanctions"),
     );
 }
+
+// ── #926: reducing screener timelock must not unlock pending registrations ───
+
+#[test]
+fn test_reducing_timelock_does_not_shorten_pending_registration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let screener = Address::generate(&env);
+
+    // Default 24h timelock; register freezes effective_at = now + 86400.
+    client.register_screener(&admin, &screener);
+    assert!(!client.is_screener(&screener));
+
+    // Admin shortens (or zeros) the configured timelock mid-flight.
+    client.set_screener_timelock(&admin, &0u64);
+    assert_eq!(client.get_screener_timelock(), 0u64);
+
+    // Still before the *original* effective_at — confirm must fail.
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + 3_600);
+    let too_soon = client.try_confirm_screener_registration(&admin, &screener);
+    assert_eq!(too_soon, Err(Ok(ComplianceError::ScreenerTimelockActive)));
+    assert!(!client.is_screener(&screener));
+
+    // After original 24h window, confirm succeeds.
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + 86_400);
+    client.confirm_screener_registration(&admin, &screener);
+    assert!(client.is_screener(&screener));
+}
+
+#[test]
+fn test_re_register_while_pending_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let screener = Address::generate(&env);
+
+    client.register_screener(&admin, &screener);
+    // Lower timelock then try to re-register — must not overwrite frozen effective_at
+    // or instantly activate with the new (zero) timelock.
+    client.set_screener_timelock(&admin, &0u64);
+    let again = client.try_register_screener(&admin, &screener);
+    assert_eq!(again, Err(Ok(ComplianceError::ScreenerAlreadyRegistered)));
+    assert!(!client.is_screener(&screener));
+
+    // Original commitment still governs confirm.
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + 1);
+    let early = client.try_confirm_screener_registration(&admin, &screener);
+    assert_eq!(early, Err(Ok(ComplianceError::ScreenerTimelockActive)));
+}
+
+#[test]
+fn test_reducing_timelock_only_affects_future_registrations() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let pending = Address::generate(&env);
+    let fresh = Address::generate(&env);
+
+    client.register_screener(&admin, &pending);
+    client.set_screener_timelock(&admin, &3_600u64);
+
+    // New registration uses the shortened 1h timelock.
+    client.register_screener(&admin, &fresh);
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000 + 3_600);
+    client.confirm_screener_registration(&admin, &fresh);
+    assert!(client.is_screener(&fresh));
+
+    // Original pending still needs the full original 24h.
+    let still_pending = client.try_confirm_screener_registration(&admin, &pending);
+    assert_eq!(
+        still_pending,
+        Err(Ok(ComplianceError::ScreenerTimelockActive))
+    );
+}

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -12,6 +12,12 @@ const DEFAULT_VOTING_PERIOD_SECS: u64 = 7 * 86_400;
 const DEFAULT_EXECUTION_DELAY_SECS: u64 = 48 * 3_600;
 const DEFAULT_QUORUM_BPS: u32 = 1_000;
 const DEFAULT_PASS_BPS: u32 = 6_000;
+/// #933: default quorum for parameter-change proposals (10%).
+const DEFAULT_PARAMETER_QUORUM_BPS: u32 = 1_000;
+/// #933: default quorum for treasury proposals (20%).
+const DEFAULT_TREASURY_QUORUM_BPS: u32 = 2_000;
+/// #933: default quorum for critical proposals e.g. admin changes (50%).
+const DEFAULT_CRITICAL_QUORUM_BPS: u32 = 5_000;
 /// A passed proposal not executed within this window of passing expires and
 /// can no longer be executed, so a stale approval can't be enacted long after
 /// the conditions that justified it have changed.
@@ -26,6 +32,19 @@ pub enum ProposalStatus {
     Executed,
     Cancelled,
     Expired,
+}
+
+/// #933: Proposal severity. Parameter tweaks need less consensus than critical
+/// actions (admin changes, upgrades). Quorum is resolved per category.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProposalCategory {
+    /// Fee / parameter adjustments — lower quorum bar.
+    ParameterChange,
+    /// Treasury moves and fund allocation.
+    Treasury,
+    /// Admin, upgrades, and other high-impact actions — highest quorum.
+    Critical,
 }
 
 #[contracttype]
@@ -50,6 +69,13 @@ pub struct Proposal {
     /// Ledger timestamp at which the proposal transitioned to `Passed`, or 0 if
     /// it has not (yet) passed. Used to enforce `EXECUTION_EXPIRY_SECS`.
     pub passed_at: u64,
+    /// #933: category chosen at creation; drives which quorum tier applies.
+    pub category: ProposalCategory,
+    /// #933: quorum_bps snapshotted at creation so mid-vote admin changes to
+    /// category quorums cannot retarget an in-flight proposal.
+    pub quorum_bps: u32,
+    /// #933: pass_bps snapshotted at creation (same freeze rationale as quorum).
+    pub pass_bps: u32,
 }
 
 #[contracttype]
@@ -58,10 +84,17 @@ pub struct GovernanceConfig {
     pub admin: Address,
     pub share_token: Address,
     pub voting_period_secs: u64,
+    /// Default / ParameterChange quorum (kept for backward-compatible get_config).
     pub quorum_bps: u32,
     pub pass_bps: u32,
     pub execution_delay_secs: u64,
+    /// #931: absolute minimum share balance required to create a proposal.
+    /// Must be > 0 so spam from zero-balance addresses is blocked.
     pub min_share_balance: i128,
+    /// #933: treasury-category quorum in basis points.
+    pub treasury_quorum_bps: u32,
+    /// #933: critical-category quorum in basis points.
+    pub critical_quorum_bps: u32,
 }
 
 #[contracttype]
@@ -107,6 +140,25 @@ fn load_config(env: &Env) -> GovernanceResult<GovernanceConfig> {
         .ok_or(GovernanceError::NotInitialized)
 }
 
+fn validate_bps(quorum_bps: u32, pass_bps: u32) -> GovernanceResult<()> {
+    if quorum_bps == 0 || quorum_bps > 10_000 {
+        return Err(GovernanceError::InvalidConfig);
+    }
+    if pass_bps <= 5_000 || pass_bps > 10_000 {
+        return Err(GovernanceError::InvalidConfig);
+    }
+    Ok(())
+}
+
+/// #933: resolve the quorum tier for a category from live config.
+fn quorum_for_category(config: &GovernanceConfig, category: &ProposalCategory) -> u32 {
+    match category {
+        ProposalCategory::ParameterChange => config.quorum_bps,
+        ProposalCategory::Treasury => config.treasury_quorum_bps,
+        ProposalCategory::Critical => config.critical_quorum_bps,
+    }
+}
+
 /// Voting weight is the holder's share balance at the moment the proposal was
 /// created (`snapshot_at`), not their balance at vote time — otherwise shares
 /// acquired mid-vote (or borrowed just long enough to vote) would inflate
@@ -120,21 +172,21 @@ fn finalize_proposal(env: &Env, proposal: &mut Proposal) -> GovernanceResult<()>
         return Ok(());
     }
 
-    let config = load_config(env)?;
     let snapshot_supply = proposal.snapshot_supply;
     if snapshot_supply <= 0 {
         proposal.status = ProposalStatus::Rejected;
         return Ok(());
     }
 
+    // #933: use quorum/pass snapshotted onto the proposal at creation.
     let total_votes = proposal.votes_for + proposal.votes_against;
-    let quorum = (snapshot_supply * config.quorum_bps as i128) / 10_000i128;
+    let quorum = (snapshot_supply * proposal.quorum_bps as i128) / 10_000i128;
     if total_votes < quorum {
         proposal.status = ProposalStatus::Rejected;
         return Err(GovernanceError::QuorumNotMet);
     }
 
-    if proposal.votes_for * 10_000i128 >= total_votes * config.pass_bps as i128 {
+    if proposal.votes_for * 10_000i128 >= total_votes * proposal.pass_bps as i128 {
         proposal.status = ProposalStatus::Passed;
         // Anchored to voting_ends_at (not "now") so a delayed finalization
         // call can't push back the execution-expiry window.
@@ -189,6 +241,11 @@ impl Governance {
         if voting_period_secs > 0 && voting_period_secs < MIN_VOTING_PERIOD_SECS {
             panic!("voting period too short");
         }
+        // #931: proposal creation requires a positive stake threshold so any
+        // address without holdings cannot spam list_proposals.
+        if min_share_balance <= 0 {
+            panic!("min_share_balance must be positive");
+        }
 
         let config = GovernanceConfig {
             admin: admin.clone(),
@@ -214,13 +271,20 @@ impl Governance {
                 execution_delay_secs
             },
             min_share_balance,
+            // #933: tiered defaults (parameter uses quorum_bps above).
+            treasury_quorum_bps: DEFAULT_TREASURY_QUORUM_BPS,
+            critical_quorum_bps: DEFAULT_CRITICAL_QUORUM_BPS,
         };
+        let _ = DEFAULT_PARAMETER_QUORUM_BPS;
 
         env.storage().instance().set(&DataKey::Config, &config);
         env.storage().instance().set(&DataKey::ProposalCount, &0u64);
         env.storage().instance().set(&DataKey::Initialized, &true);
     }
 
+    /// #931 / #933: create a proposal. Caller must hold at least
+    /// `min_share_balance` shares (proposal threshold). Category selects the
+    /// quorum tier, which is snapshotted onto the proposal.
     pub fn create_proposal(
         env: Env,
         proposer: Address,
@@ -228,12 +292,21 @@ impl Governance {
         target_contract: Address,
         function_name: String,
         calldata: String,
+        category: ProposalCategory,
     ) -> Result<u64, GovernanceError> {
         proposer.require_auth();
         let config = load_config(&env)?;
         let now = env.ledger().timestamp();
         let balance = proposal_weight(&env, &config.share_token, &proposer, now);
+        // #931: absolute proposal threshold — reject zero/under-threshold stake.
         if balance < config.min_share_balance {
+            return Err(GovernanceError::InsufficientShareBalance);
+        }
+
+        let snapshot_supply = ShareTokenClient::new(&env, &config.share_token).total_supply();
+        // #931: quorum-eligibility — proposer must hold a positive stake against
+        // a non-zero supply so empty/spam proposals cannot open governance noise.
+        if snapshot_supply <= 0 || balance <= 0 {
             return Err(GovernanceError::InsufficientShareBalance);
         }
 
@@ -243,7 +316,7 @@ impl Governance {
             .get(&DataKey::ProposalCount)
             .unwrap_or(0);
         let id = count + 1;
-        let snapshot_supply = ShareTokenClient::new(&env, &config.share_token).total_supply();
+        let quorum_bps = quorum_for_category(&config, &category);
         let proposal = Proposal {
             id,
             proposer: proposer.clone(),
@@ -259,6 +332,9 @@ impl Governance {
             execution_delay: config.execution_delay_secs,
             snapshot_supply,
             passed_at: 0,
+            category,
+            quorum_bps,
+            pass_bps: config.pass_bps,
         };
 
         env.storage()
@@ -293,7 +369,9 @@ impl Governance {
         {
             return Err(GovernanceError::AlreadyVoted);
         }
-        if env.ledger().timestamp() > proposal.voting_ends_at {
+        // #932: voting window is [created_at, voting_ends_at). At equality the
+        // period has fully elapsed — no more votes, and finalize may run.
+        if env.ledger().timestamp() >= proposal.voting_ends_at {
             let _ = finalize_proposal(&env, &mut proposal);
             env.storage()
                 .instance()
@@ -340,7 +418,10 @@ impl Governance {
         {
             return Err(GovernanceError::ProposalInactive);
         }
-        if env.ledger().timestamp() < proposal.voting_ends_at {
+        // #932: voting period must fully elapse before execution. Reject while
+        // `now <= voting_ends_at` so fast unanimous support cannot skip the
+        // configured window (and so vote/execute never both succeed at equality).
+        if env.ledger().timestamp() <= proposal.voting_ends_at {
             return Err(GovernanceError::VotingPeriodActive);
         }
         if env.ledger().timestamp()
@@ -440,8 +521,10 @@ impl Governance {
                 .get::<DataKey, Proposal>(&DataKey::Proposal(id))
             {
                 let mut changed = false;
+                // #932: align finalize with vote/execute — period fully elapsed
+                // at `now >= voting_ends_at`.
                 if proposal.status == ProposalStatus::Active
-                    && env.ledger().timestamp() > proposal.voting_ends_at
+                    && env.ledger().timestamp() >= proposal.voting_ends_at
                 {
                     let _ = finalize_proposal(&env, &mut proposal);
                     changed = true;
@@ -484,12 +567,9 @@ impl Governance {
         Ok(weight)
     }
 
-    /// Updates the quorum and pass-threshold, gated to the address holding
-    /// governance authority (`config.admin`) so quorum/threshold stay
-    /// configurable by current governance rather than fixed at deploy time.
-    /// Does not affect proposals already created — their `snapshot_supply`
-    /// and finalization use the config values in effect when `execute_proposal`
-    /// runs, consistent with how quorum/threshold already work today.
+    /// Updates the default (ParameterChange) quorum and pass-threshold.
+    /// Gated to `config.admin`. Does not rewrite snapshotted values on
+    /// already-created proposals.
     pub fn update_config(
         env: Env,
         caller: Address,
@@ -501,12 +581,7 @@ impl Governance {
         if caller != config.admin {
             return Err(GovernanceError::Unauthorized);
         }
-        if quorum_bps == 0 || quorum_bps > 10_000 {
-            return Err(GovernanceError::InvalidConfig);
-        }
-        if pass_bps <= 5_000 || pass_bps > 10_000 {
-            return Err(GovernanceError::InvalidConfig);
-        }
+        validate_bps(quorum_bps, pass_bps)?;
 
         config.quorum_bps = quorum_bps;
         config.pass_bps = pass_bps;
@@ -514,5 +589,43 @@ impl Governance {
         env.events()
             .publish((EVT, symbol_short!("cfg")), (caller, quorum_bps, pass_bps));
         Ok(())
+    }
+
+    /// #933: set per-category quorum (and optional pass threshold via pass_bps).
+    /// `pass_bps` applies globally (same supermajority rule for all categories);
+    /// category only differentiates quorum. Snapshotted onto new proposals only.
+    pub fn set_category_quorum(
+        env: Env,
+        caller: Address,
+        category: ProposalCategory,
+        quorum_bps: u32,
+    ) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        let mut config = load_config(&env)?;
+        if caller != config.admin {
+            return Err(GovernanceError::Unauthorized);
+        }
+        if quorum_bps == 0 || quorum_bps > 10_000 {
+            return Err(GovernanceError::InvalidConfig);
+        }
+
+        match category {
+            ProposalCategory::ParameterChange => config.quorum_bps = quorum_bps,
+            ProposalCategory::Treasury => config.treasury_quorum_bps = quorum_bps,
+            ProposalCategory::Critical => config.critical_quorum_bps = quorum_bps,
+        }
+        env.storage().instance().set(&DataKey::Config, &config);
+        env.events()
+            .publish((EVT, symbol_short!("cat_q")), (caller, category, quorum_bps));
+        Ok(())
+    }
+
+    /// #933: read the quorum bps configured for a category.
+    pub fn get_category_quorum(
+        env: Env,
+        category: ProposalCategory,
+    ) -> Result<u32, GovernanceError> {
+        let config = load_config(&env)?;
+        Ok(quorum_for_category(&config, &category))
     }
 }

--- a/contracts/governance/tests/lib.rs
+++ b/contracts/governance/tests/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use governance::{Governance, GovernanceClient, ProposalStatus};
+use governance::{Governance, GovernanceClient, GovernanceError, ProposalCategory, ProposalStatus};
 use share::{ShareToken, ShareTokenClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -49,6 +49,24 @@ fn make_proposal(env: &Env, gov: &GovernanceClient, proposer: &Address, target: 
         target,
         &String::from_str(env, "no_op"),
         &String::from_str(env, "{}"),
+        &ProposalCategory::ParameterChange,
+    )
+}
+
+fn make_proposal_with_category(
+    env: &Env,
+    gov: &GovernanceClient,
+    proposer: &Address,
+    target: &Address,
+    category: &ProposalCategory,
+) -> u64 {
+    gov.create_proposal(
+        proposer,
+        &String::from_str(env, "Test proposal"),
+        target,
+        &String::from_str(env, "no_op"),
+        &String::from_str(env, "{}"),
+        category,
     )
 }
 
@@ -317,6 +335,7 @@ fn test_zero_snapshot_supply_rejects_proposal_immediately() {
         &share_admin2,
         &String::from_str(&env, "no_op"),
         &String::from_str(&env, "{}"),
+        &ProposalCategory::ParameterChange,
     );
     // No votes cast → total_votes = 0. quorum = 0 so 0 >= 0 passes quorum check.
     // Then pass threshold: YES=0, total=0. 0*10000 >= 0*6000 → 0 >= 0 → Passed.
@@ -566,4 +585,258 @@ fn test_passed_proposal_executes_within_expiry_window() {
 
     let proposal = gov.get_proposal(&id).unwrap();
     assert_eq!(proposal.status, ProposalStatus::Executed);
+}
+
+// ── #932: voting period must fully elapse before execute ─────────────────────
+
+#[test]
+fn test_execute_rejected_at_exact_voting_ends_at() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _) = setup_share(&env);
+    let (gov, _) = setup_governance(&env, &share_id);
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    share.mint(&proposer, &1_000i128);
+    share.mint(&voter, &200_000i128);
+
+    let id = make_proposal(&env, &gov, &proposer, &proposer);
+    gov.vote(&id, &voter, &true);
+
+    let proposal = gov.get_proposal(&id).unwrap();
+    // Land exactly on voting_ends_at — period has not fully elapsed past the end.
+    env.ledger()
+        .with_mut(|l| l.timestamp = proposal.voting_ends_at);
+
+    let result = gov.try_execute_proposal(&id);
+    assert_eq!(
+        result,
+        Err(Ok(GovernanceError::VotingPeriodActive)),
+        "execute at voting_ends_at must fail even with unanimous support"
+    );
+
+    // Vote at equality must also fail (no overlap window).
+    let late_voter = Address::generate(&env);
+    share.mint(&late_voter, &10_000i128);
+    let vote_result = gov.try_vote(&id, &late_voter, &true);
+    assert!(vote_result.is_err(), "vote at voting_ends_at must fail");
+}
+
+#[test]
+fn test_execute_requires_voting_period_elapsed_before_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _) = setup_share(&env);
+    let (gov, _) = setup_governance(&env, &share_id);
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    share.mint(&proposer, &1_000i128);
+    share.mint(&voter, &200_000i128);
+
+    let id = make_proposal(&env, &gov, &proposer, &proposer);
+    gov.vote(&id, &voter, &true);
+
+    // Still inside voting window.
+    env.ledger().with_mut(|l| l.timestamp += VOTING_PERIOD / 2);
+    let early = gov.try_execute_proposal(&id);
+    assert_eq!(early, Err(Ok(GovernanceError::VotingPeriodActive)));
+
+    // One second after voting ends — voting closed, but execution delay still active.
+    let proposal = gov.get_proposal(&id).unwrap();
+    env.ledger()
+        .with_mut(|l| l.timestamp = proposal.voting_ends_at + 1);
+    let delay = gov.try_execute_proposal(&id);
+    assert_eq!(delay, Err(Ok(GovernanceError::TimelockActive)));
+}
+
+// ── #931: proposal threshold / create eligibility ────────────────────────────
+
+#[test]
+fn test_create_proposal_rejects_zero_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _) = setup_share(&env);
+    let (gov, _) = setup_governance(&env, &share_id);
+
+    // Ensure supply is non-zero via another holder, but proposer has nothing.
+    let holder = Address::generate(&env);
+    share.mint(&holder, &100_000i128);
+    let poor = Address::generate(&env);
+
+    let result = gov.try_create_proposal(
+        &poor,
+        &String::from_str(&env, "spam"),
+        &holder,
+        &String::from_str(&env, "no_op"),
+        &String::from_str(&env, "{}"),
+        &ProposalCategory::ParameterChange,
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::InsufficientShareBalance)));
+}
+
+#[test]
+fn test_create_proposal_rejects_below_min_share_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, share_admin) = setup_share(&env);
+    let gov_admin = Address::generate(&env);
+    let gov_id = env.register(Governance, ());
+    let gov = GovernanceClient::new(&env, &gov_id);
+    // Threshold of 10_000 shares to create.
+    gov.initialize(
+        &gov_admin,
+        &share_id,
+        &VOTING_PERIOD,
+        &QUORUM_BPS,
+        &PASS_BPS,
+        &EXEC_DELAY,
+        &10_000i128,
+    );
+
+    let proposer = Address::generate(&env);
+    share.mint(&proposer, &9_999i128);
+
+    let result = gov.try_create_proposal(
+        &proposer,
+        &String::from_str(&env, "under threshold"),
+        &share_admin,
+        &String::from_str(&env, "no_op"),
+        &String::from_str(&env, "{}"),
+        &ProposalCategory::ParameterChange,
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::InsufficientShareBalance)));
+
+    share.mint(&proposer, &1i128); // now exactly 10_000
+    let id = gov.create_proposal(
+        &proposer,
+        &String::from_str(&env, "at threshold"),
+        &share_admin,
+        &String::from_str(&env, "no_op"),
+        &String::from_str(&env, "{}"),
+        &ProposalCategory::ParameterChange,
+    );
+    assert_eq!(id, 1u64);
+}
+
+// ── #933: proposal categories with per-category quorum ───────────────────────
+
+#[test]
+fn test_category_quorum_defaults_and_snapshot() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _) = setup_share(&env);
+    let (gov, gov_admin) = setup_governance(&env, &share_id);
+
+    assert_eq!(
+        gov.get_category_quorum(&ProposalCategory::ParameterChange),
+        QUORUM_BPS
+    );
+    assert_eq!(gov.get_category_quorum(&ProposalCategory::Treasury), 2_000);
+    assert_eq!(gov.get_category_quorum(&ProposalCategory::Critical), 5_000);
+
+    let proposer = Address::generate(&env);
+    share.mint(&proposer, &1_000_000i128);
+
+    let param_id =
+        make_proposal_with_category(&env, &gov, &proposer, &proposer, &ProposalCategory::ParameterChange);
+    let treasury_id =
+        make_proposal_with_category(&env, &gov, &proposer, &proposer, &ProposalCategory::Treasury);
+    let critical_id =
+        make_proposal_with_category(&env, &gov, &proposer, &proposer, &ProposalCategory::Critical);
+
+    assert_eq!(gov.get_proposal(&param_id).unwrap().quorum_bps, QUORUM_BPS);
+    assert_eq!(gov.get_proposal(&treasury_id).unwrap().quorum_bps, 2_000);
+    assert_eq!(gov.get_proposal(&critical_id).unwrap().quorum_bps, 5_000);
+    assert_eq!(
+        gov.get_proposal(&critical_id).unwrap().category,
+        ProposalCategory::Critical
+    );
+
+    // Mid-flight config change must not rewrite snapshotted quorum.
+    gov.set_category_quorum(&gov_admin, &ProposalCategory::Critical, &8_000u32);
+    assert_eq!(gov.get_category_quorum(&ProposalCategory::Critical), 8_000);
+    assert_eq!(
+        gov.get_proposal(&critical_id).unwrap().quorum_bps,
+        5_000,
+        "in-flight proposal keeps creation-time quorum"
+    );
+
+    let new_critical =
+        make_proposal_with_category(&env, &gov, &proposer, &proposer, &ProposalCategory::Critical);
+    assert_eq!(gov.get_proposal(&new_critical).unwrap().quorum_bps, 8_000);
+}
+
+#[test]
+fn test_critical_category_requires_higher_quorum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (share, share_id, _) = setup_share(&env);
+    let (gov, _) = setup_governance(&env, &share_id);
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    // Supply = 1_000_000. Parameter quorum 10% = 100_000; Critical 50% = 500_000.
+    share.mint(&proposer, &800_000i128);
+    share.mint(&voter, &200_000i128);
+
+    let param_id =
+        make_proposal_with_category(&env, &gov, &proposer, &proposer, &ProposalCategory::ParameterChange);
+    let critical_id =
+        make_proposal_with_category(&env, &gov, &proposer, &proposer, &ProposalCategory::Critical);
+
+    // 200k votes: enough for parameter (100k), not for critical (500k).
+    gov.vote(&param_id, &voter, &true);
+    gov.vote(&critical_id, &voter, &true);
+
+    env.ledger()
+        .with_mut(|l| l.timestamp += VOTING_PERIOD + EXEC_DELAY + 2);
+
+    gov.execute_proposal(&param_id);
+    assert_eq!(
+        gov.get_proposal(&param_id).unwrap().status,
+        ProposalStatus::Executed
+    );
+
+    let critical_result = gov.try_execute_proposal(&critical_id);
+    assert!(critical_result.is_err());
+    gov.list_proposals();
+    assert_eq!(
+        gov.get_proposal(&critical_id).unwrap().status,
+        ProposalStatus::Rejected
+    );
+}
+
+#[test]
+fn test_set_category_quorum_rejects_non_admin_and_invalid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let (_share, share_id, _) = setup_share(&env);
+    let (gov, gov_admin) = setup_governance(&env, &share_id);
+
+    let impostor = Address::generate(&env);
+    assert!(gov
+        .try_set_category_quorum(&impostor, &ProposalCategory::Treasury, &3_000u32)
+        .is_err());
+    assert!(gov
+        .try_set_category_quorum(&gov_admin, &ProposalCategory::Treasury, &0u32)
+        .is_err());
+    assert!(gov
+        .try_set_category_quorum(&gov_admin, &ProposalCategory::Treasury, &10_001u32)
+        .is_err());
 }


### PR DESCRIPTION


- #926: Reject re-registration while a pending screener exists; freeze effective_at at registration time so set_screener_timelock cannot shorten an in-flight pending registration.
- #931: Add min_share_balance proposal threshold and quorum-eligibility check to create_proposal; enforce positive stake.
- #932: Enforce voting period fully elapsed before execute; align finalize, vote, and execute boundaries (>= voting_ends_at).
- #933: Add ProposalCategory with per-category quorum tiers (ParameterChange, Treasury, Critical); snapshot quorum/pass at proposal creation so mid-vote config changes cannot retarget in-flight proposals.

closes #926
closes #931 
closes #932 
closes #933